### PR TITLE
fix(cli): update create error to point to correct repo

### DIFF
--- a/packages/sandbox/src/commands/create.ts
+++ b/packages/sandbox/src/commands/create.ts
@@ -64,7 +64,7 @@ export const create = cmd.command({
         [
           `Sandbox created but interactive port is missing.`,
           `${chalk.bold("hint:")} This is an internal error. Please try again.`,
-          "╰▶ Report this issue: https://github.com/vercel/sandbox-sdk/issues",
+          "╰▶ Report this issue: https://github.com/vercel/sandbox/issues",
         ].join("\n"),
       );
     }


### PR DESCRIPTION
The repository has since been updated, so we can point this error message to the correct URL.