### PR TITLE
chore(docs): update sandbox README's for clarification on each package

### DIFF
--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -4,6 +4,11 @@ Command line interface for Vercel Sandbox.
 
 Read the full documentation at [vercel.com/docs/vercel-sandbox/cli-reference](https://vercel.com/docs/vercel-sandbox/cli-reference).
 
+## Packages
+
+- [`@vercel/sandbox`](https://www.npmjs.com/package/@vercel/sandbox) - The SDK for programmatic access to Vercel Sandbox. [Source](https://github.com/vercel/sandbox/tree/main/packages/vercel-sandbox) | [Documentation](https://vercel.com/docs/vercel-sandbox/sdk-reference)
+- [`sandbox`](https://www.npmjs.com/package/sandbox) (this package) - The CLI for interacting with Vercel Sandbox from the command line. [Source](https://github.com/vercel/sandbox/tree/main/packages/sandbox) | [Documentation](https://vercel.com/docs/vercel-sandbox/cli-reference)
+
 ## Installation
 
 ```bash
@@ -16,16 +21,4 @@ pnpm i -g sandbox
 sandbox create # Create a new sandbox
 sandbox ls # List your sandboxes
 sandbox --help # View all commands
-```
-
-## SDK
-
-For programmatic access to Vercel Sandbox, use the [`@vercel/sandbox`](https://www.npmjs.com/package/@vercel/sandbox) package instead:
-
-```bash
-pnpm add @vercel/sandbox
-```
-
-```ts
-import { Sandbox } from "@vercel/sandbox";
 ```

--- a/packages/vercel-sandbox/README.md
+++ b/packages/vercel-sandbox/README.md
@@ -5,7 +5,7 @@ VMs. View the documentation [here](https://vercel.com/docs/vercel-sandbox).
 
 ## Packages
 
-- [`@vercel/sandbox`](https://www.npmjs.com/package/@vercel/sandbox) - The SDK for programmatic access to Vercel Sandbox. [Source](https://github.com/vercel/sandbox/tree/main/packages/vercel-sandbox) | [Documentation](https://vercel.com/docs/vercel-sandbox/sdk-reference)
+- [`@vercel/sandbox`](https://www.npmjs.com/package/@vercel/sandbox) (this package) - The SDK for programmatic access to Vercel Sandbox. [Source](https://github.com/vercel/sandbox/tree/main/packages/vercel-sandbox) | [Documentation](https://vercel.com/docs/vercel-sandbox/sdk-reference)
 - [`sandbox`](https://www.npmjs.com/package/sandbox) - The CLI for interacting with Vercel Sandbox from the command line. [Source](https://github.com/vercel/sandbox/tree/main/packages/sandbox) | [Documentation](https://vercel.com/docs/vercel-sandbox/cli-reference)
 
 ## What is a sandbox?


### PR DESCRIPTION
Add a small note of clarification on sandbox + vercel-sandbox package about which package is which. This won't be present in the README.md at root.