### PR TITLE
cli: show team and project after sandbox creation

### DIFF
--- a/.changeset/dull-icons-worry.md
+++ b/.changeset/dull-icons-worry.md
@@ -1,0 +1,5 @@
+---
+"sandbox": patch
+---
+
+Display team and project info in a framed format after sandbox creation


### PR DESCRIPTION
# Problem

When creating a new sandbox via the CLI (`sandbox create`), the output only shows the sandbox ID but doesn't indicate which team or project the sandbox belongs to. This leaves users confused about where their sandbox was created.

# Solution

Display team and project info in a framed format after sandbox creation:

```
✅ Sandbox sbx_abc123 created.
   │ team: team_slug
   ╰ project: my-project
```

With ports:
```
✅ Sandbox sbx_abc123 created.
   │ team: team_slug
   │ project: my-project
   │ ports:
   │ • 3000 -> https://...
   ╰ • 8080 -> https://...
```

Changes:
- Extract `owner` and `project` slugs from OIDC token claims (with backwards compatibility for tokens without these fields)
- Thread slug values through the scope parser to make them available in commands
- Integrate port listing into the same framed view with consistent indentation
- Remove redundant sandbox ID from interactive shell spinner and command prompt

Supersedes #15 and therefore also resolves EC-4722.

Resolves EC-4761