### PR TITLE
chore: add missing changeset

### DIFF
--- a/.changeset/three-rules-make.md
+++ b/.changeset/three-rules-make.md
@@ -1,0 +1,6 @@
+---
+"sandbox": minor
+"@vercel/sandbox": minor
+---
+
+Add support for network policies


### PR DESCRIPTION
https://github.com/vercel/sandbox/pull/20 and https://github.com/vercel/sandbox/pull/21 did not have any changeset, which we need to trigger a new release of the SDK/CLI