### PR TITLE
chore: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,32 +16,29 @@ infrastructure][hive] that powers 2M+ builds a day at Vercel.
 
 ## Getting started
 
-To get started, create a new project:
+To get started using Node.js 22+, create a new project:
 
 ```sh
-mkdir sandbox-test
-cd sandbox-test
-pnpm init
-pnpm add @vercel/sandbox ms
-pnpm add -D @types/ms @types/node
-```
-
-Link it to Vercel:
-
-```sh
+mkdir my-sandbox-app && cd my-sandbox-app
+npm init -y
 vercel link
 ```
 
-Pull its environment variables:
+Pull your authentication token:
 
 ```sh
 vercel env pull
 ```
 
-Now create `next-dev.ts`:
+Install the Sandbox SDK:
+
+```sh
+pnpm i @vercel/sandbox
+```
+
+Create a `index.mts` file:
 
 ```ts
-import ms from "ms";
 import { Sandbox } from "@vercel/sandbox";
 import { setTimeout } from "timers/promises";
 import { spawn } from "child_process";
@@ -53,7 +50,6 @@ async function main() {
       type: "git",
     },
     resources: { vcpus: 4 },
-    timeout: ms("5m"),
     ports: [3000],
     runtime: "node24",
   });
@@ -87,10 +83,10 @@ async function main() {
 main().catch(console.error);
 ```
 
-Run it like this:
+Run it:
 
 ```sh
-node --env-file .env.local --experimental-strip-types ./next-dev.ts
+node --experimental-strip-types --env-file .env.local index.mts
 ```
 
 This will:

--- a/packages/vercel-sandbox/README.md
+++ b/packages/vercel-sandbox/README.md
@@ -12,7 +12,7 @@ VMs. View the documentation [here](https://vercel.com/docs/vercel-sandbox).
 
 A sandbox is an isolated Linux system for your experimentation and use.
 Internally, it is a Firecracker MicroVM that is powered by [the same
-infrastructure][hive] that powers 1M+ builds a day at Vercel.
+infrastructure][hive] that powers 2M+ builds a day at Vercel.
 
 ## Getting started
 


### PR DESCRIPTION
In https://github.com/vercel/sandbox/pull/29 I forgot to also update the root README. Also https://github.com/vercel/sandbox/pull/11 was only updated on the root README but not the one for `@vercel/sandbox`

We should look into adding a symlink but not sure if that will break NPM/GitHub