### PR TITLE
feat(cli): add network policy column to list sandboxes

### DIFF
--- a/.changeset/cool-facts-return.md
+++ b/.changeset/cool-facts-return.md
@@ -1,0 +1,5 @@
+---
+"sandbox": minor
+---
+
+Adds the sandbox's network policy to the CLI's list output

--- a/packages/sandbox/src/commands/list.ts
+++ b/packages/sandbox/src/commands/list.ts
@@ -68,6 +68,9 @@ export const list = cmd.command({
           SNAPSHOT: {
             value: (s) => s.sourceSnapshotId ?? "-",
           },
+          NETWORK: {
+            value: (s) => formatNetwork(s.networkPolicy),
+          },
         },
       }),
     );
@@ -83,3 +86,23 @@ const SandboxStatusColor: Record<Sandbox["status"], ChalkInstance> = {
   "snapshotting": chalk.blue,
   "aborted": chalk.gray.dim,
 };
+
+type ListedSandbox = Awaited<
+  ReturnType<typeof Sandbox.list>
+>["json"]["sandboxes"][number];
+
+export const formatNetwork = (policy: ListedSandbox["networkPolicy"]) => {
+  if (!policy) {
+    return "allow-all";
+  }
+
+  switch (policy.mode) {
+    case "allow-all":
+    case "deny-all":
+      return policy.mode;
+    default: {
+      const rules = (policy.allowedDomains ?? []).length + (policy.allowedCIDRs ?? []).length + (policy.deniedCIDRs ?? []).length;
+      return `${rules} rule${rules !== 1 ? "s" : ""}`;
+    }
+  }
+}


### PR DESCRIPTION
To better view network policies for each sandbox at a glance:

```
$ node bin/sandbox.mjs ls
ID                                 STATUS    CREATED         MEMORY     VCPUS   RUNTIME   TIMEOUT        SNAPSHOT   NETWORK  
sbx_b8h6z2chEoTxgPIk5rZqSnYBNQKT   running   a minute ago    4,096 MB   2       node24    in 5 minutes   -          2 rules  
sbx_2znbSoRyLCGoSJXnK5ooI3mWdJ2j   running   2 minutes ago   4,096 MB   2       node24    in 3 minutes   -          1 rule   
sbx_hBSyl3aXlGthrjl7G8csZWjv7QK8   running   3 minutes ago   4,096 MB   2       node24    in 2 minutes   -          allow-all
sbx_ienhNKgKQbzjCQ5IT0zj9Y3JxkJD   running   3 minutes ago   4,096 MB   2       node24    in 2 minutes   -          deny-all 
```

I used "rules", to count the policy's `(allowed|denied)CIDRs` and `allowedDomains`, but open to other ideas.