### PR TITLE
cli: improved output of 'sandbox' command

### DIFF
--- a/packages/sandbox/src/help.ts
+++ b/packages/sandbox/src/help.ts
@@ -50,10 +50,7 @@ ${cmd("logout", "", "Log out of the Sandbox CLI")}
 
   ${chalk.gray("–")} Execute a command in an existing sandbox
 
-    ${chalk.cyan(`$ ${packageName} exec <sandbox-id> -- npm install`)}
+    ${chalk.cyan(`$ ${packageName} exec <sandbox-id> -- npm test`)}
 
-  ${chalk.gray("–")} Connect to an existing sandbox
-
-    ${chalk.cyan(`$ ${packageName} connect <sandbox-id>`)}
 `);
 }

--- a/packages/sandbox/src/help.ts
+++ b/packages/sandbox/src/help.ts
@@ -1,0 +1,44 @@
+import chalk from "chalk";
+import { version, packageName, logo, getTitleName } from "./pkg";
+
+function cmd(cmdName: string, args: string, desc: string): string {
+  return `      ${cmdName.padEnd(21)}${chalk.dim(args.padEnd(12))}${chalk.dim(desc)}`;
+}
+
+export function printHelp() {
+  console.log(chalk.grey(`${getTitleName()} ${version}`));
+  console.log(`
+  ${chalk.bold(`${logo} ${packageName}`)} [options] <command>
+
+  ${chalk.dim(`For command help, run \`${packageName} <command> --help\``)}
+
+  ${chalk.dim("Commands:")}
+
+    ${chalk.dim("Sandbox")}
+
+${cmd("create", "", "Create a new sandbox")}
+${cmd("ls | list", "", "List sandboxes for the current project")}
+${cmd("run", "[cmd]", "Create and run a command in a sandbox")}
+${cmd("rm | stop", "[id...]", "Stop one or more running sandboxes")}
+
+    ${chalk.dim("Interaction")}
+
+${cmd("ssh | connect", "[id]", "Start an interactive shell in a sandbox")}
+${cmd("exec", "[id] [cmd]", "Execute a command in a sandbox")}
+${cmd("cp | copy", "[src] [dst]", "Copy files between local and remote")}
+
+    ${chalk.dim("Snapshots & Config")}
+
+${cmd("snapshot", "[id]", "Take a filesystem snapshot of a sandbox")}
+${cmd("snapshots", "[cmd]", "Manage sandbox snapshots")}
+${cmd("config", "[cmd]", "Update sandbox configuration")}
+
+    ${chalk.dim("Auth")}
+
+${cmd("login", "", "Log in to the Sandbox CLI")}
+${cmd("logout", "", "Log out of the Sandbox CLI")}
+
+  ${chalk.dim("Examples:")}
+
+  ${chalk.gray("–")} Create a sandbox and start a shell
+

--- a/packages/sandbox/src/help.ts
+++ b/packages/sandbox/src/help.ts
@@ -23,7 +23,7 @@ ${cmd("rm | stop", "[id...]", "Stop one or more running sandboxes")}
 
     ${chalk.dim("Interaction")}
 
-${cmd("ssh | connect", "[id]", "Start an interactive shell in a sandbox")}
+${cmd("connect", "[id]", "Start an interactive shell in a sandbox")}
 ${cmd("exec", "[id] [cmd]", "Execute a command in a sandbox")}
 ${cmd("cp | copy", "[src] [dst]", "Copy files between local and remote")}
 

--- a/packages/sandbox/src/help.ts
+++ b/packages/sandbox/src/help.ts
@@ -14,27 +14,16 @@ export function printHelp() {
 
   ${chalk.dim("Commands:")}
 
-    ${chalk.dim("Sandbox")}
-
 ${cmd("create", "", "Create a new sandbox")}
 ${cmd("ls | list", "", "List sandboxes for the current project")}
 ${cmd("run", "[cmd]", "Create and run a command in a sandbox")}
 ${cmd("rm | stop", "[id...]", "Stop one or more running sandboxes")}
-
-    ${chalk.dim("Interaction")}
-
 ${cmd("ssh | connect", "[id]", "Start an interactive shell in a sandbox")}
 ${cmd("exec", "[id] [cmd]", "Execute a command in a sandbox")}
 ${cmd("cp | copy", "[src] [dst]", "Copy files between local and remote")}
-
-    ${chalk.dim("Snapshots & Config")}
-
 ${cmd("snapshot", "[id]", "Take a filesystem snapshot of a sandbox")}
 ${cmd("snapshots", "[cmd]", "Manage sandbox snapshots")}
 ${cmd("config", "[cmd]", "Update sandbox configuration")}
-
-    ${chalk.dim("Auth")}
-
 ${cmd("login", "", "Log in to the Sandbox CLI")}
 ${cmd("logout", "", "Log out of the Sandbox CLI")}
 

--- a/packages/sandbox/src/help.ts
+++ b/packages/sandbox/src/help.ts
@@ -42,3 +42,18 @@ ${cmd("logout", "", "Log out of the Sandbox CLI")}
 
   ${chalk.gray("–")} Create a sandbox and start a shell
 
+    ${chalk.cyan(`$ ${packageName} create --connect`)}
+
+  ${chalk.gray("–")} Run a command in a new sandbox
+
+    ${chalk.cyan(`$ ${packageName} run -- node -e "console.log('hello')"`)}
+
+  ${chalk.gray("–")} Execute a command in an existing sandbox
+
+    ${chalk.cyan(`$ ${packageName} exec <sandbox-id> -- npm install`)}
+
+  ${chalk.gray("–")} Connect to an existing sandbox
+
+    ${chalk.cyan(`$ ${packageName} connect <sandbox-id>`)}
+`);
+}

--- a/packages/sandbox/src/help.ts
+++ b/packages/sandbox/src/help.ts
@@ -23,7 +23,7 @@ ${cmd("rm | stop", "[id...]", "Stop one or more running sandboxes")}
 
     ${chalk.dim("Interaction")}
 
-${cmd("connect", "[id]", "Start an interactive shell in a sandbox")}
+${cmd("ssh | connect", "[id]", "Start an interactive shell in a sandbox")}
 ${cmd("exec", "[id] [cmd]", "Execute a command in a sandbox")}
 ${cmd("cp | copy", "[src] [dst]", "Copy files between local and remote")}
 

--- a/packages/sandbox/src/pkg.ts
+++ b/packages/sandbox/src/pkg.ts
@@ -1,1 +1,17 @@
-export { version } from "../package.json";
+import pkg from "../package.json";
+
+export const { version } = pkg;
+export const packageName = pkg.name;
+
+/**
+ * Unicode symbol used to represent the CLI.
+ */
+export const logo = "▲";
+
+/**
+ * Returns the display name for the CLI header,
+ * such as `Vercel Sandbox CLI`.
+ */
+export function getTitleName(): string {
+  return "Vercel Sandbox CLI";
+}

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -2,6 +2,7 @@ import { run } from "cmd-ts";
 import { app } from "./app";
 import dotenv from "dotenv-flow";
 import { StyledError } from "./error";
+import { printHelp } from "./help";
 
 dotenv.config({
   silent: true,
@@ -9,10 +10,19 @@ dotenv.config({
 
 async function main() {
   try {
+    let args = process.argv.slice(2);
+
+    if (
+      args.length === 0 ||
+      (args.length === 1 && (args[0] === "--help" || args[0] === "-h"))
+    ) {
+      printHelp();
+      return;
+    }
+
     // We've renamed `sandbox sh` to `sandbox create --connect`. cmd-ts doesn't support aliases for commands
     // with different arguments. Best effort deprecation warning, remap to the new command if the user just
     // runs `sandbox sh ...`
-    let args = process.argv.slice(2);
     if (args.length >= 1 && args[0] === "sh") {
       args = ["create", "--connect", ...args.slice(1)];
       process.stderr.write('Warning: `sandbox sh` is deprecated. Please use `sandbox create --connect` instead.\n');


### PR DESCRIPTION
Redesigns the `sandbox` CLI help output to match the Vercel CLI style — categorized commands, column-aligned layout, chalk colors, and usage examples.


| Before      | After |
| ----------- | ----------- |
|   <img width="1210" height="612" alt="2026-02-11 at 15 02 39@2x" src="https://github.com/user-attachments/assets/3de4d907-3542-404f-a381-2188786866c1" />   |    <img width="1322" height="1112" alt="2026-02-11 at 15 42 42@2x" src="https://github.com/user-attachments/assets/79b7a343-6df3-4f63-8196-bc60283059f5" />  |

