### PR TITLE
fix(cli): fix table output not using correct width

### DIFF
--- a/.changeset/fruity-bottles-appear.md
+++ b/.changeset/fruity-bottles-appear.md
@@ -1,0 +1,5 @@
+---
+"sandbox": patch
+---
+
+Fix table output not using the same width for each row


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="2087" height="250" alt="Screenshot 2026-02-12 at 15 37 03" src="https://github.com/user-attachments/assets/a504d30a-e916-4550-8cfc-c184087b5f3d" /> | <img width="1709" height="233" alt="Screenshot 2026-02-12 at 15 34 31" src="https://github.com/user-attachments/assets/59325e2b-00ca-4942-a3ca-2cc9fa2a33ff" /> | 