### PR TITLE
Add chmod/mode support to writeFiles API

### DIFF
--- a/packages/vercel-sandbox/src/api-client/api-client.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.ts
@@ -457,7 +457,7 @@ export class APIClient extends BaseClient {
   async writeFiles(params: {
     sandboxId: string;
     cwd: string;
-    files: { path: string; content: Buffer }[];
+    files: { path: string; content: Buffer; mode?: number }[];
     extractDir: string;
     signal?: AbortSignal;
   }) {
@@ -475,6 +475,7 @@ export class APIClient extends BaseClient {
           cwd: params.cwd,
         }),
         content: file.content,
+        mode: file.mode,
       });
     }
 

--- a/packages/vercel-sandbox/src/api-client/file-writer.ts
+++ b/packages/vercel-sandbox/src/api-client/file-writer.ts
@@ -11,6 +11,11 @@ interface FileBuffer {
    * The content of the file as a Buffer.
    */
   content: Buffer;
+  /**
+   * The file mode (permissions) as an octal number.
+   * @example 0o755 for executable files
+   */
+  mode?: number;
 }
 
 interface FileStream {
@@ -27,6 +32,11 @@ interface FileStream {
    * the header of the compressed file.
    */
   size: number;
+  /**
+   * The file mode (permissions) as an octal number.
+   * @example 0o755 for executable files
+   */
+  mode?: number;
 }
 
 /**
@@ -56,8 +66,8 @@ export class FileWriter {
     return new Promise<void>((resolve, reject) => {
       const entry = this.pack.entry(
         "size" in file
-          ? { name: file.name, size: file.size }
-          : { name: file.name, size: file.content.length },
+          ? { name: file.name, size: file.size, mode: file.mode }
+          : { name: file.name, size: file.content.length, mode: file.mode },
         (error) => {
           if (error) {
             return reject(error);

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -203,6 +203,20 @@ describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")("Sandbox", () => {
     expect((await consumeReadable(content2!)).toString()).toBe("Hello 2");
   });
 
+  it("allows to write files with custom mode (chmod)", async () => {
+    await sandbox.writeFiles([
+      { path: "script.sh", content: Buffer.from("#!/bin/bash\necho hello"), mode: 0o755 },
+    ]);
+
+    // Verify the file was written and has executable permissions
+    const result = await sandbox.runCommand("stat", ["-c", "%a", "script.sh"]);
+    expect(result.stdout.trim()).toBe("755");
+
+    // Also verify the script is actually executable
+    const execResult = await sandbox.runCommand("./script.sh");
+    expect(execResult.stdout.trim()).toBe("hello");
+  });
+
   it("allows to write files and then read them to a buffer", async () => {
     await sandbox.writeFiles([
       { path: "hello1.txt", content: Buffer.from("Hello 1") },

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -616,13 +616,19 @@ export class Sandbox {
    * Defaults to writing to /vercel/sandbox unless an absolute path is specified.
    * Writes files using the `vercel-sandbox` user.
    *
-   * @param files - Array of files with path and stream/buffer contents
+   * @param files - Array of files with path, content, and optional mode (permissions)
    * @param opts - Optional parameters.
    * @param opts.signal - An AbortSignal to cancel the operation.
    * @returns A promise that resolves when the files are written
+   *
+   * @example
+   * // Write a file with executable permissions
+   * await sandbox.writeFiles([
+   *   { path: "script.sh", content: Buffer.from("#!/bin/bash\necho hello"), mode: 0o755 },
+   * ]);
    */
   async writeFiles(
-    files: { path: string; content: Buffer }[],
+    files: { path: string; content: Buffer; mode?: number }[],
     opts?: { signal?: AbortSignal },
   ) {
     return this.client.writeFiles({


### PR DESCRIPTION
Allows setting file permissions when writing files to a sandbox by passing an optional `mode` property.

### What changed
- Added optional `mode` parameter to `FileWriter.addFile()` which passes through to the tar-stream entry header
- Updated `writeFiles` method signature in both `APIClient` and `Sandbox` classes to accept `mode?: number`
- Added integration test verifying executable permissions work correctly

### Example usage
```ts
await sandbox.writeFiles([
  { path: "script.sh", content: Buffer.from("#!/bin/bash\necho hello"), mode: 0o755 },
]);
```

<a href="https://vercel.slack.com/archives/C08L9SK5SM9/p1773695514536839?thread_ts=1773695514.536839&cid=C08L9SK5SM9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>