### PR TITLE
Add `node:fs` implementation on `Sandbox`

### DIFF
--- a/.changeset/spotty-planets-shop.md
+++ b/.changeset/spotty-planets-shop.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": minor
+---
+
+Expose Filesystem api from Sandbox

--- a/examples/workflow-code-runner/package.json
+++ b/examples/workflow-code-runner/package.json
@@ -13,7 +13,7 @@
     "next": "16.0.10",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "workflow": "4.2.0-beta.73",
+    "workflow": "4.2.1",
     "zod": "^4.1.9"
   },
   "devDependencies": {

--- a/packages/vercel-sandbox/src/filesystem.test.ts
+++ b/packages/vercel-sandbox/src/filesystem.test.ts
@@ -1,0 +1,482 @@
+import { it, expect, describe, vi, beforeEach } from "vitest";
+import { Stats, Dirent } from "fs";
+import { FileSystem } from "./filesystem";
+
+function makeMockSandbox() {
+  return {
+    readFileToBuffer: vi.fn(),
+    writeFiles: vi.fn(),
+    mkDir: vi.fn(),
+    runCommand: vi.fn(),
+  };
+}
+
+function mockCommandResult(stdout: string, exitCode = 0, stderr = "") {
+  return {
+    exitCode,
+    stdout: vi.fn().mockResolvedValue(stdout),
+    stderr: vi.fn().mockResolvedValue(stderr),
+  };
+}
+
+describe("FileSystem", () => {
+  let sandbox: ReturnType<typeof makeMockSandbox>;
+  let fs: FileSystem;
+
+  beforeEach(() => {
+    sandbox = makeMockSandbox();
+    fs = new FileSystem(sandbox as any);
+  });
+
+  describe("readFile", () => {
+    it("returns a Buffer when no encoding is specified", async () => {
+      sandbox.readFileToBuffer.mockResolvedValue(Buffer.from("hello"));
+      const result = await fs.readFile("/test.txt");
+      expect(Buffer.isBuffer(result)).toBe(true);
+      expect(result.toString()).toBe("hello");
+      expect(sandbox.readFileToBuffer).toHaveBeenCalledWith(
+        { path: "/test.txt" },
+        { signal: undefined },
+      );
+    });
+
+    it("returns a string when encoding is specified as string", async () => {
+      sandbox.readFileToBuffer.mockResolvedValue(Buffer.from("hello"));
+      const result = await fs.readFile("/test.txt", "utf8");
+      expect(typeof result).toBe("string");
+      expect(result).toBe("hello");
+    });
+
+    it("returns a string when encoding is specified in options", async () => {
+      sandbox.readFileToBuffer.mockResolvedValue(Buffer.from("hello"));
+      const result = await fs.readFile("/test.txt", { encoding: "utf8" });
+      expect(typeof result).toBe("string");
+      expect(result).toBe("hello");
+    });
+
+    it("throws ENOENT when file does not exist", async () => {
+      sandbox.readFileToBuffer.mockResolvedValue(null);
+      await expect(fs.readFile("/missing.txt")).rejects.toMatchObject({
+        code: "ENOENT",
+        syscall: "open",
+        path: "/missing.txt",
+      });
+    });
+
+    it("passes signal through", async () => {
+      const signal = AbortSignal.abort();
+      sandbox.readFileToBuffer.mockResolvedValue(Buffer.from("data"));
+      await fs.readFile("/test.txt", { signal });
+      expect(sandbox.readFileToBuffer).toHaveBeenCalledWith(
+        { path: "/test.txt" },
+        { signal },
+      );
+    });
+  });
+
+  describe("writeFile", () => {
+    it("writes string data as utf8 Buffer", async () => {
+      sandbox.writeFiles.mockResolvedValue(undefined);
+      await fs.writeFile("/test.txt", "hello");
+      expect(sandbox.writeFiles).toHaveBeenCalledWith(
+        [{ path: "/test.txt", content: Buffer.from("hello") }],
+        { signal: undefined },
+      );
+    });
+
+    it("writes Buffer data directly", async () => {
+      sandbox.writeFiles.mockResolvedValue(undefined);
+      const buf = Buffer.from("binary");
+      await fs.writeFile("/test.bin", buf);
+      expect(sandbox.writeFiles).toHaveBeenCalledWith(
+        [{ path: "/test.bin", content: buf }],
+        { signal: undefined },
+      );
+    });
+
+    it("writes Uint8Array data", async () => {
+      sandbox.writeFiles.mockResolvedValue(undefined);
+      const data = new Uint8Array([1, 2, 3]);
+      await fs.writeFile("/test.bin", data);
+      const calledContent = sandbox.writeFiles.mock.calls[0][0][0].content;
+      expect(Buffer.isBuffer(calledContent)).toBe(true);
+      expect([...calledContent]).toEqual([1, 2, 3]);
+    });
+
+    it("respects encoding option", async () => {
+      sandbox.writeFiles.mockResolvedValue(undefined);
+      await fs.writeFile("/test.txt", "data", "utf8");
+      expect(sandbox.writeFiles).toHaveBeenCalled();
+    });
+  });
+
+  describe("appendFile", () => {
+    it("appends to existing file", async () => {
+      sandbox.readFileToBuffer.mockResolvedValue(Buffer.from("hello "));
+      sandbox.writeFiles.mockResolvedValue(undefined);
+      await fs.appendFile("/test.txt", "world");
+      expect(sandbox.writeFiles).toHaveBeenCalledWith(
+        [{ path: "/test.txt", content: Buffer.from("hello world") }],
+        { signal: undefined },
+      );
+    });
+
+    it("creates file if it does not exist", async () => {
+      sandbox.readFileToBuffer.mockResolvedValue(null);
+      sandbox.writeFiles.mockResolvedValue(undefined);
+      await fs.appendFile("/new.txt", "data");
+      expect(sandbox.writeFiles).toHaveBeenCalledWith(
+        [{ path: "/new.txt", content: Buffer.from("data") }],
+        { signal: undefined },
+      );
+    });
+  });
+
+  describe("mkdir", () => {
+    it("calls sandbox.mkDir for non-recursive", async () => {
+      sandbox.mkDir.mockResolvedValue(undefined);
+      await fs.mkdir("/newdir");
+      expect(sandbox.mkDir).toHaveBeenCalledWith("/newdir", {
+        signal: undefined,
+      });
+    });
+
+    it("uses mkdir -p for recursive", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
+      await fs.mkdir("/a/b/c", { recursive: true });
+      expect(sandbox.runCommand).toHaveBeenCalledWith(
+        "mkdir",
+        ["-p", "/a/b/c"],
+        { signal: undefined },
+      );
+    });
+  });
+
+  describe("readdir", () => {
+    it("returns list of filenames", async () => {
+      sandbox.runCommand.mockResolvedValue(
+        mockCommandResult("file1.txt\nfile2.txt\ndir1\n"),
+      );
+      const result = await fs.readdir("/mydir");
+      expect(result).toEqual(["file1.txt", "file2.txt", "dir1"]);
+    });
+
+    it("returns Dirent objects with withFileTypes", async () => {
+      sandbox.runCommand.mockResolvedValue(
+        mockCommandResult("file.txt|f\nsubdir|d\nlink|l\n"),
+      );
+      const result = await fs.readdir("/mydir", { withFileTypes: true });
+      expect(result).toHaveLength(3);
+      expect(result[0]).toBeInstanceOf(Dirent);
+      expect(result[0].name).toBe("file.txt");
+      expect(result[0].isFile()).toBe(true);
+      expect(result[0].isDirectory()).toBe(false);
+      expect(result[1].name).toBe("subdir");
+      expect(result[1].isDirectory()).toBe(true);
+      expect(result[2].name).toBe("link");
+      expect(result[2].isSymbolicLink()).toBe(true);
+    });
+
+    it("throws ENOENT for missing directory", async () => {
+      sandbox.runCommand.mockResolvedValue(
+        mockCommandResult(
+          "",
+          2,
+          "ls: cannot access '/missing': No such file or directory",
+        ),
+      );
+      await expect(fs.readdir("/missing")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    });
+  });
+
+  describe("stat", () => {
+    it("parses stat output and returns a Stats instance", async () => {
+      // Format: size|rawModeHex|uid|gid|atimeS|mtimeS|ctimeS|birthtimeS|nlink|ino|dev|blksize|blocks
+      // 0o100755 = 0x81ed in hex for regular file with 755 permissions
+      sandbox.runCommand.mockResolvedValue(
+        mockCommandResult(
+          "1024|81ed|1000|1000|1700000000|1700000001|1700000002|1700000003|1|12345|2049|4096|8",
+        ),
+      );
+      const stats = await fs.stat("/test.txt");
+      expect(stats).toBeInstanceOf(Stats);
+      expect(stats.size).toBe(1024);
+      expect(stats.uid).toBe(1000);
+      expect(stats.isFile()).toBe(true);
+      expect(stats.isDirectory()).toBe(false);
+      expect(stats.mtimeMs).toBe(1700000001000);
+    });
+
+    it("correctly identifies directories", async () => {
+      // 0o40755 = 0x41ed in hex for directory with 755 permissions
+      sandbox.runCommand.mockResolvedValue(
+        mockCommandResult(
+          "4096|41ed|0|0|1700000000|1700000001|1700000002|0|2|100|2049|4096|8",
+        ),
+      );
+      const stats = await fs.stat("/mydir");
+      expect(stats.isDirectory()).toBe(true);
+      expect(stats.isFile()).toBe(false);
+    });
+
+    it("throws ENOENT for missing file", async () => {
+      sandbox.runCommand.mockResolvedValue(
+        mockCommandResult(
+          "",
+          1,
+          "stat: cannot statx '/missing': No such file or directory",
+        ),
+      );
+      await expect(fs.stat("/missing")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    });
+  });
+
+  describe("lstat", () => {
+    it("does not follow symlinks", async () => {
+      // 0o120777 = 0xa1ff in hex for symbolic link
+      sandbox.runCommand.mockResolvedValue(
+        mockCommandResult(
+          "0|a1ff|1000|1000|1700000000|1700000001|1700000002|0|1|12345|2049|4096|0",
+        ),
+      );
+      const stats = await fs.lstat("/mylink");
+      expect(stats.isSymbolicLink()).toBe(true);
+      expect(sandbox.runCommand).toHaveBeenCalledWith(
+        "stat",
+        ["-c", expect.any(String), "/mylink"],
+        expect.any(Object),
+      );
+      // Ensure -L is NOT used for lstat
+      const args = sandbox.runCommand.mock.calls[0][1];
+      expect(args).not.toContain("-L");
+    });
+  });
+
+  describe("unlink", () => {
+    it("removes a file", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
+      await fs.unlink("/test.txt");
+      expect(sandbox.runCommand).toHaveBeenCalledWith(
+        "rm",
+        ["/test.txt"],
+        expect.any(Object),
+      );
+    });
+
+    it("throws ENOENT for missing file", async () => {
+      sandbox.runCommand.mockResolvedValue(
+        mockCommandResult(
+          "",
+          1,
+          "rm: cannot remove '/missing': No such file or directory",
+        ),
+      );
+      await expect(fs.unlink("/missing")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    });
+  });
+
+  describe("rm", () => {
+    it("removes with recursive and force flags", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
+      await fs.rm("/dir", { recursive: true, force: true });
+      expect(sandbox.runCommand).toHaveBeenCalledWith(
+        "rm",
+        ["-r", "-f", "/dir"],
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("rmdir", () => {
+    it("removes an empty directory", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
+      await fs.rmdir("/emptydir");
+      expect(sandbox.runCommand).toHaveBeenCalledWith(
+        "rmdir",
+        ["/emptydir"],
+        expect.any(Object),
+      );
+    });
+
+    it("throws ENOTEMPTY for non-empty directory", async () => {
+      sandbox.runCommand.mockResolvedValue(
+        mockCommandResult(
+          "",
+          1,
+          "rmdir: failed to remove '/dir': Directory not empty",
+        ),
+      );
+      await expect(fs.rmdir("/dir")).rejects.toMatchObject({
+        code: "ENOTEMPTY",
+      });
+    });
+  });
+
+  describe("rename", () => {
+    it("renames a file", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
+      await fs.rename("/old.txt", "/new.txt");
+      expect(sandbox.runCommand).toHaveBeenCalledWith(
+        "mv",
+        ["/old.txt", "/new.txt"],
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("copyFile", () => {
+    it("copies a file", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
+      await fs.copyFile("/src.txt", "/dst.txt");
+      expect(sandbox.runCommand).toHaveBeenCalledWith(
+        "cp",
+        ["/src.txt", "/dst.txt"],
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("access", () => {
+    it("resolves when file exists", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult("", 0));
+      await expect(fs.access("/existing")).resolves.toBeUndefined();
+    });
+
+    it("throws ENOENT when file does not exist", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult("", 1));
+      await expect(fs.access("/missing")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    });
+  });
+
+  describe("exists", () => {
+    it("returns true when file exists", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult("", 0));
+      expect(await fs.exists("/existing")).toBe(true);
+    });
+
+    it("returns false when file does not exist", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult("", 1));
+      expect(await fs.exists("/missing")).toBe(false);
+    });
+  });
+
+  describe("chmod", () => {
+    it("changes mode with numeric mode", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
+      await fs.chmod("/test.txt", 0o755);
+      expect(sandbox.runCommand).toHaveBeenCalledWith(
+        "chmod",
+        ["755", "/test.txt"],
+        expect.any(Object),
+      );
+    });
+
+    it("changes mode with string mode", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
+      await fs.chmod("/test.txt", "644");
+      expect(sandbox.runCommand).toHaveBeenCalledWith(
+        "chmod",
+        ["644", "/test.txt"],
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("symlink", () => {
+    it("creates a symbolic link", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
+      await fs.symlink("/target", "/link");
+      expect(sandbox.runCommand).toHaveBeenCalledWith(
+        "ln",
+        ["-s", "/target", "/link"],
+        expect.any(Object),
+      );
+    });
+
+    it("throws EEXIST when link already exists", async () => {
+      sandbox.runCommand.mockResolvedValue(
+        mockCommandResult(
+          "",
+          1,
+          "ln: failed to create symbolic link '/link': File exists",
+        ),
+      );
+      await expect(fs.symlink("/target", "/link")).rejects.toMatchObject({
+        code: "EEXIST",
+      });
+    });
+  });
+
+  describe("readlink", () => {
+    it("reads a symlink target", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult("/target\n"));
+      const result = await fs.readlink("/link");
+      expect(result).toBe("/target");
+    });
+  });
+
+  describe("realpath", () => {
+    it("resolves the real path", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult("/real/path\n"));
+      const result = await fs.realpath("/some/link");
+      expect(result).toBe("/real/path");
+    });
+  });
+
+  describe("truncate", () => {
+    it("truncates a file to specified length", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
+      await fs.truncate("/test.txt", 100);
+      expect(sandbox.runCommand).toHaveBeenCalledWith(
+        "truncate",
+        ["-s", "100", "/test.txt"],
+        expect.any(Object),
+      );
+    });
+
+    it("truncates to 0 by default", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
+      await fs.truncate("/test.txt");
+      expect(sandbox.runCommand).toHaveBeenCalledWith(
+        "truncate",
+        ["-s", "0", "/test.txt"],
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("mkdtemp", () => {
+    it("creates a temp directory", async () => {
+      sandbox.runCommand.mockResolvedValue(
+        mockCommandResult("/tmp/prefix123456\n"),
+      );
+      const result = await fs.mkdtemp("/tmp/prefix");
+      expect(result).toBe("/tmp/prefix123456");
+      expect(sandbox.runCommand).toHaveBeenCalledWith(
+        "mktemp",
+        ["-d", "/tmp/prefixXXXXXX"],
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("chown", () => {
+    it("changes file owner", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
+      await fs.chown("/test.txt", 1000, 1000);
+      expect(sandbox.runCommand).toHaveBeenCalledWith(
+        "chown",
+        ["1000:1000", "/test.txt"],
+        expect.any(Object),
+      );
+    });
+  });
+});

--- a/packages/vercel-sandbox/src/filesystem.test.ts
+++ b/packages/vercel-sandbox/src/filesystem.test.ts
@@ -1,5 +1,5 @@
 import { it, expect, describe, vi, beforeEach } from "vitest";
-import { Stats, Dirent } from "fs";
+import type { Stats, Dirent } from "fs";
 import { FileSystem } from "./filesystem";
 
 function makeMockSandbox() {
@@ -167,7 +167,6 @@ describe("FileSystem", () => {
       );
       const result = await fs.readdir("/mydir", { withFileTypes: true });
       expect(result).toHaveLength(3);
-      expect(result[0]).toBeInstanceOf(Dirent);
       expect(result[0].name).toBe("file.txt");
       expect(result[0].isFile()).toBe(true);
       expect(result[0].isDirectory()).toBe(false);
@@ -201,7 +200,6 @@ describe("FileSystem", () => {
         ),
       );
       const stats = await fs.stat("/test.txt");
-      expect(stats).toBeInstanceOf(Stats);
       expect(stats.size).toBe(1024);
       expect(stats.uid).toBe(1000);
       expect(stats.isFile()).toBe(true);

--- a/packages/vercel-sandbox/src/filesystem.ts
+++ b/packages/vercel-sandbox/src/filesystem.ts
@@ -1,6 +1,19 @@
-import * as fs from "fs";
+import type { Stats, Dirent } from "fs";
+import * as constants from "node:constants";
 
-// UV_DIRENT_* constants exist at runtime but aren't in @types/node
+const {
+  S_IFMT,
+  S_IFREG,
+  S_IFDIR,
+  S_IFLNK,
+  S_IFBLK,
+  S_IFCHR,
+  S_IFIFO,
+  S_IFSOCK,
+} = constants;
+
+// https://github.com/nodejs/node/blob/main/deps/uv/include/uv.h#L1267-L1276
+// exposed through node:constants but not in @types/node
 const UV_DIRENT_FILE = 1;
 const UV_DIRENT_DIR = 2;
 const UV_DIRENT_LINK = 3;
@@ -80,30 +93,100 @@ function parseEncoding(options?: EncodingOption): {
   return { encoding: options.encoding ?? null, signal: options.signal };
 }
 
-function parseStat(stdout: string): fs.Stats {
-  // The Stats constructor and Dirent constructor exist at runtime but are marked
-  // private in @types/node. We cast to the actual runtime signatures.
-  const StatsConstructor = fs.Stats as unknown as new (
-    dev: number,
-    mode: number,
-    nlink: number,
-    uid: number,
-    gid: number,
-    rdev: number,
-    blksize: number,
-    ino: number,
-    size: number,
-    blocks: number,
-    atimeMs: number,
-    mtimeMs: number,
-    ctimeMs: number,
-    birthtimeMs: number,
-  ) => fs.Stats;
+class SandboxStats {
+  readonly atime: Date;
+  readonly mtime: Date;
+  readonly ctime: Date;
+  readonly birthtime: Date;
 
+  constructor(
+    readonly dev: number,
+    private readonly _mode: number,
+    readonly nlink: number,
+    readonly uid: number,
+    readonly gid: number,
+    readonly rdev: number,
+    readonly blksize: number,
+    readonly ino: number,
+    readonly size: number,
+    readonly blocks: number,
+    readonly atimeMs: number,
+    readonly mtimeMs: number,
+    readonly ctimeMs: number,
+    readonly birthtimeMs: number,
+  ) {
+    this.atime = new Date(atimeMs);
+    this.mtime = new Date(mtimeMs);
+    this.ctime = new Date(ctimeMs);
+    this.birthtime = new Date(birthtimeMs);
+  }
+
+  get mode(): number {
+    return this._mode;
+  }
+
+  isFile(): boolean {
+    return (this.mode & S_IFMT) === S_IFREG;
+  }
+  isDirectory(): boolean {
+    return (this.mode & S_IFMT) === S_IFDIR;
+  }
+  isBlockDevice(): boolean {
+    return (this.mode & S_IFMT) === S_IFBLK;
+  }
+  isCharacterDevice(): boolean {
+    return (this.mode & S_IFMT) === S_IFCHR;
+  }
+  isSymbolicLink(): boolean {
+    return (this.mode & S_IFMT) === S_IFLNK;
+  }
+  isFIFO(): boolean {
+    return (this.mode & S_IFMT) === S_IFIFO;
+  }
+  isSocket(): boolean {
+    return (this.mode & S_IFMT) === S_IFSOCK;
+  }
+}
+
+class SandboxDirent {
+  readonly path: string;
+
+  constructor(
+    public name: string,
+    private type: number,
+    public parentPath: string,
+  ) {
+    this.path = `${this.parentPath}/${this.name}`;
+  }
+
+  isFile(): boolean {
+    return this.type === UV_DIRENT_FILE;
+  }
+  isDirectory(): boolean {
+    return this.type === UV_DIRENT_DIR;
+  }
+  isBlockDevice(): boolean {
+    return this.type === UV_DIRENT_BLOCK;
+  }
+  isCharacterDevice(): boolean {
+    return this.type === UV_DIRENT_CHAR;
+  }
+  isSymbolicLink(): boolean {
+    return this.type === UV_DIRENT_LINK;
+  }
+  isFIFO(): boolean {
+    return this.type === UV_DIRENT_FIFO;
+  }
+  isSocket(): boolean {
+    return this.type === UV_DIRENT_SOCKET;
+  }
+}
+
+function parseStat(stdout: string) {
   // Format: size|rawModeHex|uid|gid|atimeMs|mtimeMs|ctimeMs|birthtimeMs|nlink|ino|dev|blksize|blocks
   const parts = stdout.trim().split("|");
 
-  return new StatsConstructor(
+  return new SandboxStats(
     parseInt(parts[10]!, 10), // dev
     parseInt(parts[1]!, 16), // mode (raw mode from %f, hex)
     parseInt(parts[8]!, 10), // nlink
@@ -118,10 +201,10 @@ function parseStat(stdout: string): fs.Stats {
     parseFloat(parts[5]!) * 1000, // mtimeMs
     parseFloat(parts[6]!) * 1000, // ctimeMs
     parseFloat(parts[7]!) * 1000, // birthtimeMs
-  );
+  ) satisfies Stats;
 }
 
-function parseDirent(stdout: string, path: string): fs.Dirent {
+function parseDirent(stdout: string, path: string) {
   const parts = stdout.trim().split("|");
   const name = parts[0];
   const type = parts[1];
@@ -134,14 +217,8 @@ function parseDirent(stdout: string, path: string): fs.Dirent {
     throw new Error(`Invalid dirent type: ${type}`);
   }
 
-  const DirentConstructor = fs.Dirent as unknown as new (
-    name: string,
-    type: number,
-    path: string,
-  ) => fs.Dirent;
-
   const direntType = FIND_TYPE_TO_DIRENT[type] ?? UV_DIRENT_FILE;
-  return new DirentConstructor(name, direntType, path);
+  return new SandboxDirent(name, direntType, path) satisfies Dirent;
 }
 
 // %f = raw mode in hex, includes file type bits so Stats.isFile()/isDirectory()/etc. work
@@ -306,11 +383,11 @@ export class FileSystem {
   async readdir(
     path: string,
     options: { signal?: AbortSignal; withFileTypes: true },
-  ): Promise<fs.Dirent[]>;
+  ): Promise<Dirent[]>;
   async readdir(
     path: string,
     options?: { signal?: AbortSignal; withFileTypes?: boolean },
-  ): Promise<string[] | fs.Dirent[]> {
+  ): Promise<string[] | Dirent[]> {
     "use step";
     if (options?.withFileTypes) {
       // Use find to get name and type in one pass
@@ -352,10 +429,7 @@ export class FileSystem {
    * @param path - Path to the file
    * @param options - Options
    */
-  async stat(
-    path: string,
-    options?: { signal?: AbortSignal },
-  ): Promise<fs.Stats> {
+  async stat(path: string, options?: { signal?: AbortSignal }): Promise<Stats> {
     "use step";
     const result = await this.sandbox.runCommand(
       "stat",
@@ -381,7 +455,7 @@ export class FileSystem {
   async lstat(
     path: string,
     options?: { signal?: AbortSignal },
-  ): Promise<fs.Stats> {
+  ): Promise<Stats> {
     "use step";
     const result = await this.sandbox.runCommand(
       "stat",
@@ -395,9 +469,7 @@ export class FileSystem {
       }
       throw fsError("EACCES", stderr.trim(), "lstat", path);
     }
-    const stat = await parseStat(await result.stdout());
-
-    return stat;
+    return parseStat(await result.stdout());
   }
 
   /**

--- a/packages/vercel-sandbox/src/filesystem.ts
+++ b/packages/vercel-sandbox/src/filesystem.ts
@@ -1,0 +1,712 @@
+/**
+ * A `node:fs/promises`-compatible API for interacting with the Sandbox filesystem.
+ *
+ * Access via {@link Sandbox.fs}.
+ *
+ * @hideconstructor
+ */
+
+import { Stats, Dirent } from "fs";
+
+// The Stats constructor and Dirent constructor exist at runtime but are marked
+// private in @types/node. We cast to the actual runtime signatures.
+const StatsConstructor = Stats as unknown as new (
+  dev: number,
+  mode: number,
+  nlink: number,
+  uid: number,
+  gid: number,
+  rdev: number,
+  blksize: number,
+  ino: number,
+  size: number,
+  blocks: number,
+  atimeMs: number,
+  mtimeMs: number,
+  ctimeMs: number,
+  birthtimeMs: number,
+) => Stats;
+
+const DirentConstructor = Dirent as unknown as new (
+  name: string,
+  type: number,
+  path: string,
+) => Dirent;
+
+// UV_DIRENT_* constants exist at runtime but aren't in @types/node
+const UV_DIRENT_FILE = 1;
+const UV_DIRENT_DIR = 2;
+const UV_DIRENT_LINK = 3;
+const UV_DIRENT_FIFO = 4;
+const UV_DIRENT_SOCKET = 5;
+const UV_DIRENT_CHAR = 6;
+const UV_DIRENT_BLOCK = 7;
+
+type EncodingOption =
+  | { encoding?: BufferEncoding | null; signal?: AbortSignal }
+  | BufferEncoding
+  | null;
+
+type WriteFileData = string | Buffer | Uint8Array;
+
+interface MkdirOptions {
+  recursive?: boolean;
+  signal?: AbortSignal;
+}
+
+interface RmOptions {
+  recursive?: boolean;
+  force?: boolean;
+  signal?: AbortSignal;
+}
+
+function fsError(
+  code: string,
+  message: string,
+  syscall: string,
+  path: string,
+): Error & { code: string; syscall: string; path: string } {
+  const err = new Error(
+    `${code}: ${message}, ${syscall} '${path}'`,
+  ) as Error & {
+    code: string;
+    syscall: string;
+    path: string;
+  };
+  err.code = code;
+  err.syscall = syscall;
+  err.path = path;
+  return err;
+}
+
+interface SandboxHandle {
+  readFileToBuffer(
+    file: { path: string },
+    opts?: { signal?: AbortSignal },
+  ): Promise<Buffer | null>;
+  writeFiles(
+    files: { path: string; content: Buffer }[],
+    opts?: { signal?: AbortSignal },
+  ): Promise<void>;
+  mkDir(path: string, opts?: { signal?: AbortSignal }): Promise<void>;
+  runCommand(
+    cmd: string,
+    args?: string[],
+    opts?: { signal?: AbortSignal },
+  ): Promise<{
+    exitCode: number;
+    stdout(opts?: { signal?: AbortSignal }): Promise<string>;
+    stderr(opts?: { signal?: AbortSignal }): Promise<string>;
+  }>;
+}
+
+function parseEncoding(options?: EncodingOption): {
+  encoding: BufferEncoding | null;
+  signal?: AbortSignal;
+} {
+  if (options === null || options === undefined) {
+    return { encoding: null };
+  }
+  if (typeof options === "string") {
+    return { encoding: options };
+  }
+  return { encoding: options.encoding ?? null, signal: options.signal };
+}
+
+function parseStat(stdout: string): Stats {
+  // Format: size|rawModeHex|uid|gid|atimeMs|mtimeMs|ctimeMs|birthtimeMs|nlink|ino|dev|blksize|blocks
+  const parts = stdout.trim().split("|");
+
+  return new StatsConstructor(
+    parseInt(parts[10]!, 10),        // dev
+    parseInt(parts[1]!, 16),         // mode (raw mode from %f, hex)
+    parseInt(parts[8]!, 10),         // nlink
+    parseInt(parts[2]!, 10),         // uid
+    parseInt(parts[3]!, 10),         // gid
+    0,                               // rdev
+    parseInt(parts[11]!, 10),        // blksize
+    parseInt(parts[9]!, 10),         // ino
+    parseInt(parts[0]!, 10),         // size
+    parseInt(parts[12]!, 10),        // blocks
+    parseFloat(parts[4]!) * 1000,    // atimeMs
+    parseFloat(parts[5]!) * 1000,    // mtimeMs
+    parseFloat(parts[6]!) * 1000,    // ctimeMs
+    parseFloat(parts[7]!) * 1000,    // birthtimeMs
+  );
+}
+
+// %f = raw mode in hex, includes file type bits so Stats.isFile()/isDirectory()/etc. work
+const STAT_FORMAT = "%s|%f|%u|%g|%X|%Y|%Z|%W|%h|%i|%d|%B|%b";
+
+const FIND_TYPE_TO_DIRENT: Record<string, number> = {
+  f: UV_DIRENT_FILE,
+  d: UV_DIRENT_DIR,
+  l: UV_DIRENT_LINK,
+  b: UV_DIRENT_BLOCK,
+  c: UV_DIRENT_CHAR,
+  p: UV_DIRENT_FIFO,
+  s: UV_DIRENT_SOCKET,
+};
+
+export class FileSystem {
+  /** @internal */
+  private sandbox: SandboxHandle;
+
+  /** @internal */
+  constructor(sandbox: SandboxHandle) {
+    this.sandbox = sandbox;
+  }
+
+  /**
+   * Read the entire contents of a file.
+   *
+   * @param path - Path to the file
+   * @param options - Encoding or options object. If encoding is specified, returns a string; otherwise returns a Buffer.
+   */
+  async readFile(
+    path: string,
+    options?: { encoding?: null; signal?: AbortSignal } | null,
+  ): Promise<Buffer>;
+  async readFile(
+    path: string,
+    options:
+      | { encoding: BufferEncoding; signal?: AbortSignal }
+      | BufferEncoding,
+  ): Promise<string>;
+  async readFile(
+    path: string,
+    options?: EncodingOption,
+  ): Promise<Buffer | string> {
+    const { encoding, signal } = parseEncoding(options);
+    const buffer = await this.sandbox.readFileToBuffer({ path }, { signal });
+    if (buffer === null) {
+      throw fsError("ENOENT", "no such file or directory", "open", path);
+    }
+    return encoding ? buffer.toString(encoding) : buffer;
+  }
+
+  /**
+   * Write data to a file, replacing the file if it already exists.
+   *
+   * @param path - Path to the file
+   * @param data - The data to write
+   * @param options - Write options
+   */
+  async writeFile(
+    path: string,
+    data: WriteFileData,
+    options?:
+      | { encoding?: BufferEncoding; signal?: AbortSignal }
+      | BufferEncoding,
+  ): Promise<void> {
+    const { encoding, signal } =
+      typeof options === "string"
+        ? { encoding: options, signal: undefined }
+        : { encoding: options?.encoding, signal: options?.signal };
+    let content: Buffer;
+    if (typeof data === "string") {
+      content = Buffer.from(data, encoding ?? "utf8");
+    } else if (Buffer.isBuffer(data)) {
+      content = data;
+    } else {
+      content = Buffer.from(data);
+    }
+    await this.sandbox.writeFiles([{ path, content }], { signal });
+  }
+
+  /**
+   * Append data to a file, creating the file if it does not yet exist.
+   *
+   * @param path - Path to the file
+   * @param data - The data to append
+   * @param options - Write options
+   */
+  async appendFile(
+    path: string,
+    data: WriteFileData,
+    options?:
+      | { encoding?: BufferEncoding; signal?: AbortSignal }
+      | BufferEncoding,
+  ): Promise<void> {
+    const { encoding, signal } =
+      typeof options === "string"
+        ? { encoding: options, signal: undefined }
+        : { encoding: options?.encoding, signal: options?.signal };
+    let appendContent: Buffer;
+    if (typeof data === "string") {
+      appendContent = Buffer.from(data, encoding ?? "utf8");
+    } else if (Buffer.isBuffer(data)) {
+      appendContent = data;
+    } else {
+      appendContent = Buffer.from(data);
+    }
+
+    const existing = await this.sandbox.readFileToBuffer({ path }, { signal });
+    const content =
+      existing !== null
+        ? Buffer.concat([existing, appendContent])
+        : appendContent;
+    await this.sandbox.writeFiles([{ path, content }], { signal });
+  }
+
+  /**
+   * Create a directory.
+   *
+   * @param path - Path of the directory to create
+   * @param options - Options for directory creation
+   */
+  async mkdir(
+    path: string,
+    options?: MkdirOptions | number,
+  ): Promise<string | undefined> {
+    const opts =
+      typeof options === "number" ? { recursive: false } : (options ?? {});
+    if (opts.recursive) {
+      const result = await this.sandbox.runCommand("mkdir", ["-p", path], {
+        signal: opts.signal,
+      });
+      if (result.exitCode !== 0) {
+        const stderr = await result.stderr();
+        throw fsError(
+          "EACCES",
+          stderr.trim() || "permission denied",
+          "mkdir",
+          path,
+        );
+      }
+      return undefined;
+    }
+    await this.sandbox.mkDir(path, { signal: opts.signal });
+    return undefined;
+  }
+
+  /**
+   * Read the contents of a directory.
+   *
+   * @param path - Path to the directory
+   * @param options - Options. When `withFileTypes` is true, returns `Dirent` objects.
+   */
+  async readdir(
+    path: string,
+    options?: { signal?: AbortSignal; withFileTypes?: false },
+  ): Promise<string[]>;
+  async readdir(
+    path: string,
+    options: { signal?: AbortSignal; withFileTypes: true },
+  ): Promise<Dirent[]>;
+  async readdir(
+    path: string,
+    options?: { signal?: AbortSignal; withFileTypes?: boolean },
+  ): Promise<string[] | Dirent[]> {
+    if (options?.withFileTypes) {
+      // Use find to get name and type in one pass
+      const result = await this.sandbox.runCommand(
+        "find",
+        [path, "-maxdepth", "1", "-mindepth", "1", "-printf", "%f|%y\\n"],
+        { signal: options?.signal },
+      );
+      if (result.exitCode !== 0) {
+        const stderr = await result.stderr();
+        if (stderr.includes("No such file or directory")) {
+          throw fsError("ENOENT", "no such file or directory", "scandir", path);
+        }
+        throw fsError("EACCES", stderr.trim(), "scandir", path);
+      }
+      const stdout = await result.stdout();
+      const lines = stdout.trim().split("\n").filter(Boolean);
+      return lines.map((line) => {
+        const [name, type] = line.split("|");
+        const direntType =
+          FIND_TYPE_TO_DIRENT[type!] ?? UV_DIRENT_FILE;
+        return new DirentConstructor(name!, direntType, path);
+      });
+    }
+
+    const result = await this.sandbox.runCommand("ls", ["-1", path], {
+      signal: options?.signal,
+    });
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      if (stderr.includes("No such file or directory")) {
+        throw fsError("ENOENT", "no such file or directory", "scandir", path);
+      }
+      throw fsError("EACCES", stderr.trim(), "scandir", path);
+    }
+    const stdout = await result.stdout();
+    return stdout.trim().split("\n").filter(Boolean);
+  }
+
+  /**
+   * Get file status. Follows symbolic links.
+   *
+   * @param path - Path to the file
+   * @param options - Options
+   */
+  async stat(
+    path: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<Stats> {
+    const result = await this.sandbox.runCommand(
+      "stat",
+      ["-L", "-c", STAT_FORMAT, path],
+      { signal: options?.signal },
+    );
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      if (stderr.includes("No such file or directory")) {
+        throw fsError("ENOENT", "no such file or directory", "stat", path);
+      }
+      throw fsError("EACCES", stderr.trim(), "stat", path);
+    }
+    return parseStat(await result.stdout());
+  }
+
+  /**
+   * Get file status. Does not follow symbolic links.
+   *
+   * @param path - Path to the file
+   * @param options - Options
+   */
+  async lstat(
+    path: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<Stats> {
+    const result = await this.sandbox.runCommand(
+      "stat",
+      ["-c", STAT_FORMAT, path],
+      { signal: options?.signal },
+    );
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      if (stderr.includes("No such file or directory")) {
+        throw fsError("ENOENT", "no such file or directory", "lstat", path);
+      }
+      throw fsError("EACCES", stderr.trim(), "lstat", path);
+    }
+    return parseStat(await result.stdout());
+  }
+
+  /**
+   * Remove a file or symbolic link.
+   *
+   * @param path - Path to the file
+   * @param options - Options
+   */
+  async unlink(
+    path: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<void> {
+    const result = await this.sandbox.runCommand("rm", [path], {
+      signal: options?.signal,
+    });
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      if (stderr.includes("No such file or directory")) {
+        throw fsError("ENOENT", "no such file or directory", "unlink", path);
+      }
+      throw fsError("EACCES", stderr.trim(), "unlink", path);
+    }
+  }
+
+  /**
+   * Remove files and directories.
+   *
+   * @param path - Path to remove
+   * @param options - Options
+   */
+  async rm(path: string, options?: RmOptions): Promise<void> {
+    const args: string[] = [];
+    if (options?.recursive) args.push("-r");
+    if (options?.force) args.push("-f");
+    args.push(path);
+
+    const result = await this.sandbox.runCommand("rm", args, {
+      signal: options?.signal,
+    });
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      if (stderr.includes("No such file or directory")) {
+        throw fsError("ENOENT", "no such file or directory", "rm", path);
+      }
+      throw fsError("EACCES", stderr.trim(), "rm", path);
+    }
+  }
+
+  /**
+   * Remove a directory.
+   *
+   * @param path - Path to the directory
+   * @param options - Options
+   */
+  async rmdir(path: string, options?: { signal?: AbortSignal }): Promise<void> {
+    const result = await this.sandbox.runCommand("rmdir", [path], {
+      signal: options?.signal,
+    });
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      if (stderr.includes("No such file or directory")) {
+        throw fsError("ENOENT", "no such file or directory", "rmdir", path);
+      }
+      if (stderr.includes("not empty")) {
+        throw fsError("ENOTEMPTY", "directory not empty", "rmdir", path);
+      }
+      throw fsError("EACCES", stderr.trim(), "rmdir", path);
+    }
+  }
+
+  /**
+   * Rename a file or directory.
+   *
+   * @param oldPath - Current path
+   * @param newPath - New path
+   * @param options - Options
+   */
+  async rename(
+    oldPath: string,
+    newPath: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<void> {
+    const result = await this.sandbox.runCommand("mv", [oldPath, newPath], {
+      signal: options?.signal,
+    });
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      if (stderr.includes("No such file or directory")) {
+        throw fsError("ENOENT", "no such file or directory", "rename", oldPath);
+      }
+      throw fsError("EACCES", stderr.trim(), "rename", oldPath);
+    }
+  }
+
+  /**
+   * Copy a file.
+   *
+   * @param src - Source path
+   * @param dest - Destination path
+   * @param options - Options
+   */
+  async copyFile(
+    src: string,
+    dest: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<void> {
+    const result = await this.sandbox.runCommand("cp", [src, dest], {
+      signal: options?.signal,
+    });
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      if (stderr.includes("No such file or directory")) {
+        throw fsError("ENOENT", "no such file or directory", "copyfile", src);
+      }
+      throw fsError("EACCES", stderr.trim(), "copyfile", src);
+    }
+  }
+
+  /**
+   * Test whether a file exists and the user has the specified permissions.
+   *
+   * @param path - Path to the file
+   * @param options - Options
+   */
+  async access(
+    path: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<void> {
+    const result = await this.sandbox.runCommand("test", ["-e", path], {
+      signal: options?.signal,
+    });
+    if (result.exitCode !== 0) {
+      throw fsError("ENOENT", "no such file or directory", "access", path);
+    }
+  }
+
+  /**
+   * Check if a path exists.
+   *
+   * This is a convenience method not in `node:fs/promises` but commonly needed.
+   *
+   * @param path - Path to check
+   * @param options - Options
+   */
+  async exists(
+    path: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<boolean> {
+    const result = await this.sandbox.runCommand("test", ["-e", path], {
+      signal: options?.signal,
+    });
+    return result.exitCode === 0;
+  }
+
+  /**
+   * Change file mode (permissions).
+   *
+   * @param path - Path to the file
+   * @param mode - File mode (e.g., 0o755 or "755")
+   * @param options - Options
+   */
+  async chmod(
+    path: string,
+    mode: number | string,
+    options?: { signal?: AbortSignal },
+  ): Promise<void> {
+    const modeStr = typeof mode === "number" ? mode.toString(8) : mode;
+    const result = await this.sandbox.runCommand("chmod", [modeStr, path], {
+      signal: options?.signal,
+    });
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      if (stderr.includes("No such file or directory")) {
+        throw fsError("ENOENT", "no such file or directory", "chmod", path);
+      }
+      throw fsError("EACCES", stderr.trim(), "chmod", path);
+    }
+  }
+
+  /**
+   * Change file owner and group.
+   *
+   * @param path - Path to the file
+   * @param uid - User ID
+   * @param gid - Group ID
+   * @param options - Options
+   */
+  async chown(
+    path: string,
+    uid: number,
+    gid: number,
+    options?: { signal?: AbortSignal },
+  ): Promise<void> {
+    const result = await this.sandbox.runCommand(
+      "chown",
+      [`${uid}:${gid}`, path],
+      { signal: options?.signal },
+    );
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      if (stderr.includes("No such file or directory")) {
+        throw fsError("ENOENT", "no such file or directory", "chown", path);
+      }
+      throw fsError("EACCES", stderr.trim(), "chown", path);
+    }
+  }
+
+  /**
+   * Create a symbolic link.
+   *
+   * @param target - The target of the symbolic link
+   * @param path - The path of the symbolic link to create
+   * @param options - Options
+   */
+  async symlink(
+    target: string,
+    path: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<void> {
+    const result = await this.sandbox.runCommand("ln", ["-s", target, path], {
+      signal: options?.signal,
+    });
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      if (stderr.includes("File exists")) {
+        throw fsError("EEXIST", "file already exists", "symlink", path);
+      }
+      throw fsError("EACCES", stderr.trim(), "symlink", path);
+    }
+  }
+
+  /**
+   * Read the value of a symbolic link.
+   *
+   * @param path - Path to the symbolic link
+   * @param options - Options
+   */
+  async readlink(
+    path: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<string> {
+    const result = await this.sandbox.runCommand("readlink", [path], {
+      signal: options?.signal,
+    });
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      if (stderr.includes("No such file or directory")) {
+        throw fsError("ENOENT", "no such file or directory", "readlink", path);
+      }
+      throw fsError("EINVAL", "invalid argument", "readlink", path);
+    }
+    return (await result.stdout()).trim();
+  }
+
+  /**
+   * Resolve the real path of a file (resolving symlinks).
+   *
+   * @param path - Path to resolve
+   * @param options - Options
+   */
+  async realpath(
+    path: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<string> {
+    const result = await this.sandbox.runCommand("realpath", [path], {
+      signal: options?.signal,
+    });
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      if (stderr.includes("No such file or directory")) {
+        throw fsError("ENOENT", "no such file or directory", "realpath", path);
+      }
+      throw fsError("EACCES", stderr.trim(), "realpath", path);
+    }
+    return (await result.stdout()).trim();
+  }
+
+  /**
+   * Truncate a file to a specified length.
+   *
+   * @param path - Path to the file
+   * @param len - Length to truncate to (default: 0)
+   * @param options - Options
+   */
+  async truncate(
+    path: string,
+    len?: number,
+    options?: { signal?: AbortSignal },
+  ): Promise<void> {
+    const result = await this.sandbox.runCommand(
+      "truncate",
+      ["-s", String(len ?? 0), path],
+      { signal: options?.signal },
+    );
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      if (stderr.includes("No such file or directory")) {
+        throw fsError("ENOENT", "no such file or directory", "truncate", path);
+      }
+      throw fsError("EACCES", stderr.trim(), "truncate", path);
+    }
+  }
+
+  /**
+   * Create a unique temporary directory.
+   *
+   * @param prefix - The prefix for the temporary directory name
+   * @param options - Options
+   * @returns The path of the created temporary directory
+   */
+  async mkdtemp(
+    prefix: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<string> {
+    const result = await this.sandbox.runCommand(
+      "mktemp",
+      ["-d", `${prefix}XXXXXX`],
+      { signal: options?.signal },
+    );
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      throw fsError("EACCES", stderr.trim(), "mkdtemp", prefix);
+    }
+    return (await result.stdout()).trim();
+  }
+}

--- a/packages/vercel-sandbox/src/filesystem.ts
+++ b/packages/vercel-sandbox/src/filesystem.ts
@@ -1,37 +1,4 @@
-/**
- * A `node:fs/promises`-compatible API for interacting with the Sandbox filesystem.
- *
- * Access via {@link Sandbox.fs}.
- *
- * @hideconstructor
- */
-
-import { Stats, Dirent } from "fs";
-
-// The Stats constructor and Dirent constructor exist at runtime but are marked
-// private in @types/node. We cast to the actual runtime signatures.
-const StatsConstructor = Stats as unknown as new (
-  dev: number,
-  mode: number,
-  nlink: number,
-  uid: number,
-  gid: number,
-  rdev: number,
-  blksize: number,
-  ino: number,
-  size: number,
-  blocks: number,
-  atimeMs: number,
-  mtimeMs: number,
-  ctimeMs: number,
-  birthtimeMs: number,
-) => Stats;
-
-const DirentConstructor = Dirent as unknown as new (
-  name: string,
-  type: number,
-  path: string,
-) => Dirent;
+import * as fs from "fs";
 
 // UV_DIRENT_* constants exist at runtime but aren't in @types/node
 const UV_DIRENT_FILE = 1;
@@ -113,26 +80,68 @@ function parseEncoding(options?: EncodingOption): {
   return { encoding: options.encoding ?? null, signal: options.signal };
 }
 
-function parseStat(stdout: string): Stats {
+function parseStat(stdout: string): fs.Stats {
+  // The Stats constructor and Dirent constructor exist at runtime but are marked
+  // private in @types/node. We cast to the actual runtime signatures.
+  const StatsConstructor = fs.Stats as unknown as new (
+    dev: number,
+    mode: number,
+    nlink: number,
+    uid: number,
+    gid: number,
+    rdev: number,
+    blksize: number,
+    ino: number,
+    size: number,
+    blocks: number,
+    atimeMs: number,
+    mtimeMs: number,
+    ctimeMs: number,
+    birthtimeMs: number,
+  ) => fs.Stats;
+
   // Format: size|rawModeHex|uid|gid|atimeMs|mtimeMs|ctimeMs|birthtimeMs|nlink|ino|dev|blksize|blocks
   const parts = stdout.trim().split("|");
 
   return new StatsConstructor(
-    parseInt(parts[10]!, 10),        // dev
-    parseInt(parts[1]!, 16),         // mode (raw mode from %f, hex)
-    parseInt(parts[8]!, 10),         // nlink
-    parseInt(parts[2]!, 10),         // uid
-    parseInt(parts[3]!, 10),         // gid
-    0,                               // rdev
-    parseInt(parts[11]!, 10),        // blksize
-    parseInt(parts[9]!, 10),         // ino
-    parseInt(parts[0]!, 10),         // size
-    parseInt(parts[12]!, 10),        // blocks
-    parseFloat(parts[4]!) * 1000,    // atimeMs
-    parseFloat(parts[5]!) * 1000,    // mtimeMs
-    parseFloat(parts[6]!) * 1000,    // ctimeMs
-    parseFloat(parts[7]!) * 1000,    // birthtimeMs
+    parseInt(parts[10]!, 10), // dev
+    parseInt(parts[1]!, 16), // mode (raw mode from %f, hex)
+    parseInt(parts[8]!, 10), // nlink
+    parseInt(parts[2]!, 10), // uid
+    parseInt(parts[3]!, 10), // gid
+    0, // rdev
+    parseInt(parts[11]!, 10), // blksize
+    parseInt(parts[9]!, 10), // ino
+    parseInt(parts[0]!, 10), // size
+    parseInt(parts[12]!, 10), // blocks
+    parseFloat(parts[4]!) * 1000, // atimeMs
+    parseFloat(parts[5]!) * 1000, // mtimeMs
+    parseFloat(parts[6]!) * 1000, // ctimeMs
+    parseFloat(parts[7]!) * 1000, // birthtimeMs
   );
+}
+
+function parseDirent(stdout: string, path: string): fs.Dirent {
+  const parts = stdout.trim().split("|");
+  const name = parts[0];
+  const type = parts[1];
+
+  if (!name) {
+    throw fsError("ENOENT", "no such file or directory", "readdir", path);
+  }
+
+  if (!type) {
+    throw new Error(`Invalid dirent type: ${type}`);
+  }
+
+  const DirentConstructor = fs.Dirent as unknown as new (
+    name: string,
+    type: number,
+    path: string,
+  ) => fs.Dirent;
+
+  const direntType = FIND_TYPE_TO_DIRENT[type] ?? UV_DIRENT_FILE;
+  return new DirentConstructor(name, direntType, path);
 }
 
 // %f = raw mode in hex, includes file type bits so Stats.isFile()/isDirectory()/etc. work
@@ -177,6 +186,7 @@ export class FileSystem {
     path: string,
     options?: EncodingOption,
   ): Promise<Buffer | string> {
+    "use step";
     const { encoding, signal } = parseEncoding(options);
     const buffer = await this.sandbox.readFileToBuffer({ path }, { signal });
     if (buffer === null) {
@@ -199,6 +209,7 @@ export class FileSystem {
       | { encoding?: BufferEncoding; signal?: AbortSignal }
       | BufferEncoding,
   ): Promise<void> {
+    "use step";
     const { encoding, signal } =
       typeof options === "string"
         ? { encoding: options, signal: undefined }
@@ -228,6 +239,7 @@ export class FileSystem {
       | { encoding?: BufferEncoding; signal?: AbortSignal }
       | BufferEncoding,
   ): Promise<void> {
+    "use step";
     const { encoding, signal } =
       typeof options === "string"
         ? { encoding: options, signal: undefined }
@@ -259,6 +271,7 @@ export class FileSystem {
     path: string,
     options?: MkdirOptions | number,
   ): Promise<string | undefined> {
+    "use step";
     const opts =
       typeof options === "number" ? { recursive: false } : (options ?? {});
     if (opts.recursive) {
@@ -293,11 +306,12 @@ export class FileSystem {
   async readdir(
     path: string,
     options: { signal?: AbortSignal; withFileTypes: true },
-  ): Promise<Dirent[]>;
+  ): Promise<fs.Dirent[]>;
   async readdir(
     path: string,
     options?: { signal?: AbortSignal; withFileTypes?: boolean },
-  ): Promise<string[] | Dirent[]> {
+  ): Promise<string[] | fs.Dirent[]> {
+    "use step";
     if (options?.withFileTypes) {
       // Use find to get name and type in one pass
       const result = await this.sandbox.runCommand(
@@ -314,12 +328,8 @@ export class FileSystem {
       }
       const stdout = await result.stdout();
       const lines = stdout.trim().split("\n").filter(Boolean);
-      return lines.map((line) => {
-        const [name, type] = line.split("|");
-        const direntType =
-          FIND_TYPE_TO_DIRENT[type!] ?? UV_DIRENT_FILE;
-        return new DirentConstructor(name!, direntType, path);
-      });
+
+      return lines.map((line) => parseDirent(line, path));
     }
 
     const result = await this.sandbox.runCommand("ls", ["-1", path], {
@@ -345,7 +355,8 @@ export class FileSystem {
   async stat(
     path: string,
     options?: { signal?: AbortSignal },
-  ): Promise<Stats> {
+  ): Promise<fs.Stats> {
+    "use step";
     const result = await this.sandbox.runCommand(
       "stat",
       ["-L", "-c", STAT_FORMAT, path],
@@ -370,7 +381,8 @@ export class FileSystem {
   async lstat(
     path: string,
     options?: { signal?: AbortSignal },
-  ): Promise<Stats> {
+  ): Promise<fs.Stats> {
+    "use step";
     const result = await this.sandbox.runCommand(
       "stat",
       ["-c", STAT_FORMAT, path],
@@ -383,7 +395,9 @@ export class FileSystem {
       }
       throw fsError("EACCES", stderr.trim(), "lstat", path);
     }
-    return parseStat(await result.stdout());
+    const stat = await parseStat(await result.stdout());
+
+    return stat;
   }
 
   /**
@@ -396,6 +410,7 @@ export class FileSystem {
     path: string,
     options?: { signal?: AbortSignal },
   ): Promise<void> {
+    "use step";
     const result = await this.sandbox.runCommand("rm", [path], {
       signal: options?.signal,
     });
@@ -415,6 +430,7 @@ export class FileSystem {
    * @param options - Options
    */
   async rm(path: string, options?: RmOptions): Promise<void> {
+    "use step";
     const args: string[] = [];
     if (options?.recursive) args.push("-r");
     if (options?.force) args.push("-f");
@@ -439,6 +455,7 @@ export class FileSystem {
    * @param options - Options
    */
   async rmdir(path: string, options?: { signal?: AbortSignal }): Promise<void> {
+    "use step";
     const result = await this.sandbox.runCommand("rmdir", [path], {
       signal: options?.signal,
     });
@@ -466,6 +483,7 @@ export class FileSystem {
     newPath: string,
     options?: { signal?: AbortSignal },
   ): Promise<void> {
+    "use step";
     const result = await this.sandbox.runCommand("mv", [oldPath, newPath], {
       signal: options?.signal,
     });
@@ -490,6 +508,7 @@ export class FileSystem {
     dest: string,
     options?: { signal?: AbortSignal },
   ): Promise<void> {
+    "use step";
     const result = await this.sandbox.runCommand("cp", [src, dest], {
       signal: options?.signal,
     });
@@ -512,6 +531,7 @@ export class FileSystem {
     path: string,
     options?: { signal?: AbortSignal },
   ): Promise<void> {
+    "use step";
     const result = await this.sandbox.runCommand("test", ["-e", path], {
       signal: options?.signal,
     });
@@ -550,6 +570,7 @@ export class FileSystem {
     mode: number | string,
     options?: { signal?: AbortSignal },
   ): Promise<void> {
+    "use step";
     const modeStr = typeof mode === "number" ? mode.toString(8) : mode;
     const result = await this.sandbox.runCommand("chmod", [modeStr, path], {
       signal: options?.signal,
@@ -577,6 +598,7 @@ export class FileSystem {
     gid: number,
     options?: { signal?: AbortSignal },
   ): Promise<void> {
+    "use step";
     const result = await this.sandbox.runCommand(
       "chown",
       [`${uid}:${gid}`, path],
@@ -603,6 +625,7 @@ export class FileSystem {
     path: string,
     options?: { signal?: AbortSignal },
   ): Promise<void> {
+    "use step";
     const result = await this.sandbox.runCommand("ln", ["-s", target, path], {
       signal: options?.signal,
     });
@@ -625,6 +648,7 @@ export class FileSystem {
     path: string,
     options?: { signal?: AbortSignal },
   ): Promise<string> {
+    "use step";
     const result = await this.sandbox.runCommand("readlink", [path], {
       signal: options?.signal,
     });
@@ -648,6 +672,7 @@ export class FileSystem {
     path: string,
     options?: { signal?: AbortSignal },
   ): Promise<string> {
+    "use step";
     const result = await this.sandbox.runCommand("realpath", [path], {
       signal: options?.signal,
     });
@@ -673,6 +698,7 @@ export class FileSystem {
     len?: number,
     options?: { signal?: AbortSignal },
   ): Promise<void> {
+    "use step";
     const result = await this.sandbox.runCommand(
       "truncate",
       ["-s", String(len ?? 0), path],
@@ -698,6 +724,7 @@ export class FileSystem {
     prefix: string,
     options?: { signal?: AbortSignal },
   ): Promise<string> {
+    "use step";
     const result = await this.sandbox.runCommand(
       "mktemp",
       ["-d", `${prefix}XXXXXX`],

--- a/packages/vercel-sandbox/src/index.ts
+++ b/packages/vercel-sandbox/src/index.ts
@@ -14,3 +14,4 @@ export type {
 } from "./command.js";
 export { StreamError } from "./api-client/api-error.js";
 export { APIError } from "./api-client/api-error.js";
+export { FileSystem } from "./filesystem.js";

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -22,6 +22,7 @@ import {
   toSandboxSnapshot,
 } from "./utils/sandbox-snapshot.js";
 import { getPrivateParams, type WithPrivate } from "./utils/types.js";
+import { FileSystem } from "./filesystem.js";
 
 export type { NetworkPolicy, NetworkPolicyRule, NetworkTransformer };
 
@@ -203,6 +204,17 @@ export class Sandbox {
   /* @hidden
    */
   public readonly routes: SandboxRouteData[];
+
+  /**
+   * A `node:fs/promises`-compatible API for interacting with the sandbox filesystem.
+   *
+   * @example
+   * const content = await sandbox.fs.readFile('/etc/hostname', 'utf8');
+   * await sandbox.fs.writeFile('/tmp/hello.txt', 'Hello, world!');
+   * const files = await sandbox.fs.readdir('/tmp');
+   * const stats = await sandbox.fs.stat('/tmp/hello.txt');
+   */
+  public readonly fs: FileSystem;
 
   /**
    * Unique ID of this sandbox.
@@ -421,6 +433,7 @@ export class Sandbox {
     this._client = client ?? null;
     this.routes = routes;
     this.sandbox = sandbox;
+    this.fs = new FileSystem(this);
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,8 +254,8 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
       workflow:
-        specifier: 4.2.0-beta.73
-        version: 4.2.0-beta.73(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@6.6.7))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@6.6.7))(reflect-metadata@0.2.2)(rxjs@6.6.7))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
+        specifier: 4.2.1
+        version: 4.2.1(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@6.6.7))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@6.6.7))(reflect-metadata@0.2.2)(rxjs@6.6.7))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
       zod:
         specifier: ^4.1.9
         version: 4.3.6
@@ -2593,11 +2593,21 @@ packages:
   '@workflow/astro@4.0.0-beta.47':
     resolution: {integrity: sha512-t/9R18hMKrwLVO1Gc61MUTsnRj+ZdQXvur5IkZWlMfo6xgH9RN5xUR8O0b2fN+GRBlMnzdR5hTG+DYH4PrWQ8w==}
 
+  '@workflow/astro@4.0.1':
+    resolution: {integrity: sha512-4cmIBgFB085/D1Whgkpc0w0+oEDDEM1W/jL046kuGTSSDRgTSsXq9VWEE6p5h1qu6qRUt8ZR4k1/caq/AEGzmA==}
+
   '@workflow/builders@4.0.1-beta.64':
     resolution: {integrity: sha512-RChF5D2XMyW63+1OiRovrQLlsGTpoA+A21SwvuoJ/XpoIIVQhz99z6sEwGABlk0Qj+z4ZJfyuSQdUs+zg7P+Ng==}
 
+  '@workflow/builders@4.0.2':
+    resolution: {integrity: sha512-ptFjJgQYHbNgBMNmiE5P9gmRW0MF5K88dI4DzTPuhXIbtfPklNqXa+NEOoLjBNHdUKO+DT7BaWbMVYkuGr38KQ==}
+
   '@workflow/cli@4.2.0-beta.73':
     resolution: {integrity: sha512-2jW1QX8/Y0C+uBOzvk4KZy8BoOwRgPHCI7Hx7hOrHxEmUrKVSj5jJTEWpwmagJl+gxCcbo1tB8YBD5yYRMzfwA==}
+    hasBin: true
+
+  '@workflow/cli@4.2.1':
+    resolution: {integrity: sha512-YqX4QOXXVBzGUQZZUFvTn6avUuUwelaEu3whGei/SpFo3oDOwDBU99ObdPhBYlKv18tGnDS8nH4oRXdKPS2DnQ==}
     hasBin: true
 
   '@workflow/core@4.2.0-beta.73':
@@ -2608,11 +2618,31 @@ packages:
       '@opentelemetry/api':
         optional: true
 
+  '@workflow/core@4.2.1':
+    resolution: {integrity: sha512-b7GiVsJ1EEnMP54b9ugNHsHX1aM8mgPMeAQUy8aP7HcrXspWVAgms8I2louV4JKJeuIMLf6qkvQseyW5285URw==}
+    peerDependencies:
+      '@opentelemetry/api': '1'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
+  '@workflow/errors@4.1.0':
+    resolution: {integrity: sha512-MLf82s2hFgRIGaJRI0BQvhrNoCK7mOPSNGIBom42phbnrWbj2O0YSpZTBr1dNNFF7Cd8TgLEmaQrCsHZqlWhJw==}
+
   '@workflow/errors@4.1.0-beta.19':
     resolution: {integrity: sha512-AEZefVGpant/4eUJixnjGlK3LfyNPWp/C6YpmAsJbPPaFHPggKE7WT185BCMtXJMbpVKF/d/rNa7fxZ3J/yYhw==}
 
   '@workflow/nest@0.0.0-beta.22':
     resolution: {integrity: sha512-8pCwKGSPWscoKfqjca+K/AiI/sUF690iGChmSvMe9PWQKnMVYtcbawaujCf/i0ru+tMmfFO80Vm+iNpMj/YbZQ==}
+    hasBin: true
+    peerDependencies:
+      '@nestjs/common': '>=10.0.0'
+      '@nestjs/core': '>=10.0.0'
+      '@swc/cli': '>=0.4.0'
+      '@swc/core': '>=1.5.0'
+
+  '@workflow/nest@0.0.1':
+    resolution: {integrity: sha512-EupXaO5evmdvSsrYg9DoTztTykVgXGAjNI1jpHhO7U7UsuJlfPtM8/BZgnTkmnq15Xz410C0D/qPBWAr9fPTLA==}
     hasBin: true
     peerDependencies:
       '@nestjs/common': '>=10.0.0'
@@ -2628,14 +2658,34 @@ packages:
       next:
         optional: true
 
+  '@workflow/next@4.0.2':
+    resolution: {integrity: sha512-0dHHF5MjW4YGVbY48cXU5HYlbw2mlJ5sRqiY/i2ZxsZros4GDKLnzEpXb5/NvLox5JCwZQVQDkjCUIsFRs2dCg==}
+    peerDependencies:
+      next: '>13'
+    peerDependenciesMeta:
+      next:
+        optional: true
+
   '@workflow/nitro@4.0.1-beta.68':
     resolution: {integrity: sha512-g5yEEZpncc99fqdXZcQWSC2dvASbhzqLHKB4lOP2da+Sy8i2Fb86hKIwtSTgi/POpr/9WCI3u4F1i8sn3DBhig==}
+
+  '@workflow/nitro@4.0.2':
+    resolution: {integrity: sha512-k58mfN+DQR2TlfM4eMN0YDfdmH0KY45NXjcGseN5a7amsHYMHootM803vUQUGMs7HZVZZhjJbC09eRSJYulxBA==}
 
   '@workflow/nuxt@4.0.1-beta.57':
     resolution: {integrity: sha512-pTWDevRsscNoklP2R43a/ENUlBU/dBcQWxlvmrP7eTkK6LmRjvl1+S57fKiMcRzlYvhUB8yOAD9CDaZZ2jMecg==}
 
+  '@workflow/nuxt@4.0.2':
+    resolution: {integrity: sha512-DFTeQuRbxtu8cQ8v8x7cw43fexqUwdOIixCoSO8SmXeTQjsZY2wm0/XC79ayBbrLKmQIQHs4UVmL/B3tUtmImg==}
+
   '@workflow/rollup@4.0.0-beta.30':
     resolution: {integrity: sha512-ZbJPwo01UyiyzBr6GIv20jYnfXfGm/PZ9yA4ARrkwwZt1X/G1S/J08T33iWYUkXV0RH+6DJUvJioHtn8QbL0DA==}
+
+  '@workflow/rollup@4.0.1':
+    resolution: {integrity: sha512-jDOHhjdl3o1ZTVvwrsQMpVH7m9oinv8FVbt4uDmO3NzBG/KvN0TZ+kSFmcEzaAt8cWBu9ZVJxYNKDg3RKdiYBQ==}
+
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
   '@workflow/serde@4.1.0-beta.2':
     resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
@@ -2643,15 +2693,31 @@ packages:
   '@workflow/sveltekit@4.0.0-beta.62':
     resolution: {integrity: sha512-HetSMA+rh/ZbQTNH55wfSLFEoUhsQpKK7vX6aY35CUwVATiq1Ib8/hgVBM01ZI0HxD+T5HzbZg7wx9dJOJicXw==}
 
+  '@workflow/sveltekit@4.0.1':
+    resolution: {integrity: sha512-cxjx+Nt90jNtBoGOAZrjglQ62+eDtlheCd2z2ZHPbNUy5M+wVVXuMr8KGkacHf/KDWbzi4McTnTOVtX6R2DHrA==}
+
+  '@workflow/swc-plugin@4.1.0':
+    resolution: {integrity: sha512-FcWKJwzkRqf0u08/WCyg2n1H3932JQpFk3g6edE7trXKFW06a8o4F22k/xgPFsbxAq8UpywcIN7f46H0/uH5Tw==}
+    peerDependencies:
+      '@swc/core': 1.15.3
+
   '@workflow/swc-plugin@4.1.0-beta.21':
     resolution: {integrity: sha512-CcZG8T3oxMNils93OTomXT54pMwqH2IPheiZjg4bEz2aQtIQXGyU3ul0NRCDyLFgQa9tb3mgW18yOsOqajr0Tg==}
     peerDependencies:
       '@swc/core': 1.15.3
 
+  '@workflow/typescript-plugin@4.0.1':
+    resolution: {integrity: sha512-n2CYGiywL7QeBxdYXAeKcEXBu+T3DMFoau84OO+h6ugaa6Me++UZEbEoVnG7RvsYua0jLDbmWkIPYy4GJcOMCA==}
+    peerDependencies:
+      typescript: '>=5.0.0'
+
   '@workflow/typescript-plugin@4.0.1-beta.5':
     resolution: {integrity: sha512-5upSEmro3cYqB5JS7qjUVJKovlSIy+Yg3ets2OEQxMn6UATeCf5Qxbrb2EOy02pW2QUdkfu1wZ2XUsbahRQjRg==}
     peerDependencies:
       typescript: '>=5.0.0'
+
+  '@workflow/utils@4.1.0':
+    resolution: {integrity: sha512-wE7hTfSzR0sEougUluG6fFNR8O98F86v7nz3QGqPwtlNM1ZadW5s65Jhog9b0IA6PcAE4KHDy/iKktEyc23prw==}
 
   '@workflow/utils@4.1.0-beta.13':
     resolution: {integrity: sha512-3vVuXZVfLVeJ78MM6D0gNXg6hMZdDYAzmF92p+HxItI0B2Yk1EuDIIUfBXKWwTOKCCuKF4iroZt2u9BFqrs2AQ==}
@@ -2659,11 +2725,33 @@ packages:
   '@workflow/vite@4.0.0-beta.23':
     resolution: {integrity: sha512-EM5rDgrkwWN5vAY2YteuL8/bELEv6g2dckTHiEl4SuYNYZK/NLvQV7b57ypMNafWAc2hZ/euplE1fBqsuQEC3Q==}
 
+  '@workflow/vite@4.0.1':
+    resolution: {integrity: sha512-WJBSKKaNI8MaUzLuWgNR2jIaulS0G8rZjTR0ZtwVT8c6bsuy4e8uee4+3CC7zS8YQcaqJ/RTWi3Ct93e00Ym0A==}
+
+  '@workflow/web@4.1.0':
+    resolution: {integrity: sha512-iCDzJPBG6gyxNmnQGN55T3Q0bXCFG1ZkjkVbozajR6bfH41OZvmLDLwK6dJlqP+iqu3HjBtBIpPn0p2Wo+7jhw==}
+
   '@workflow/web@4.1.0-beta.45':
     resolution: {integrity: sha512-ITqHjQMS5QPj0lx4vGdyhASz/IrqKQcgnv97OBiKvnwcWCH+nszmP59LJ/BL9DTb0AR2ugFWh2FlGe1GJxTTZg==}
 
+  '@workflow/world-local@4.1.0':
+    resolution: {integrity: sha512-dOi/2M3q0kFMnY6dovgojj4s0ddrAVSxk1MNQOarf3q4XmW4Q9C9+bsA3d/EXthQmb+9eiI6PiDPxQJALcUekw==}
+    peerDependencies:
+      '@opentelemetry/api': '1'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
   '@workflow/world-local@4.1.0-beta.46':
     resolution: {integrity: sha512-jCDcJdQTDwq4+5BTf3OajUtRuDaXM6yYdrGsA0P4PAnY7grgOW+R1Thd4cW4EHJZYhOQ5bfgrCCCMF8nhAwukw==}
+    peerDependencies:
+      '@opentelemetry/api': '1'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
+  '@workflow/world-vercel@4.1.0':
+    resolution: {integrity: sha512-l9Q/jHRk1v1VYLttwXMRaf/1eHOsvTVbecVEJI0lpt4zP3FH2dMyXl25TIl6k+s7a4qdXyySy62LtCx4ijy2DA==}
     peerDependencies:
       '@opentelemetry/api': '1'
     peerDependenciesMeta:
@@ -2677,6 +2765,11 @@ packages:
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
+
+  '@workflow/world@4.1.0':
+    resolution: {integrity: sha512-lvJD7vQTjuWn/sxXUnK+oiszVuWrg4YJAccaMojBb42zbp38/V9Lsig0zuSR3pPsKrjfvmiWtGn8ATma8Kp+1Q==}
+    peerDependencies:
+      zod: 4.3.6
 
   '@workflow/world@4.1.0-beta.14':
     resolution: {integrity: sha512-23BC9d7m7DDuGuaLncMHZ/6XFJePsY7Dr2zVecRWpM6NvOmAKV+oiOav/HEBxUCdaccSshSsLRqwdHX9Q9HCZA==}
@@ -5904,6 +5997,15 @@ packages:
       '@opentelemetry/api':
         optional: true
 
+  workflow@4.2.1:
+    resolution: {integrity: sha512-wpyVjgoqdMxyA3Xn1v5wD1cdrN1iOffc5sVLx8PGS1akVDnb03FvN4SxaeFLYVZYzKl+DjhQbxdxkOO+zbxQjg==}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': '1'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
   wrap-ansi@3.0.1:
     resolution: {integrity: sha512-iXR3tDXpbnTpzjKSylUJRkLuOrEC7hwEB221cgn6wtF8wpmz28puFXAEfPT5zrjM3wahygB//VuWEr1vTkDcNQ==}
     engines: {node: '>=4'}
@@ -7993,6 +8095,21 @@ snapshots:
       - aws-crt
       - supports-color
 
+  '@workflow/astro@4.0.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@swc/core': 1.15.3
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)
+      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.0)
+      '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3)
+      '@workflow/vite': 4.0.1(@opentelemetry/api@1.9.0)
+      exsolve: 1.0.8
+      pathe: 2.0.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - aws-crt
+      - supports-color
+
   '@workflow/builders@4.0.1-beta.64(@opentelemetry/api@1.9.0)':
     dependencies:
       '@swc/core': 1.15.3
@@ -8000,6 +8117,26 @@ snapshots:
       '@workflow/errors': 4.1.0-beta.19
       '@workflow/swc-plugin': 4.1.0-beta.21(@swc/core@1.15.3)
       '@workflow/utils': 4.1.0-beta.13
+      builtin-modules: 5.0.0
+      chalk: 5.6.2
+      enhanced-resolve: 5.19.0
+      esbuild: 0.27.4
+      find-up: 7.0.0
+      json5: 2.2.3
+      tinyglobby: 0.2.15
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - aws-crt
+      - supports-color
+
+  '@workflow/builders@4.0.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@swc/core': 1.15.3
+      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.0)
+      '@workflow/errors': 4.1.0
+      '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3)
+      '@workflow/utils': 4.1.0
       builtin-modules: 5.0.0
       chalk: 5.6.2
       enhanced-resolve: 5.19.0
@@ -8051,6 +8188,44 @@ snapshots:
       - aws-crt
       - supports-color
 
+  '@workflow/cli@4.2.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@oclif/core': 4.8.1
+      '@oclif/plugin-help': 6.2.37
+      '@swc/core': 1.15.3
+      '@vercel/cli-auth': 0.0.1
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)
+      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.0)
+      '@workflow/errors': 4.1.0
+      '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3)
+      '@workflow/utils': 4.1.0
+      '@workflow/web': 4.1.0
+      '@workflow/world': 4.1.0(zod@4.3.6)
+      '@workflow/world-local': 4.1.0(@opentelemetry/api@1.9.0)
+      '@workflow/world-vercel': 4.1.0(@opentelemetry/api@1.9.0)
+      boxen: 8.0.1
+      builtin-modules: 5.0.0
+      chalk: 5.6.2
+      chokidar: 4.0.3
+      date-fns: 4.1.0
+      dotenv: 17.3.1
+      easy-table: 1.2.0
+      enhanced-resolve: 5.19.0
+      esbuild: 0.27.4
+      find-up: 7.0.0
+      mixpart: 0.0.4
+      open: 10.2.0
+      ora: 8.2.0
+      terminal-link: 5.0.0
+      tinyglobby: 0.2.15
+      xdg-app-paths: 5.1.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - aws-crt
+      - supports-color
+
   '@workflow/core@4.2.0-beta.73(@opentelemetry/api@1.9.0)':
     dependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.13
@@ -8077,6 +8252,38 @@ snapshots:
       - aws-crt
       - supports-color
 
+  '@workflow/core@4.2.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@aws-sdk/credential-provider-web-identity': 3.972.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@standard-schema/spec': 1.0.0
+      '@types/ms': 2.1.0
+      '@vercel/functions': 3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13)
+      '@workflow/errors': 4.1.0
+      '@workflow/serde': 4.1.0
+      '@workflow/utils': 4.1.0
+      '@workflow/world': 4.1.0(zod@4.3.6)
+      '@workflow/world-local': 4.1.0(@opentelemetry/api@1.9.0)
+      '@workflow/world-vercel': 4.1.0(@opentelemetry/api@1.9.0)
+      debug: 4.4.3(supports-color@8.1.1)
+      devalue: 5.6.3
+      ms: 2.1.3
+      nanoid: 5.1.6
+      seedrandom: 3.0.5
+      semver: 7.7.4
+      ulid: 3.0.2
+      zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - aws-crt
+      - supports-color
+
+  '@workflow/errors@4.1.0':
+    dependencies:
+      '@workflow/utils': 4.1.0
+      ms: 2.1.3
+
   '@workflow/errors@4.1.0-beta.19':
     dependencies:
       '@workflow/utils': 4.1.0-beta.13
@@ -8097,12 +8304,43 @@ snapshots:
       - aws-crt
       - supports-color
 
+  '@workflow/nest@0.0.1(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@6.6.7))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@6.6.7))(reflect-metadata@0.2.2)(rxjs@6.6.7))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)':
+    dependencies:
+      '@nestjs/common': 11.1.17(reflect-metadata@0.2.2)(rxjs@6.6.7)
+      '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@6.6.7))(reflect-metadata@0.2.2)(rxjs@6.6.7)
+      '@swc/cli': 0.8.0(@swc/core@1.15.3)(chokidar@5.0.0)
+      '@swc/core': 1.15.3
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)
+      '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3)
+      pathe: 2.0.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - aws-crt
+      - supports-color
+
   '@workflow/next@4.0.1-beta.69(@opentelemetry/api@1.9.0)(next@16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
       '@swc/core': 1.15.3
       '@workflow/builders': 4.0.1-beta.64(@opentelemetry/api@1.9.0)
       '@workflow/core': 4.2.0-beta.73(@opentelemetry/api@1.9.0)
       '@workflow/swc-plugin': 4.1.0-beta.21(@swc/core@1.15.3)
+      semver: 7.7.4
+      watchpack: 2.5.1
+    optionalDependencies:
+      next: 16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - aws-crt
+      - supports-color
+
+  '@workflow/next@4.0.2(@opentelemetry/api@1.9.0)(next@16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+    dependencies:
+      '@swc/core': 1.15.3
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)
+      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.0)
+      '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3)
       semver: 7.7.4
       watchpack: 2.5.1
     optionalDependencies:
@@ -8129,10 +8367,37 @@ snapshots:
       - aws-crt
       - supports-color
 
+  '@workflow/nitro@4.0.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@swc/core': 1.15.3
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)
+      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.0)
+      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.0)
+      '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3)
+      '@workflow/vite': 4.0.1(@opentelemetry/api@1.9.0)
+      exsolve: 1.0.8
+      pathe: 2.0.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - aws-crt
+      - supports-color
+
   '@workflow/nuxt@4.0.1-beta.57(@opentelemetry/api@1.9.0)':
     dependencies:
       '@nuxt/kit': 4.4.2
       '@workflow/nitro': 4.0.1-beta.68(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - aws-crt
+      - magicast
+      - supports-color
+
+  '@workflow/nuxt@4.0.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@nuxt/kit': 4.4.2
+      '@workflow/nitro': 4.0.2(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -8152,6 +8417,20 @@ snapshots:
       - aws-crt
       - supports-color
 
+  '@workflow/rollup@4.0.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@swc/core': 1.15.3
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)
+      '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3)
+      exsolve: 1.0.7
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - aws-crt
+      - supports-color
+
+  '@workflow/serde@4.1.0': {}
+
   '@workflow/serde@4.1.0-beta.2': {}
 
   '@workflow/sveltekit@4.0.0-beta.62(@opentelemetry/api@1.9.0)':
@@ -8170,13 +8449,41 @@ snapshots:
       - aws-crt
       - supports-color
 
+  '@workflow/sveltekit@4.0.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@swc/core': 1.15.3
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)
+      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.0)
+      '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3)
+      '@workflow/vite': 4.0.1(@opentelemetry/api@1.9.0)
+      exsolve: 1.0.8
+      fs-extra: 11.3.4
+      pathe: 2.0.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - aws-crt
+      - supports-color
+
+  '@workflow/swc-plugin@4.1.0(@swc/core@1.15.3)':
+    dependencies:
+      '@swc/core': 1.15.3
+
   '@workflow/swc-plugin@4.1.0-beta.21(@swc/core@1.15.3)':
     dependencies:
       '@swc/core': 1.15.3
 
+  '@workflow/typescript-plugin@4.0.1(typescript@5.8.3)':
+    dependencies:
+      typescript: 5.8.3
+
   '@workflow/typescript-plugin@4.0.1-beta.5(typescript@5.8.3)':
     dependencies:
       typescript: 5.8.3
+
+  '@workflow/utils@4.1.0':
+    dependencies:
+      ms: 2.1.3
 
   '@workflow/utils@4.1.0-beta.13':
     dependencies:
@@ -8191,11 +8498,39 @@ snapshots:
       - aws-crt
       - supports-color
 
+  '@workflow/vite@4.0.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - aws-crt
+      - supports-color
+
+  '@workflow/web@4.1.0':
+    dependencies:
+      express: 4.22.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@workflow/web@4.1.0-beta.45':
     dependencies:
       express: 4.22.1
     transitivePeerDependencies:
       - supports-color
+
+  '@workflow/world-local@4.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@vercel/queue': 0.1.4
+      '@workflow/errors': 4.1.0
+      '@workflow/utils': 4.1.0
+      '@workflow/world': 4.1.0(zod@4.3.6)
+      async-sema: 3.1.1
+      ulid: 3.0.2
+      undici: 7.22.0
+      zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
 
   '@workflow/world-local@4.1.0-beta.46(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -8205,6 +8540,18 @@ snapshots:
       '@workflow/world': 4.1.0-beta.14(zod@4.3.6)
       async-sema: 3.1.1
       ulid: 3.0.1
+      undici: 7.22.0
+      zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@workflow/world-vercel@4.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@vercel/queue': 0.1.4
+      '@workflow/errors': 4.1.0
+      '@workflow/world': 4.1.0(zod@4.3.6)
+      cbor-x: 1.6.0
       undici: 7.22.0
       zod: 4.3.6
     optionalDependencies:
@@ -8221,6 +8568,11 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
+
+  '@workflow/world@4.1.0(zod@4.3.6)':
+    dependencies:
+      ulid: 3.0.2
+      zod: 4.3.6
 
   '@workflow/world@4.1.0-beta.14(zod@4.3.6)':
     dependencies:
@@ -10327,7 +10679,7 @@ snapshots:
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.0.3
 
   minimatch@9.0.5:
     dependencies:
@@ -11869,6 +12221,35 @@ snapshots:
       '@workflow/sveltekit': 4.0.0-beta.62(@opentelemetry/api@1.9.0)
       '@workflow/typescript-plugin': 4.0.1-beta.5(typescript@5.8.3)
       '@workflow/utils': 4.1.0-beta.13
+      ms: 2.1.3
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - '@nestjs/common'
+      - '@nestjs/core'
+      - '@swc/cli'
+      - '@swc/core'
+      - '@swc/helpers'
+      - aws-crt
+      - magicast
+      - next
+      - supports-color
+      - typescript
+
+  workflow@4.2.1(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@6.6.7))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@6.6.7))(reflect-metadata@0.2.2)(rxjs@6.6.7))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3):
+    dependencies:
+      '@workflow/astro': 4.0.1(@opentelemetry/api@1.9.0)
+      '@workflow/cli': 4.2.1(@opentelemetry/api@1.9.0)
+      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.0)
+      '@workflow/errors': 4.1.0
+      '@workflow/nest': 0.0.1(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@6.6.7))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@6.6.7))(reflect-metadata@0.2.2)(rxjs@6.6.7))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)
+      '@workflow/next': 4.0.2(@opentelemetry/api@1.9.0)(next@16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@workflow/nitro': 4.0.2(@opentelemetry/api@1.9.0)
+      '@workflow/nuxt': 4.0.2(@opentelemetry/api@1.9.0)
+      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.0)
+      '@workflow/sveltekit': 4.0.1(@opentelemetry/api@1.9.0)
+      '@workflow/typescript-plugin': 4.0.1(typescript@5.8.3)
+      '@workflow/utils': 4.1.0
       ms: 2.1.3
     optionalDependencies:
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
This PR introduces a node:fs-compatible API for the Vercel Sandbox environment.

The goal is to provide a familiar, minimal subset of Node’s filesystem interface that works within the constraints of the Sandbox runtime, enabling easier portability of existing Node.js code and libraries.

In particular provide something we can pass directly around with `just-bash` as an `fs` implementation without needing their `Sandbox` primitive wrapper.

