### PR TITLE
feat(sandbox): add multi-user and group management

### DIFF
--- a/.changeset/multi-user-and-groups.md
+++ b/.changeset/multi-user-and-groups.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": minor
+---
+
+Add multi-user and group management: `createUser`, `asUser`, `createGroup`, `addUserToGroup`, and `removeUserFromGroup` on the `Sandbox` class, plus a `SandboxUser` class that scopes command and file operations to a specific user's context

--- a/packages/vercel-sandbox/README.md
+++ b/packages/vercel-sandbox/README.md
@@ -286,6 +286,10 @@ file permissions, and process ownership. This is useful for multi-agent workflow
 where each agent needs its own workspace, or for simulating multi-user
 environments.
 
+> **Note:** The sandbox image must have `/bin/bash` installed. It is the login
+> shell for created users and is used to wrap commands that run as a user. The
+> stock Vercel Sandbox images include it.
+
 ### Creating users
 
 ```typescript

--- a/packages/vercel-sandbox/README.md
+++ b/packages/vercel-sandbox/README.md
@@ -303,7 +303,7 @@ alice.homeDir;  // "/home/alice"
 `createUser` sets up:
 
 - A Linux user with `/bin/bash` as the default shell
-- A home directory at `/home/<username>` group-owned by `vercel-sandbox` with `770` permissions
+- A home directory at `/home/<username>` group-owned by the sandbox's default user group with `770` permissions
 
 ### Running commands as a user
 
@@ -402,8 +402,8 @@ cat.exitCode; // non-zero — Permission denied
 ```
 
 **The SDK can read all users' files** because home directories are group-owned
-by `vercel-sandbox`. Both `SandboxUser` methods and direct `sandbox` methods
-work:
+by the sandbox's default user group. Both `SandboxUser` methods and direct
+`sandbox` methods work:
 
 ```typescript
 // Via SandboxUser (relative paths resolve to home dir)

--- a/packages/vercel-sandbox/README.md
+++ b/packages/vercel-sandbox/README.md
@@ -279,6 +279,243 @@ Sandbox runs sudo in the following configuration:
 Both these images are based on Amazon Linux 2023. The full package list is
 available [here](https://docs.aws.amazon.com/linux/al2023/release-notes/all-packages-AL2023.7.html).
 
+## Multi-user
+
+Sandboxes support creating isolated Linux users with their own home directories,
+file permissions, and process ownership. This is useful for multi-agent workflows
+where each agent needs its own workspace, or for simulating multi-user
+environments.
+
+### Creating users
+
+```typescript
+import { Sandbox } from "@vercel/sandbox";
+
+const sandbox = await Sandbox.create();
+
+// Creates /home/alice with isolated permissions
+const alice = await sandbox.createUser("alice");
+
+alice.username; // "alice"
+alice.homeDir;  // "/home/alice"
+```
+
+`createUser` sets up:
+
+- A Linux user with `/bin/bash` as the default shell
+- A home directory at `/home/<username>` group-owned by `vercel-sandbox` with `770` permissions
+
+### Running commands as a user
+
+All commands run as the user by default, with the working directory set to their
+home:
+
+```typescript
+const alice = await sandbox.createUser("alice");
+
+const whoami = await alice.runCommand("whoami");
+await whoami.stdout(); // "alice\n"
+
+const pwd = await alice.runCommand("pwd");
+await pwd.stdout(); // "/home/alice\n"
+```
+
+You can pass environment variables, override the working directory, or use the
+full `RunCommandParams` interface:
+
+```typescript
+// Environment variables
+await alice.runCommand({
+  cmd: "node",
+  args: ["-e", "console.log(process.env.API_KEY)"],
+  env: { API_KEY: "secret" },
+});
+
+// Custom working directory
+await alice.runCommand({ cmd: "ls", cwd: "/tmp" });
+
+// Detached mode for long-running processes
+const server = await alice.runCommand({
+  cmd: "node",
+  args: ["server.js"],
+  detached: true,
+});
+```
+
+To escalate to root, pass `sudo: true`:
+
+```typescript
+await alice.runCommand({
+  cmd: "dnf",
+  args: ["install", "-y", "git"],
+  sudo: true,
+});
+```
+
+### File operations
+
+`writeFiles`, `readFile`, `readFileToBuffer`, and `mkDir` all resolve relative
+paths against the user's home directory. Written files are owned by the user:
+
+```typescript
+const alice = await sandbox.createUser("alice");
+
+// Writes to /home/alice/app.js, owned by alice:alice
+await alice.writeFiles([
+  { path: "app.js", content: Buffer.from('console.log("hi")') },
+]);
+
+// Read it back
+const buf = await alice.readFileToBuffer({ path: "app.js" });
+buf?.toString(); // 'console.log("hi")'
+
+// Stream reads
+const stream = await alice.readFile({ path: "app.js" });
+
+// Create directories owned by the user
+await alice.mkDir("projects/my-app");
+
+// Absolute paths also work
+await alice.writeFiles([
+  { path: "/tmp/output.txt", content: Buffer.from("data") },
+]);
+```
+
+### File isolation
+
+Users cannot access each other's home directories:
+
+```typescript
+const alice = await sandbox.createUser("alice");
+const bob = await sandbox.createUser("bob");
+
+await alice.writeFiles([
+  { path: "secret.txt", content: Buffer.from("alice only") },
+]);
+
+// Bob cannot read, list, or write to alice's home
+const cat = await bob.runCommand({
+  cmd: "cat",
+  args: ["/home/alice/secret.txt"],
+});
+cat.exitCode; // non-zero — Permission denied
+```
+
+**The SDK can read all users' files** because home directories are group-owned
+by `vercel-sandbox`. Both `SandboxUser` methods and direct `sandbox` methods
+work:
+
+```typescript
+// Via SandboxUser (relative paths resolve to home dir)
+const buf = await alice.readFileToBuffer({ path: "secret.txt" });
+buf?.toString(); // "alice only"
+
+// Via sandbox directly (absolute path required)
+const buf2 = await sandbox.readFileToBuffer({ path: "/home/alice/secret.txt" });
+buf2?.toString(); // "alice only"
+```
+
+### Groups and shared directories
+
+Create groups to let users collaborate through a shared directory:
+
+```typescript
+const devs = await sandbox.createGroup("devs");
+devs.sharedDir; // "/shared/devs"
+
+await sandbox.addUserToGroup("alice", "devs");
+await sandbox.addUserToGroup("bob", "devs");
+
+// Alice writes to the shared directory
+await alice.runCommand({
+  cmd: "bash",
+  args: ["-c", 'echo "spec v2" > /shared/devs/spec.txt'],
+});
+
+// Bob can read it — files inherit group ownership via setgid
+const spec = await bob.runCommand({
+  cmd: "cat",
+  args: ["/shared/devs/spec.txt"],
+});
+await spec.stdout(); // "spec v2\n"
+
+// Non-members are blocked
+const charlie = await sandbox.createUser("charlie");
+const ls = await charlie.runCommand({ cmd: "ls", args: ["/shared/devs"] });
+ls.exitCode; // non-zero — Permission denied
+```
+
+Shared directories use setgid (`2770`), so files created inside them
+automatically inherit the group. All group members get read/write access.
+
+Convenience methods are available on `SandboxUser`:
+
+```typescript
+await alice.addToGroup("devs");
+await alice.removeFromGroup("devs");
+```
+
+### Using `asUser` for existing users
+
+If a user already exists (e.g., from a snapshot or manual creation), use
+`asUser` to get a handle without re-creating:
+
+```typescript
+const existing = sandbox.asUser("bob");
+await existing.runCommand("whoami"); // "bob"
+```
+
+### Username validation
+
+Usernames and group names must match `/^[a-z_][a-z0-9_-]*$/` and be at most 32
+characters. Invalid names throw an error immediately:
+
+```typescript
+sandbox.asUser("Alice");        // throws — uppercase
+sandbox.asUser("user name");    // throws — space
+sandbox.asUser("$(whoami)");    // throws — special characters
+sandbox.asUser("a".repeat(33)); // throws — too long
+```
+
+### Multi-agent example
+
+```typescript
+const sandbox = await Sandbox.create();
+
+// Each agent gets its own isolated workspace
+const researcher = await sandbox.createUser("researcher");
+const coder = await sandbox.createUser("coder");
+const reviewer = await sandbox.createUser("reviewer");
+
+// Shared workspace for collaboration
+await sandbox.createGroup("project");
+await sandbox.addUserToGroup("researcher", "project");
+await sandbox.addUserToGroup("coder", "project");
+await sandbox.addUserToGroup("reviewer", "project");
+
+// Researcher writes findings to shared dir
+await researcher.runCommand({
+  cmd: "bash",
+  args: ["-c", 'echo "API spec v2" > /shared/project/spec.txt'],
+});
+
+// Coder reads spec, writes code in their own home
+const spec = await coder.runCommand({
+  cmd: "cat",
+  args: ["/shared/project/spec.txt"],
+});
+await coder.writeFiles([
+  { path: "app.js", content: Buffer.from(`// ${await spec.stdout()}`) },
+]);
+
+// Reviewer can read the shared spec but not coder's private files
+const blocked = await reviewer.runCommand({
+  cmd: "cat",
+  args: ["/home/coder/app.js"],
+});
+blocked.exitCode; // non-zero — isolation enforced
+```
+
 [create-token]: https://vercel.com/account/settings/tokens
 [hive]: https://vercel.com/blog/a-deep-dive-into-hive-vercels-builds-infrastructure
 [al-2023-packages]: https://docs.aws.amazon.com/linux/al2023/release-notes/all-packages-AL2023.7.html

--- a/packages/vercel-sandbox/src/execution-context.ts
+++ b/packages/vercel-sandbox/src/execution-context.ts
@@ -1,0 +1,103 @@
+import type { RunCommandParams } from "./session.js";
+import type { Command, CommandFinished } from "./command.js";
+
+/**
+ * The common surface for running commands and performing file operations in
+ * a sandbox, regardless of scope.
+ *
+ * Implemented by {@link Sandbox}, {@link Session}, and {@link SandboxUser},
+ * so code can be written against "somewhere to run commands" without caring
+ * whether it targets the whole sandbox or a specific user's context.
+ *
+ * Implementations may scope the operations: for example, {@link SandboxUser}
+ * runs commands as its user and resolves relative paths against the user's
+ * home directory.
+ */
+export interface ExecutionContext {
+  /**
+   * Start executing a command in this context.
+   *
+   * @param command - The command to execute.
+   * @param args - Arguments to pass to the command.
+   * @param opts - Optional parameters.
+   * @returns A {@link CommandFinished} result once execution is done.
+   */
+  runCommand(
+    command: string,
+    args?: string[],
+    opts?: { signal?: AbortSignal; timeoutMs?: number },
+  ): Promise<CommandFinished>;
+
+  /**
+   * Start executing a command in this context in detached mode.
+   *
+   * @param params - The command parameters.
+   * @returns A {@link Command} instance for the running command.
+   */
+  runCommand(params: RunCommandParams & { detached: true }): Promise<Command>;
+
+  /**
+   * Start executing a command in this context.
+   *
+   * @param params - The command parameters.
+   * @returns A {@link CommandFinished} result once execution is done.
+   */
+  runCommand(params: RunCommandParams): Promise<CommandFinished>;
+
+  /**
+   * Create a directory in the filesystem of this context.
+   *
+   * @param path - Path of the directory to create
+   * @param opts - Optional parameters.
+   */
+  mkDir(path: string, opts?: { signal?: AbortSignal }): Promise<void>;
+
+  /**
+   * Read a file from this context as a stream.
+   *
+   * @param file - File to read, with path and optional cwd
+   * @param opts - Optional parameters.
+   * @returns A ReadableStream of the file contents, or null if not found
+   */
+  readFile(
+    file: { path: string; cwd?: string },
+    opts?: { signal?: AbortSignal },
+  ): Promise<NodeJS.ReadableStream | null>;
+
+  /**
+   * Read a file from this context as a Buffer.
+   *
+   * @param file - File to read, with path and optional cwd
+   * @param opts - Optional parameters.
+   * @returns The file contents as a Buffer, or null if not found
+   */
+  readFileToBuffer(
+    file: { path: string; cwd?: string },
+    opts?: { signal?: AbortSignal },
+  ): Promise<Buffer | null>;
+
+  /**
+   * Download a file from this context to the local filesystem.
+   *
+   * @param src - Source file in the sandbox
+   * @param dst - Destination on the local machine
+   * @param opts - Optional parameters.
+   * @returns The absolute path to the written file, or null if not found
+   */
+  downloadFile(
+    src: { path: string; cwd?: string },
+    dst: { path: string; cwd?: string },
+    opts?: { mkdirRecursive?: boolean; signal?: AbortSignal },
+  ): Promise<string | null>;
+
+  /**
+   * Write files to the filesystem of this context.
+   *
+   * @param files - Array of files with path, content, and optional mode
+   * @param opts - Optional parameters.
+   */
+  writeFiles(
+    files: { path: string; content: string | Uint8Array; mode?: number }[],
+    opts?: { signal?: AbortSignal },
+  ): Promise<void>;
+}

--- a/packages/vercel-sandbox/src/index.ts
+++ b/packages/vercel-sandbox/src/index.ts
@@ -11,6 +11,7 @@ export {
   type NetworkTransformer,
 } from "./session.js";
 export type { SerializedSandbox } from "./sandbox.js";
+export { SandboxUser } from "./sandbox-user.js";
 export { Snapshot } from "./snapshot.js";
 export type { SerializedSnapshot } from "./snapshot.js";
 export type { SnapshotTreeNodeData } from "./api-client/validators.js";

--- a/packages/vercel-sandbox/src/index.ts
+++ b/packages/vercel-sandbox/src/index.ts
@@ -12,6 +12,7 @@ export {
 } from "./session.js";
 export type { SerializedSandbox } from "./sandbox.js";
 export { SandboxUser } from "./sandbox-user.js";
+export type { ExecutionContext } from "./execution-context.js";
 export { Snapshot } from "./snapshot.js";
 export type { SerializedSnapshot } from "./snapshot.js";
 export type { SnapshotTreeNodeData } from "./api-client/validators.js";

--- a/packages/vercel-sandbox/src/sandbox-user.test.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.test.ts
@@ -1,0 +1,642 @@
+import { expect, it, beforeEach, afterEach, describe } from "vitest";
+import { Sandbox } from "./sandbox.js";
+import { SandboxUser } from "./sandbox-user.js";
+
+describe("validateName (unit)", () => {
+  it("asUser rejects invalid usernames synchronously", () => {
+    const sandbox = new Sandbox({
+      client: {} as any,
+      routes: [],
+      sandbox: { id: "test" } as any,
+    });
+    expect(() => sandbox.asUser("Alice")).toThrow("Invalid username");
+    expect(() => sandbox.asUser("user name")).toThrow("Invalid username");
+    expect(() => sandbox.asUser("")).toThrow("Invalid username");
+    expect(() => sandbox.asUser("a".repeat(33))).toThrow("Invalid username");
+    expect(() => sandbox.asUser("root; rm -rf /")).toThrow("Invalid username");
+    expect(() => sandbox.asUser("$(whoami)")).toThrow("Invalid username");
+  });
+
+  it("asUser accepts valid usernames", () => {
+    const sandbox = new Sandbox({
+      client: {} as any,
+      routes: [],
+      sandbox: { id: "test" } as any,
+    });
+    expect(sandbox.asUser("alice").username).toBe("alice");
+    expect(sandbox.asUser("_user").username).toBe("_user");
+    expect(sandbox.asUser("user-name").username).toBe("user-name");
+    expect(sandbox.asUser("user_123").username).toBe("user_123");
+  });
+});
+
+describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")(
+  "SandboxUser integration",
+  () => {
+    let sandbox: Sandbox;
+
+    beforeEach(async () => {
+      sandbox = await Sandbox.create();
+    });
+
+    afterEach(async () => {
+      await sandbox.stop();
+    });
+
+    // ─── User Creation ───────────────────────────────────────────────
+
+    describe("createUser", () => {
+      it("creates a user with a home directory", async () => {
+        const alice = await sandbox.createUser("alice");
+
+        expect(alice).toBeInstanceOf(SandboxUser);
+        expect(alice.username).toBe("alice");
+        expect(alice.homeDir).toBe("/home/alice");
+
+        const result = await sandbox.runCommand({
+          cmd: "test",
+          args: ["-d", "/home/alice"],
+          sudo: true,
+        });
+        expect(result.exitCode).toBe(0);
+      });
+
+      it("sets 750 permissions on home directory", async () => {
+        await sandbox.createUser("alice");
+
+        const stat = await sandbox.runCommand({
+          cmd: "stat",
+          args: ["-c", "%a", "/home/alice"],
+          sudo: true,
+        });
+        expect((await stat.stdout()).trim()).toBe("770");
+      });
+
+      it("sets home directory group to vercel-sandbox", async () => {
+        await sandbox.createUser("alice");
+
+        const stat = await sandbox.runCommand({
+          cmd: "stat",
+          args: ["-c", "%U:%G", "/home/alice"],
+          sudo: true,
+        });
+        expect((await stat.stdout()).trim()).toBe("alice:vercel-sandbox");
+      });
+
+      it("creates multiple users", async () => {
+        const alice = await sandbox.createUser("alice");
+        const bob = await sandbox.createUser("bob");
+
+        const aliceWho = await alice.runCommand("whoami");
+        const bobWho = await bob.runCommand("whoami");
+        expect((await aliceWho.stdout()).trim()).toBe("alice");
+        expect((await bobWho.stdout()).trim()).toBe("bob");
+      });
+
+      it("throws on duplicate username", async () => {
+        await sandbox.createUser("alice");
+        await expect(sandbox.createUser("alice")).rejects.toThrow(
+          'Failed to create user "alice"',
+        );
+      });
+    });
+
+    // ─── Command Execution as User ──────────────────────────────────
+
+    describe("runCommand as user", () => {
+      it("runs as the correct user", async () => {
+        const alice = await sandbox.createUser("alice");
+        const whoami = await alice.runCommand("whoami");
+        expect((await whoami.stdout()).trim()).toBe("alice");
+      });
+
+      it("runs with correct uid/gid", async () => {
+        const alice = await sandbox.createUser("alice");
+        const id = await alice.runCommand("id");
+        const output = (await id.stdout()).trim();
+        expect(output).toContain("(alice)");
+      });
+
+      it("defaults cwd to home directory", async () => {
+        const alice = await sandbox.createUser("alice");
+        const pwd = await alice.runCommand("pwd");
+        expect((await pwd.stdout()).trim()).toBe("/home/alice");
+      });
+
+      it("allows overriding cwd", async () => {
+        const alice = await sandbox.createUser("alice");
+        const pwd = await alice.runCommand({ cmd: "pwd", cwd: "/tmp" });
+        expect((await pwd.stdout()).trim()).toBe("/tmp");
+      });
+
+      it("passes environment variables through sudo -u", async () => {
+        const alice = await sandbox.createUser("alice");
+        const cmd = await alice.runCommand({
+          cmd: "env",
+          env: { MY_VAR: "hello", ANOTHER: "world" },
+        });
+        const output = await cmd.stdout();
+        expect(output).toContain("MY_VAR=hello");
+        expect(output).toContain("ANOTHER=world");
+      });
+
+      it("delegates to root when sudo: true", async () => {
+        const alice = await sandbox.createUser("alice");
+        const whoami = await alice.runCommand({ cmd: "whoami", sudo: true });
+        expect((await whoami.stdout()).trim()).toBe("root");
+      });
+
+      it("supports detached mode", async () => {
+        const alice = await sandbox.createUser("alice");
+        const cmd = await alice.runCommand({
+          cmd: "sleep",
+          args: ["100"],
+          detached: true,
+        });
+        await cmd.kill("SIGTERM");
+        const result = await cmd.wait();
+        // The command runs inside a bash -c wrapper, so the exit code
+        // may differ from a direct kill (e.g., 255 from bash vs 143 for SIGTERM).
+        expect(result.exitCode).not.toBe(0);
+      });
+    });
+
+    // ─── File Operations as User ────────────────────────────────────
+
+    describe("writeFiles + readFile as user", () => {
+      it("writes files owned by the user in home dir", async () => {
+        const alice = await sandbox.createUser("alice");
+
+        await alice.writeFiles([
+          { path: "hello.txt", content: Buffer.from("hello world") },
+        ]);
+
+        const stat = await sandbox.runCommand({
+          cmd: "stat",
+          args: ["-c", "%U:%G", "/home/alice/hello.txt"],
+          sudo: true,
+        });
+        expect((await stat.stdout()).trim()).toBe("alice:alice");
+      });
+
+      it("reads files back via readFileToBuffer", async () => {
+        const alice = await sandbox.createUser("alice");
+
+        await alice.writeFiles([
+          { path: "data.txt", content: Buffer.from("read me") },
+        ]);
+
+        const content = await alice.readFileToBuffer({ path: "data.txt" });
+        expect(content?.toString()).toBe("read me");
+      });
+
+      it("reads files back via readFile (stream)", async () => {
+        const alice = await sandbox.createUser("alice");
+
+        await alice.writeFiles([
+          { path: "stream.txt", content: Buffer.from("streamed") },
+        ]);
+
+        const stream = await alice.readFile({ path: "stream.txt" });
+        expect(stream).not.toBeNull();
+
+        const chunks: Buffer[] = [];
+        for await (const chunk of stream!) {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        }
+        expect(Buffer.concat(chunks).toString()).toBe("streamed");
+      });
+
+      it("resolves relative paths to home directory", async () => {
+        const alice = await sandbox.createUser("alice");
+
+        await alice.writeFiles([
+          { path: "subdir/file.txt", content: Buffer.from("nested") },
+        ]);
+
+        const exists = await sandbox.runCommand({
+          cmd: "test",
+          args: ["-f", "/home/alice/subdir/file.txt"],
+          sudo: true,
+        });
+        expect(exists.exitCode).toBe(0);
+      });
+
+      it("handles absolute paths", async () => {
+        const alice = await sandbox.createUser("alice");
+
+        await alice.writeFiles([
+          { path: "/tmp/alice-file.txt", content: Buffer.from("abs path") },
+        ]);
+
+        const stat = await sandbox.runCommand({
+          cmd: "stat",
+          args: ["-c", "%U", "/tmp/alice-file.txt"],
+          sudo: true,
+        });
+        expect((await stat.stdout()).trim()).toBe("alice");
+      });
+
+      it("reads files created by user commands (umask makes them group-readable)", async () => {
+        const alice = await sandbox.createUser("alice");
+
+        // User creates a file via runCommand — inherits alice:alice ownership + default umask
+        await alice.runCommand({
+          cmd: "bash",
+          args: ["-c", 'echo "from command" > /home/alice/cmd-file.txt'],
+        });
+
+        // The HTTP file API (running as vercel-sandbox) should be able to read it
+        // because vercel-sandbox is in alice's group and default umask is 0022 (644)
+        const content = await alice.readFileToBuffer({
+          path: "cmd-file.txt",
+        });
+        expect(content?.toString()).toBe("from command\n");
+      });
+    });
+
+    describe("mkDir as user", () => {
+      it("creates a directory owned by the user with 750 permissions", async () => {
+        const alice = await sandbox.createUser("alice");
+
+        await alice.mkDir("projects");
+
+        const stat = await sandbox.runCommand({
+          cmd: "stat",
+          args: ["-c", "%U:%G %a", "/home/alice/projects"],
+          sudo: true,
+        });
+        expect((await stat.stdout()).trim()).toBe("alice:alice 770");
+      });
+    });
+
+    // ─── File Isolation Between Users ───────────────────────────────
+
+    describe("file isolation", () => {
+      it("user A cannot read user B's files via runCommand", async () => {
+        const alice = await sandbox.createUser("alice");
+        const bob = await sandbox.createUser("bob");
+
+        await alice.writeFiles([
+          { path: "secret.txt", content: Buffer.from("alice's secret") },
+        ]);
+
+        const cat = await bob.runCommand({
+          cmd: "cat",
+          args: ["/home/alice/secret.txt"],
+        });
+        expect(cat.exitCode).not.toBe(0);
+        expect(await cat.stderr()).toContain("Permission denied");
+      });
+
+      it("user A cannot list user B's home directory", async () => {
+        const alice = await sandbox.createUser("alice");
+        const bob = await sandbox.createUser("bob");
+
+        const ls = await bob.runCommand({
+          cmd: "ls",
+          args: ["/home/alice"],
+        });
+        expect(ls.exitCode).not.toBe(0);
+        expect(await ls.stderr()).toContain("Permission denied");
+      });
+
+      it("user A cannot write to user B's home directory", async () => {
+        const alice = await sandbox.createUser("alice");
+        const bob = await sandbox.createUser("bob");
+
+        const touch = await bob.runCommand({
+          cmd: "touch",
+          args: ["/home/alice/hacked.txt"],
+        });
+        expect(touch.exitCode).not.toBe(0);
+      });
+
+      it("user A cannot execute in user B's home directory", async () => {
+        const alice = await sandbox.createUser("alice");
+        const bob = await sandbox.createUser("bob");
+
+        await alice.writeFiles([
+          {
+            path: "script.sh",
+            content: Buffer.from("#!/bin/bash\necho pwned"),
+            mode: 0o755,
+          },
+        ]);
+
+        const exec = await bob.runCommand({
+          cmd: "/home/alice/script.sh",
+        });
+        expect(exec.exitCode).not.toBe(0);
+      });
+
+      it("SandboxUser can read its own files but not other users' files", async () => {
+        const alice = await sandbox.createUser("alice");
+        const bob = await sandbox.createUser("bob");
+
+        await alice.writeFiles([
+          { path: "alice.txt", content: Buffer.from("alice data") },
+        ]);
+        await bob.writeFiles([
+          { path: "bob.txt", content: Buffer.from("bob data") },
+        ]);
+
+        // Each user can read their own files via SandboxUser.readFileToBuffer
+        const aliceContent = await alice.readFileToBuffer({
+          path: "alice.txt",
+        });
+        const bobContent = await bob.readFileToBuffer({
+          path: "bob.txt",
+        });
+
+        expect(aliceContent?.toString()).toBe("alice data");
+        expect(bobContent?.toString()).toBe("bob data");
+
+        // The sandbox HTTP API can also read all users' files (home dirs
+        // are group-owned by vercel-sandbox)
+        const aliceViaSandbox = await sandbox.readFileToBuffer({
+          path: "/home/alice/alice.txt",
+        });
+        expect(aliceViaSandbox?.toString()).toBe("alice data");
+
+        // Bob cannot read alice's file via runCommand (inter-user isolation)
+        const cat = await bob.runCommand({
+          cmd: "cat",
+          args: ["/home/alice/alice.txt"],
+        });
+        expect(cat.exitCode).not.toBe(0);
+      });
+    });
+
+    // ─── Group Management ───────────────────────────────────────────
+
+    describe("createGroup", () => {
+      it("creates a group with a shared directory", async () => {
+        const devs = await sandbox.createGroup("devs");
+
+        expect(devs.groupname).toBe("devs");
+        expect(devs.sharedDir).toBe("/shared/devs");
+
+        const exists = await sandbox.runCommand({
+          cmd: "test",
+          args: ["-d", "/shared/devs"],
+          sudo: true,
+        });
+        expect(exists.exitCode).toBe(0);
+      });
+
+      it("sets setgid (2770) on the shared directory", async () => {
+        await sandbox.createGroup("devs");
+
+        const stat = await sandbox.runCommand({
+          cmd: "stat",
+          args: ["-c", "%a", "/shared/devs"],
+          sudo: true,
+        });
+        expect((await stat.stdout()).trim()).toBe("2770");
+      });
+
+      it("shared dir is owned by vercel-sandbox:<groupname>", async () => {
+        await sandbox.createGroup("devs");
+
+        const stat = await sandbox.runCommand({
+          cmd: "stat",
+          args: ["-c", "%U:%G", "/shared/devs"],
+          sudo: true,
+        });
+        expect((await stat.stdout()).trim()).toBe("vercel-sandbox:devs");
+      });
+    });
+
+    // ─── Group Access Control ───────────────────────────────────────
+
+    describe("group file sharing", () => {
+      it("group member can write to shared directory", async () => {
+        const alice = await sandbox.createUser("alice");
+        await sandbox.createGroup("devs");
+        await sandbox.addUserToGroup("alice", "devs");
+
+        const touch = await alice.runCommand({
+          cmd: "touch",
+          args: ["/shared/devs/from-alice.txt"],
+        });
+        expect(touch.exitCode).toBe(0);
+      });
+
+      it("files in shared dir inherit group ownership (setgid)", async () => {
+        const alice = await sandbox.createUser("alice");
+        await sandbox.createGroup("devs");
+        await sandbox.addUserToGroup("alice", "devs");
+
+        await alice.runCommand({
+          cmd: "touch",
+          args: ["/shared/devs/file.txt"],
+        });
+
+        const stat = await sandbox.runCommand({
+          cmd: "stat",
+          args: ["-c", "%G", "/shared/devs/file.txt"],
+          sudo: true,
+        });
+        expect((await stat.stdout()).trim()).toBe("devs");
+      });
+
+      it("non-member cannot access shared directory", async () => {
+        const alice = await sandbox.createUser("alice");
+        const bob = await sandbox.createUser("bob");
+        await sandbox.createGroup("devs");
+        await sandbox.addUserToGroup("alice", "devs");
+        // bob is NOT in devs
+
+        const ls = await bob.runCommand({
+          cmd: "ls",
+          args: ["/shared/devs"],
+        });
+        expect(ls.exitCode).not.toBe(0);
+        expect(await ls.stderr()).toContain("Permission denied");
+      });
+
+      it("two group members can read each other's files in shared dir", async () => {
+        const alice = await sandbox.createUser("alice");
+        const bob = await sandbox.createUser("bob");
+        await sandbox.createGroup("devs");
+        await sandbox.addUserToGroup("alice", "devs");
+        await sandbox.addUserToGroup("bob", "devs");
+
+        // Alice creates a file
+        await alice.runCommand({
+          cmd: "bash",
+          args: [
+            "-c",
+            'echo "shared data" > /shared/devs/collab.txt',
+          ],
+        });
+
+        // Bob reads it
+        const cat = await bob.runCommand({
+          cmd: "cat",
+          args: ["/shared/devs/collab.txt"],
+        });
+        expect(cat.exitCode).toBe(0);
+        expect((await cat.stdout()).trim()).toBe("shared data");
+      });
+
+      it("removed member loses access to shared directory", async () => {
+        const alice = await sandbox.createUser("alice");
+        await sandbox.createGroup("devs");
+        await sandbox.addUserToGroup("alice", "devs");
+
+        // Verify access works
+        const touch = await alice.runCommand({
+          cmd: "touch",
+          args: ["/shared/devs/test.txt"],
+        });
+        expect(touch.exitCode).toBe(0);
+
+        // Remove from group
+        await sandbox.removeUserFromGroup("alice", "devs");
+
+        // Access should fail now
+        const ls = await alice.runCommand({
+          cmd: "ls",
+          args: ["/shared/devs"],
+        });
+        expect(ls.exitCode).not.toBe(0);
+      });
+    });
+
+    // ─── Convenience Methods ────────────────────────────────────────
+
+    describe("SandboxUser convenience methods", () => {
+      it("addToGroup adds the user to a group", async () => {
+        const alice = await sandbox.createUser("alice");
+        await sandbox.createGroup("devs");
+
+        await alice.addToGroup("devs");
+
+        const groups = await alice.runCommand("groups");
+        expect(await groups.stdout()).toContain("devs");
+      });
+
+      it("removeFromGroup removes the user from a group", async () => {
+        const alice = await sandbox.createUser("alice");
+        await sandbox.createGroup("devs");
+        await alice.addToGroup("devs");
+        await alice.removeFromGroup("devs");
+
+        const groups = await sandbox.runCommand({
+          cmd: "groups",
+          args: ["alice"],
+          sudo: true,
+        });
+        expect(await groups.stdout()).not.toContain("devs");
+      });
+    });
+
+    // ─── Multi-Group Isolation ──────────────────────────────────────
+
+    describe("multi-group isolation", () => {
+      it("user in group A but not group B cannot access group B's shared dir", async () => {
+        const alice = await sandbox.createUser("alice");
+        await sandbox.createGroup("frontend");
+        await sandbox.createGroup("backend");
+        await sandbox.addUserToGroup("alice", "frontend");
+        // alice is NOT in backend
+
+        const touchFE = await alice.runCommand({
+          cmd: "touch",
+          args: ["/shared/frontend/fe-file.txt"],
+        });
+        expect(touchFE.exitCode).toBe(0);
+
+        const touchBE = await alice.runCommand({
+          cmd: "touch",
+          args: ["/shared/backend/be-file.txt"],
+        });
+        expect(touchBE.exitCode).not.toBe(0);
+      });
+
+      it("user in multiple groups can access all their shared dirs", async () => {
+        const alice = await sandbox.createUser("alice");
+        await sandbox.createGroup("frontend");
+        await sandbox.createGroup("backend");
+        await sandbox.addUserToGroup("alice", "frontend");
+        await sandbox.addUserToGroup("alice", "backend");
+
+        const touchFE = await alice.runCommand({
+          cmd: "touch",
+          args: ["/shared/frontend/fe-file.txt"],
+        });
+        const touchBE = await alice.runCommand({
+          cmd: "touch",
+          args: ["/shared/backend/be-file.txt"],
+        });
+        expect(touchFE.exitCode).toBe(0);
+        expect(touchBE.exitCode).toBe(0);
+      });
+    });
+
+    // ─── Process Isolation ──────────────────────────────────────────
+
+    describe("process isolation", () => {
+      it("user commands run with correct user identity", async () => {
+        const alice = await sandbox.createUser("alice");
+        const bob = await sandbox.createUser("bob");
+
+        const aliceId = await alice.runCommand("id");
+        const bobId = await bob.runCommand("id");
+
+        const aliceOutput = await aliceId.stdout();
+        const bobOutput = await bobId.stdout();
+
+        expect(aliceOutput).toContain("(alice)");
+        expect(aliceOutput).not.toContain("(bob)");
+        expect(bobOutput).toContain("(bob)");
+        expect(bobOutput).not.toContain("(alice)");
+      });
+
+      it("user cannot kill another user's process", async () => {
+        const alice = await sandbox.createUser("alice");
+        const bob = await sandbox.createUser("bob");
+
+        // Alice starts a long-running process
+        const aliceProc = await alice.runCommand({
+          cmd: "sleep",
+          args: ["300"],
+          detached: true,
+        });
+
+        // Get the PID of alice's sleep process
+        const pgrep = await sandbox.runCommand({
+          cmd: "pgrep",
+          args: ["-u", "alice", "sleep"],
+          sudo: true,
+        });
+        const pid = (await pgrep.stdout()).trim();
+
+        // Bob tries to kill it
+        const kill = await bob.runCommand({
+          cmd: "kill",
+          args: [pid],
+        });
+        expect(kill.exitCode).not.toBe(0);
+
+        // Clean up
+        await aliceProc.kill("SIGTERM");
+        await aliceProc.wait();
+      });
+
+      it("created user does not have in-guest sudo access", async () => {
+        const alice = await sandbox.createUser("alice");
+
+        // alice should not be able to run sudo inside the sandbox
+        const sudoAttempt = await alice.runCommand({
+          cmd: "sudo",
+          args: ["whoami"],
+        });
+        // sudo should fail — only vercel-sandbox has passwordless sudo
+        expect(sudoAttempt.exitCode).not.toBe(0);
+      });
+    });
+  },
+);

--- a/packages/vercel-sandbox/src/sandbox-user.test.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.test.ts
@@ -54,6 +54,18 @@ describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")(
       await sandbox.stop();
     });
 
+    // The default user (and its primary group) depends on the image: stock
+    // runtimes default to `vercel-sandbox`, Ubuntu images to `root`. Resolve
+    // it at runtime so ownership assertions hold on either image.
+    async function defaultUser(): Promise<{ username: string; group: string }> {
+      const r = await sandbox.runCommand({
+        cmd: "sh",
+        args: ["-c", "id -un; id -gn"],
+      });
+      const [username, group] = (await r.stdout()).trim().split("\n");
+      return { username, group };
+    }
+
     // ─── User Creation ───────────────────────────────────────────────
 
     describe("createUser", () => {
@@ -83,15 +95,16 @@ describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")(
         expect((await stat.stdout()).trim()).toBe("770");
       });
 
-      it("sets home directory group to vercel-sandbox", async () => {
+      it("sets home directory group to the default user's group", async () => {
         await sandbox.createUser("alice");
 
+        const { group } = await defaultUser();
         const stat = await sandbox.runCommand({
           cmd: "stat",
           args: ["-c", "%U:%G", "/home/alice"],
           sudo: true,
         });
-        expect((await stat.stdout()).trim()).toBe("alice:vercel-sandbox");
+        expect((await stat.stdout()).trim()).toBe(`alice:${group}`);
       });
 
       it("creates multiple users", async () => {
@@ -287,19 +300,20 @@ describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")(
     });
 
     describe("mkDir as user", () => {
-      it("creates a directory owned by the user, group vercel-sandbox, 770", async () => {
+      it("creates a directory owned by the user, group the default user's group, 770", async () => {
         const alice = await sandbox.createUser("alice");
 
         await alice.mkDir("projects");
 
-        // Group-owned by vercel-sandbox (like the home dir) so the HTTP file
-        // API can still write into it; mode 770 keeps other users out.
+        // Group-owned by the default user's group (like the home dir) so the
+        // HTTP file API can still write into it; mode 770 keeps other users out.
+        const { group } = await defaultUser();
         const stat = await sandbox.runCommand({
           cmd: "stat",
           args: ["-c", "%U:%G %a", "/home/alice/projects"],
           sudo: true,
         });
-        expect((await stat.stdout()).trim()).toBe("alice:vercel-sandbox 770");
+        expect((await stat.stdout()).trim()).toBe(`alice:${group} 770`);
       });
 
       it("writeFiles can write into a user-created directory", async () => {
@@ -443,15 +457,16 @@ describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")(
         expect((await stat.stdout()).trim()).toBe("2770");
       });
 
-      it("shared dir is owned by vercel-sandbox:<groupname>", async () => {
+      it("shared dir is owned by <default user>:<groupname>", async () => {
         await sandbox.createGroup("devs");
 
+        const { username } = await defaultUser();
         const stat = await sandbox.runCommand({
           cmd: "stat",
           args: ["-c", "%U:%G", "/shared/devs"],
           sudo: true,
         });
-        expect((await stat.stdout()).trim()).toBe("vercel-sandbox:devs");
+        expect((await stat.stdout()).trim()).toBe(`${username}:devs`);
       });
     });
 

--- a/packages/vercel-sandbox/src/sandbox-user.test.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.test.ts
@@ -28,6 +28,17 @@ describe("validateName (unit)", () => {
     expect(sandbox.asUser("user-name").username).toBe("user-name");
     expect(sandbox.asUser("user_123").username).toBe("user_123");
   });
+
+  it("asUser resolves the home directory", () => {
+    const sandbox = new Sandbox({
+      client: {} as any,
+      routes: [],
+      sandbox: { id: "test" } as any,
+    });
+    // root's home is /root, not /home/root
+    expect(sandbox.asUser("root").homeDir).toBe("/root");
+    expect(sandbox.asUser("alice").homeDir).toBe("/home/alice");
+  });
 });
 
 describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")(
@@ -238,36 +249,71 @@ describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")(
         expect((await stat.stdout()).trim()).toBe("alice");
       });
 
-      it("reads files created by user commands (umask makes them group-readable)", async () => {
+      it("reads files created by user commands", async () => {
         const alice = await sandbox.createUser("alice");
 
-        // User creates a file via runCommand — inherits alice:alice ownership + default umask
+        // User creates a file via runCommand — owned alice:alice.
         await alice.runCommand({
           cmd: "bash",
           args: ["-c", 'echo "from command" > /home/alice/cmd-file.txt'],
         });
 
-        // The HTTP file API (running as vercel-sandbox) should be able to read it
-        // because vercel-sandbox is in alice's group and default umask is 0022 (644)
+        // readFileToBuffer reads as alice (`sudo -u alice`), so it works
+        // regardless of the file's mode.
         const content = await alice.readFileToBuffer({
           path: "cmd-file.txt",
         });
         expect(content?.toString()).toBe("from command\n");
       });
+
+      it("reads a file the user kept private (mode 600)", async () => {
+        const alice = await sandbox.createUser("alice");
+
+        await alice.writeFiles([
+          { path: "private.txt", content: Buffer.from("top secret"), mode: 0o600 },
+        ]);
+
+        // The HTTP file API (vercel-sandbox) cannot read a 600 alice:alice
+        // file, but reading as alice herself can.
+        const content = await alice.readFileToBuffer({ path: "private.txt" });
+        expect(content?.toString()).toBe("top secret");
+      });
+
+      it("returns null when reading a missing file", async () => {
+        const alice = await sandbox.createUser("alice");
+        const content = await alice.readFileToBuffer({ path: "nope.txt" });
+        expect(content).toBeNull();
+      });
     });
 
     describe("mkDir as user", () => {
-      it("creates a directory owned by the user with 770 permissions", async () => {
+      it("creates a directory owned by the user, group vercel-sandbox, 770", async () => {
         const alice = await sandbox.createUser("alice");
 
         await alice.mkDir("projects");
 
+        // Group-owned by vercel-sandbox (like the home dir) so the HTTP file
+        // API can still write into it; mode 770 keeps other users out.
         const stat = await sandbox.runCommand({
           cmd: "stat",
           args: ["-c", "%U:%G %a", "/home/alice/projects"],
           sudo: true,
         });
-        expect((await stat.stdout()).trim()).toBe("alice:alice 770");
+        expect((await stat.stdout()).trim()).toBe("alice:vercel-sandbox 770");
+      });
+
+      it("writeFiles can write into a user-created directory", async () => {
+        const alice = await sandbox.createUser("alice");
+
+        await alice.mkDir("projects");
+        await alice.writeFiles([
+          { path: "projects/app.js", content: Buffer.from("ok") },
+        ]);
+
+        const content = await alice.readFileToBuffer({
+          path: "projects/app.js",
+        });
+        expect(content?.toString()).toBe("ok");
       });
     });
 

--- a/packages/vercel-sandbox/src/sandbox-user.test.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.test.ts
@@ -166,9 +166,9 @@ describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")(
         });
         await cmd.kill("SIGTERM");
         const result = await cmd.wait();
-        // The command runs inside a `sudo -u` wrapper, so the exit code
-        // may differ from a direct kill (e.g., sudo's propagated code vs 143
-        // for SIGTERM).
+        // The command runs inside a `sudo -u … bash -c` wrapper, so the exit
+        // code may differ from a direct kill (e.g., the wrapper's propagated
+        // code vs 143 for SIGTERM).
         expect(result.exitCode).not.toBe(0);
       });
     });

--- a/packages/vercel-sandbox/src/sandbox-user.test.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.test.ts
@@ -61,7 +61,7 @@ describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")(
         expect(result.exitCode).toBe(0);
       });
 
-      it("sets 750 permissions on home directory", async () => {
+      it("sets 770 permissions on home directory", async () => {
         await sandbox.createUser("alice");
 
         const stat = await sandbox.runCommand({
@@ -256,7 +256,7 @@ describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")(
     });
 
     describe("mkDir as user", () => {
-      it("creates a directory owned by the user with 750 permissions", async () => {
+      it("creates a directory owned by the user with 770 permissions", async () => {
         const alice = await sandbox.createUser("alice");
 
         await alice.mkDir("projects");

--- a/packages/vercel-sandbox/src/sandbox-user.test.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.test.ts
@@ -155,8 +155,9 @@ describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")(
         });
         await cmd.kill("SIGTERM");
         const result = await cmd.wait();
-        // The command runs inside a bash -c wrapper, so the exit code
-        // may differ from a direct kill (e.g., 255 from bash vs 143 for SIGTERM).
+        // The command runs inside a `sudo -u` wrapper, so the exit code
+        // may differ from a direct kill (e.g., sudo's propagated code vs 143
+        // for SIGTERM).
         expect(result.exitCode).not.toBe(0);
       });
     });

--- a/packages/vercel-sandbox/src/sandbox-user.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.ts
@@ -1,0 +1,324 @@
+import type { Writable } from "stream";
+import type { Sandbox } from "./sandbox.js";
+import type { Command, CommandFinished } from "./command.js";
+import { validateName } from "./utils/validate-name.js";
+
+/** @inline */
+interface RunCommandParams {
+  cmd: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  sudo?: boolean;
+  detached?: boolean;
+  stdout?: Writable;
+  stderr?: Writable;
+  signal?: AbortSignal;
+}
+
+/**
+ * A user context within a sandbox.
+ *
+ * All file and command operations default to running as this user.
+ * Created via {@link Sandbox.createUser} or {@link Sandbox.asUser}.
+ *
+ * @hideconstructor
+ */
+export class SandboxUser {
+  /**
+   * The Linux username.
+   */
+  readonly username: string;
+
+  /**
+   * The user's home directory (e.g., `/home/alice`).
+   */
+  readonly homeDir: string;
+
+  private readonly sandbox: Sandbox;
+
+  constructor({
+    sandbox,
+    username,
+  }: {
+    sandbox: Sandbox;
+    username: string;
+  }) {
+    this.sandbox = sandbox;
+    this.username = username;
+    this.homeDir = `/home/${username}`;
+  }
+
+  /**
+   * Build the wrapped command args to run as this user via `sudo -u`.
+   *
+   * When `env` is provided, injects `env KEY=VAL ...` so that environment
+   * variables survive the `sudo -u` transition.
+   */
+  private buildUserCommand(params: {
+    cmd: string;
+    args?: string[];
+    env?: Record<string, string>;
+    cwd?: string;
+  }): { cmd: string; args: string[] } {
+    const envEntries = Object.entries(params.env ?? {});
+    const envArgs =
+      envEntries.length > 0
+        ? ["env", ...envEntries.map(([k, v]) => `${k}=${v}`)]
+        : [];
+
+    // We cannot use the API's `cwd` parameter for user home dirs because
+    // the backend cd's to `cwd` before exec, and SUID binaries (like sudo)
+    // cannot be executed from directories with restricted permissions (770).
+    //
+    // Instead, we use: sudo -u <user> -- [env K=V...] bash -c 'cd <dir> && exec "$@"' _ <cmd> <args>
+    // This pattern:
+    // - Uses bash's "$@" to properly handle arguments with spaces
+    // - Sets the working directory inside the user's context
+    // - Passes env vars via the `env` command before bash
+    const cwd = params.cwd ?? this.homeDir;
+    return {
+      cmd: "sudo",
+      args: [
+        "-u",
+        this.username,
+        "--",
+        ...envArgs,
+        "bash",
+        "-c",
+        `cd ${cwd} && exec "$@"`,
+        "_",
+        params.cmd,
+        ...(params.args ?? []),
+      ],
+    };
+  }
+
+  /**
+   * Resolve a path relative to this user's home directory.
+   * Absolute paths are returned as-is.
+   */
+  private resolvePath(path: string): string {
+    return path.startsWith("/") ? path : `${this.homeDir}/${path}`;
+  }
+
+  /**
+   * Start executing a command as this user.
+   *
+   * @param command - The command to execute.
+   * @param args - Arguments to pass to the command.
+   * @param opts - Optional parameters.
+   * @returns A {@link CommandFinished} result once execution is done.
+   */
+  async runCommand(
+    command: string,
+    args?: string[],
+    opts?: { signal?: AbortSignal },
+  ): Promise<CommandFinished>;
+
+  /**
+   * Start executing a command as this user in detached mode.
+   *
+   * @param params - The command parameters.
+   * @returns A {@link Command} instance for the running command.
+   */
+  async runCommand(
+    params: RunCommandParams & { detached: true },
+  ): Promise<Command>;
+
+  /**
+   * Start executing a command as this user.
+   *
+   * @param params - The command parameters.
+   * @returns A {@link CommandFinished} result once execution is done.
+   */
+  async runCommand(params: RunCommandParams): Promise<CommandFinished>;
+
+  async runCommand(
+    commandOrParams: string | RunCommandParams,
+    args?: string[],
+    opts?: { signal?: AbortSignal },
+  ): Promise<Command | CommandFinished> {
+    if (typeof commandOrParams === "string") {
+      const wrapped = this.buildUserCommand({
+        cmd: commandOrParams,
+        args,
+      });
+      // Don't pass cwd to the sandbox API — the bash -c wrapper handles it.
+      // Don't pass sudo: true — vercel-sandbox already has sudo privileges.
+      return this.sandbox.runCommand({
+        ...wrapped,
+        signal: opts?.signal,
+      });
+    }
+
+    const params = commandOrParams;
+
+    // When sudo: true is passed, delegate directly to root (skip user wrapping).
+    // Don't default cwd to homeDir — the backend can't exec SUID binaries
+    // from directories with restricted permissions.
+    if (params.sudo) {
+      return this.sandbox.runCommand({
+        ...params,
+      } as RunCommandParams & { detached: true });
+    }
+
+    const wrapped = this.buildUserCommand({
+      cmd: params.cmd,
+      args: params.args,
+      env: params.env,
+      cwd: params.cwd,
+    });
+
+    return this.sandbox.runCommand({
+      cmd: wrapped.cmd,
+      args: wrapped.args,
+      // Don't pass cwd — bash -c wrapper handles it (see buildUserCommand)
+      // Don't pass sudo: true — vercel-sandbox already has sudo privileges
+      // env is already baked into the wrapped command via `env KEY=VAL`
+      detached: params.detached,
+      stdout: params.stdout,
+      stderr: params.stderr,
+      signal: params.signal,
+    } as RunCommandParams & { detached: true });
+  }
+
+  /**
+   * Write files to this user's home directory (or absolute paths).
+   * Files are written via the sandbox HTTP API then chowned to this user.
+   *
+   * The HTTP API can write to user home dirs because they are group-owned
+   * by `vercel-sandbox` with `770` permissions.
+   *
+   * @param files - Array of files with path, content, and optional mode
+   * @param opts - Optional parameters.
+   */
+  async writeFiles(
+    files: { path: string; content: Buffer; mode?: number }[],
+    opts?: { signal?: AbortSignal },
+  ) {
+    // Resolve relative paths to user's home directory
+    const absoluteFiles = files.map((f) => ({
+      ...f,
+      path: this.resolvePath(f.path),
+    }));
+
+    // Write via the HTTP API (works because home dirs are group-owned
+    // by vercel-sandbox)
+    await this.sandbox.writeFiles(absoluteFiles, opts);
+
+    // Chown all written files to this user
+    const paths = absoluteFiles.map((f) => f.path);
+    await this.sandbox.runCommand({
+      cmd: "chown",
+      args: [`${this.username}:${this.username}`, ...paths],
+      sudo: true,
+      signal: opts?.signal,
+    });
+  }
+
+  /**
+   * Read a file from this user's context as a stream.
+   *
+   * @param file - File to read, with path and optional cwd
+   * @param opts - Optional parameters.
+   * @returns A ReadableStream of the file contents, or null if not found
+   */
+  async readFile(
+    file: { path: string; cwd?: string },
+    opts?: { signal?: AbortSignal },
+  ): Promise<NodeJS.ReadableStream | null> {
+    return this.sandbox.readFile(
+      { path: file.path, cwd: file.cwd ?? this.homeDir },
+      opts,
+    );
+  }
+
+  /**
+   * Read a file from this user's context as a Buffer.
+   *
+   * @param file - File to read, with path and optional cwd
+   * @param opts - Optional parameters.
+   * @returns The file contents as a Buffer, or null if not found
+   */
+  async readFileToBuffer(
+    file: { path: string; cwd?: string },
+    opts?: { signal?: AbortSignal },
+  ): Promise<Buffer | null> {
+    return this.sandbox.readFileToBuffer(
+      { path: file.path, cwd: file.cwd ?? this.homeDir },
+      opts,
+    );
+  }
+
+  /**
+   * Download a file from this user's context to the local filesystem.
+   *
+   * @param src - Source file in the sandbox
+   * @param dst - Destination on the local machine
+   * @param opts - Optional parameters.
+   * @returns The absolute path to the written file, or null if not found
+   */
+  async downloadFile(
+    src: { path: string; cwd?: string },
+    dst: { path: string; cwd?: string },
+    opts?: { mkdirRecursive?: boolean; signal?: AbortSignal },
+  ): Promise<string | null> {
+    return this.sandbox.downloadFile(
+      { path: src.path, cwd: src.cwd ?? this.homeDir },
+      dst,
+      opts,
+    );
+  }
+
+  /**
+   * Create a directory owned by this user.
+   *
+   * @param path - Path of the directory to create
+   * @param opts - Optional parameters.
+   */
+  async mkDir(path: string, opts?: { signal?: AbortSignal }): Promise<void> {
+    const absPath = this.resolvePath(path);
+    await this.sandbox.mkDir(absPath, opts);
+    await this.sandbox.runCommand({
+      cmd: "chown",
+      args: [`${this.username}:${this.username}`, absPath],
+      sudo: true,
+      signal: opts?.signal,
+    });
+    await this.sandbox.runCommand({
+      cmd: "chmod",
+      args: ["770", absPath],
+      sudo: true,
+      signal: opts?.signal,
+    });
+  }
+
+  /**
+   * Add this user to a group.
+   *
+   * @param groupname - Name of the group to join
+   * @param opts - Optional parameters.
+   */
+  async addToGroup(
+    groupname: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<void> {
+    validateName(groupname, "group name");
+    await this.sandbox.addUserToGroup(this.username, groupname, opts);
+  }
+
+  /**
+   * Remove this user from a group.
+   *
+   * @param groupname - Name of the group to leave
+   * @param opts - Optional parameters.
+   */
+  async removeFromGroup(
+    groupname: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<void> {
+    validateName(groupname, "group name");
+    await this.sandbox.removeUserFromGroup(this.username, groupname, opts);
+  }
+}

--- a/packages/vercel-sandbox/src/sandbox-user.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.ts
@@ -8,15 +8,6 @@ import type { ExecutionContext } from "./execution-context.js";
 import { validateName } from "./utils/validate-name.js";
 
 /**
- * Group that owns every user's home directory (and any directory the SDK
- * creates inside it). The sandbox's HTTP file API runs as `vercel-sandbox`,
- * so directories must stay group-owned by it — and mode `770` — for
- * {@link SandboxUser.writeFiles} to be able to traverse and write into them
- * while other users remain locked out.
- */
-const SANDBOX_GROUP = "vercel-sandbox";
-
-/**
  * A user context within a sandbox.
  *
  * All file and command operations default to running as this user.
@@ -152,7 +143,7 @@ export class SandboxUser implements ExecutionContext {
         args,
       });
       // Don't pass cwd to the sandbox API — the bash -c wrapper cd's for us.
-      // Don't pass sudo: true — vercel-sandbox already has sudo privileges.
+      // Don't pass sudo: true — the default user already has sudo privileges.
       return this.sandbox.runCommand({
         ...wrapped,
         signal: opts?.signal,
@@ -182,7 +173,7 @@ export class SandboxUser implements ExecutionContext {
       cmd: wrapped.cmd,
       args: wrapped.args,
       // Don't pass cwd — the bash -c wrapper cd's for us (see buildUserCommand)
-      // Don't pass sudo: true — vercel-sandbox already has sudo privileges
+      // Don't pass sudo: true — the default user already has sudo privileges
       // env is already baked into the wrapped command via `env KEY=VAL`
       detached: params.detached,
       stdout: params.stdout,
@@ -197,7 +188,7 @@ export class SandboxUser implements ExecutionContext {
    * Files are written via the sandbox HTTP API then chowned to this user.
    *
    * The HTTP API can write to user home dirs because they are group-owned
-   * by `vercel-sandbox` with `770` permissions.
+   * by the sandbox's default user group with `770` permissions.
    *
    * @param files - Array of files with path, content, and optional mode
    * @param opts - Optional parameters.
@@ -213,7 +204,7 @@ export class SandboxUser implements ExecutionContext {
     }));
 
     // Write via the HTTP API (works because home dirs are group-owned
-    // by vercel-sandbox)
+    // by the default user's group)
     await this.sandbox.writeFiles(absoluteFiles, opts);
 
     const paths = absoluteFiles.map((f) => f.path);
@@ -227,14 +218,16 @@ export class SandboxUser implements ExecutionContext {
     );
 
     // Any directories the write implicitly created (e.g. `data/` in
-    // `data/config.json`) are owned by vercel-sandbox. Hand them to the user
-    // but keep them group-owned by vercel-sandbox with mode 770 — matching the
-    // home dir — so the HTTP API can still traverse and write into them later.
+    // `data/config.json`) are owned by the default user. Hand them to the user
+    // but keep them group-owned by the default user's group with mode 770 —
+    // matching the home dir — so the HTTP API can still traverse and write into
+    // them later.
     const dirs = this.ancestorDirsUnderHome(paths);
     if (dirs.length > 0) {
+      const { group } = await this.sandbox.getDefaultUser(opts);
       await this.chownOrThrow(
         dirs,
-        `${this.username}:${SANDBOX_GROUP}`,
+        `${this.username}:${group}`,
         opts?.signal,
       );
       await this.chmodOrThrow(dirs, "770", opts?.signal);
@@ -304,11 +297,12 @@ export class SandboxUser implements ExecutionContext {
    * Read a file as this user and return its bytes, or null if it does not
    * exist.
    *
-   * Reads via `sudo -u <user> base64` rather than the HTTP file API: the API
-   * runs as `vercel-sandbox` and cannot read files this user has kept private
-   * (e.g. mode `600`), whereas reading as the user honours the user's own
-   * permissions. The payload is base64-encoded because the command output
-   * channel is UTF-8 only and would otherwise corrupt binary files.
+   * Reads via `sudo -u <user> base64` rather than the HTTP file API: on stock
+   * runtimes the API runs as `vercel-sandbox` and cannot read files this user
+   * has kept private (e.g. mode `600`), whereas reading as the user always
+   * honours the user's own permissions. The payload is base64-encoded because
+   * the command output channel is UTF-8 only and would otherwise corrupt
+   * binary files.
    */
   private async catAsUser(
     file: { path: string; cwd?: string },
@@ -340,12 +334,13 @@ export class SandboxUser implements ExecutionContext {
     const absPath = this.resolvePath(path);
     await this.sandbox.mkDir(absPath, opts);
     // Own the created directory plus any parents the mkdir created under the
-    // home dir. Group-owned by vercel-sandbox with mode 770 so the HTTP file
-    // API can write into it (see SANDBOX_GROUP).
+    // home dir. Group-owned by the default user's group with mode 770 so the
+    // HTTP file API can write into it (matching the home dir).
     const dirs = [absPath, ...this.ancestorDirsUnderHome([absPath])];
+    const { group } = await this.sandbox.getDefaultUser(opts);
     await this.chownOrThrow(
       dirs,
-      `${this.username}:${SANDBOX_GROUP}`,
+      `${this.username}:${group}`,
       opts?.signal,
     );
     await this.chmodOrThrow(dirs, "770", opts?.signal);

--- a/packages/vercel-sandbox/src/sandbox-user.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.ts
@@ -14,6 +14,7 @@ interface RunCommandParams {
   stdout?: Writable;
   stderr?: Writable;
   signal?: AbortSignal;
+  timeoutMs?: number;
 }
 
 /**
@@ -110,7 +111,7 @@ export class SandboxUser {
   async runCommand(
     command: string,
     args?: string[],
-    opts?: { signal?: AbortSignal },
+    opts?: { signal?: AbortSignal; timeoutMs?: number },
   ): Promise<CommandFinished>;
 
   /**
@@ -134,7 +135,7 @@ export class SandboxUser {
   async runCommand(
     commandOrParams: string | RunCommandParams,
     args?: string[],
-    opts?: { signal?: AbortSignal },
+    opts?: { signal?: AbortSignal; timeoutMs?: number },
   ): Promise<Command | CommandFinished> {
     if (typeof commandOrParams === "string") {
       const wrapped = this.buildUserCommand({
@@ -146,6 +147,7 @@ export class SandboxUser {
       return this.sandbox.runCommand({
         ...wrapped,
         signal: opts?.signal,
+        timeoutMs: opts?.timeoutMs,
       });
     }
 
@@ -177,6 +179,7 @@ export class SandboxUser {
       stdout: params.stdout,
       stderr: params.stderr,
       signal: params.signal,
+      timeoutMs: params.timeoutMs,
     } as RunCommandParams & { detached: true });
   }
 
@@ -206,12 +209,19 @@ export class SandboxUser {
 
     // Chown all written files to this user
     const paths = absoluteFiles.map((f) => f.path);
-    await this.sandbox.runCommand({
+    if (paths.length === 0) return;
+    const chown = await this.sandbox.runCommand({
       cmd: "chown",
       args: [`${this.username}:${this.username}`, ...paths],
       sudo: true,
       signal: opts?.signal,
     });
+    if (chown.exitCode !== 0) {
+      const stderr = await chown.stderr();
+      throw new Error(
+        `Failed to set ownership on ${paths.join(", ")}: ${stderr}`,
+      );
+    }
   }
 
   /**
@@ -277,18 +287,26 @@ export class SandboxUser {
   async mkDir(path: string, opts?: { signal?: AbortSignal }): Promise<void> {
     const absPath = this.resolvePath(path);
     await this.sandbox.mkDir(absPath, opts);
-    await this.sandbox.runCommand({
+    const chown = await this.sandbox.runCommand({
       cmd: "chown",
       args: [`${this.username}:${this.username}`, absPath],
       sudo: true,
       signal: opts?.signal,
     });
-    await this.sandbox.runCommand({
+    if (chown.exitCode !== 0) {
+      const stderr = await chown.stderr();
+      throw new Error(`Failed to set ownership on ${absPath}: ${stderr}`);
+    }
+    const chmod = await this.sandbox.runCommand({
       cmd: "chmod",
       args: ["770", absPath],
       sudo: true,
       signal: opts?.signal,
     });
+    if (chmod.exitCode !== 0) {
+      const stderr = await chmod.stderr();
+      throw new Error(`Failed to set permissions on ${absPath}: ${stderr}`);
+    }
   }
 
   /**

--- a/packages/vercel-sandbox/src/sandbox-user.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.ts
@@ -4,6 +4,7 @@ import { dirname, resolve } from "node:path";
 import type { Sandbox } from "./sandbox.js";
 import type { RunCommandParams } from "./session.js";
 import type { Command, CommandFinished } from "./command.js";
+import type { ExecutionContext } from "./execution-context.js";
 import { validateName } from "./utils/validate-name.js";
 
 /**
@@ -23,7 +24,7 @@ const SANDBOX_GROUP = "vercel-sandbox";
  *
  * @hideconstructor
  */
-export class SandboxUser {
+export class SandboxUser implements ExecutionContext {
   /**
    * The Linux username.
    */

--- a/packages/vercel-sandbox/src/sandbox-user.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.ts
@@ -69,23 +69,31 @@ export class SandboxUser implements ExecutionContext {
         ? ["env", ...envEntries.map(([k, v]) => `${k}=${v}`)]
         : [];
 
-    // We cannot use the API's `cwd` parameter for user home dirs because
-    // the backend cd's to `cwd` before exec, and SUID binaries (like sudo)
-    // cannot be executed from directories with restricted permissions (770).
-    //
-    // Instead, we use: sudo --chdir <dir> -u <user> -- [env K=V...] <cmd> <args>
-    // Passing `cwd` via `sudo --chdir` keeps it a separate argv element, so it
-    // is never shell-interpreted — this avoids injection by design rather than
-    // relying on quoting, and removes the need for a `bash -c` wrapper.
     const cwd = params.cwd ?? this.homeDir;
+
+    // Run as the target user via `sudo -u`, changing into `cwd` first.
+    //
+    // We can't set the directory via the sandbox API's `cwd` (the backend cd's
+    // there before exec, and SUID binaries like sudo cannot start from a `770`
+    // home dir), nor via `sudo --chdir` (the sandbox's sudoers policy forbids
+    // the `-D` option). Instead we cd inside a `bash -c` wrapper.
+    //
+    // `cwd`, the command, its args, and any `env KEY=VAL` are passed as
+    // separate positional parameters to `bash -c` (`$1` is `cwd`; `$@` after
+    // the shift is the command). Because they are argv elements rather than
+    // text spliced into the script, they are never re-parsed by the shell —
+    // injection-safe by construction.
     return {
       cmd: "sudo",
       args: [
-        "--chdir",
-        cwd,
         "-u",
         this.username,
         "--",
+        "bash",
+        "-c",
+        'cd "$1" || exit 1; shift; exec "$@"',
+        "bash", // $0 placeholder for `bash -c`
+        cwd,
         ...envArgs,
         params.cmd,
         ...(params.args ?? []),
@@ -143,7 +151,7 @@ export class SandboxUser implements ExecutionContext {
         cmd: commandOrParams,
         args,
       });
-      // Don't pass cwd to the sandbox API — sudo --chdir handles it.
+      // Don't pass cwd to the sandbox API — the bash -c wrapper cd's for us.
       // Don't pass sudo: true — vercel-sandbox already has sudo privileges.
       return this.sandbox.runCommand({
         ...wrapped,
@@ -173,7 +181,7 @@ export class SandboxUser implements ExecutionContext {
     return this.sandbox.runCommand({
       cmd: wrapped.cmd,
       args: wrapped.args,
-      // Don't pass cwd — sudo --chdir handles it (see buildUserCommand)
+      // Don't pass cwd — the bash -c wrapper cd's for us (see buildUserCommand)
       // Don't pass sudo: true — vercel-sandbox already has sudo privileges
       // env is already baked into the wrapped command via `env KEY=VAL`
       detached: params.detached,

--- a/packages/vercel-sandbox/src/sandbox-user.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.ts
@@ -71,23 +71,20 @@ export class SandboxUser {
     // the backend cd's to `cwd` before exec, and SUID binaries (like sudo)
     // cannot be executed from directories with restricted permissions (770).
     //
-    // Instead, we use: sudo -u <user> -- [env K=V...] bash -c 'cd <dir> && exec "$@"' _ <cmd> <args>
-    // This pattern:
-    // - Uses bash's "$@" to properly handle arguments with spaces
-    // - Sets the working directory inside the user's context
-    // - Passes env vars via the `env` command before bash
+    // Instead, we use: sudo --chdir <dir> -u <user> -- [env K=V...] <cmd> <args>
+    // Passing `cwd` via `sudo --chdir` keeps it a separate argv element, so it
+    // is never shell-interpreted — this avoids injection by design rather than
+    // relying on quoting, and removes the need for a `bash -c` wrapper.
     const cwd = params.cwd ?? this.homeDir;
     return {
       cmd: "sudo",
       args: [
+        "--chdir",
+        cwd,
         "-u",
         this.username,
         "--",
         ...envArgs,
-        "bash",
-        "-c",
-        `cd ${cwd} && exec "$@"`,
-        "_",
         params.cmd,
         ...(params.args ?? []),
       ],
@@ -144,7 +141,7 @@ export class SandboxUser {
         cmd: commandOrParams,
         args,
       });
-      // Don't pass cwd to the sandbox API — the bash -c wrapper handles it.
+      // Don't pass cwd to the sandbox API — sudo --chdir handles it.
       // Don't pass sudo: true — vercel-sandbox already has sudo privileges.
       return this.sandbox.runCommand({
         ...wrapped,
@@ -173,7 +170,7 @@ export class SandboxUser {
     return this.sandbox.runCommand({
       cmd: wrapped.cmd,
       args: wrapped.args,
-      // Don't pass cwd — bash -c wrapper handles it (see buildUserCommand)
+      // Don't pass cwd — sudo --chdir handles it (see buildUserCommand)
       // Don't pass sudo: true — vercel-sandbox already has sudo privileges
       // env is already baked into the wrapped command via `env KEY=VAL`
       detached: params.detached,

--- a/packages/vercel-sandbox/src/sandbox-user.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.ts
@@ -30,6 +30,12 @@ export class SandboxUser implements ExecutionContext {
 
   private readonly sandbox: Sandbox;
 
+  /**
+   * Memoized lookup of this user's primary group.
+   * See {@link SandboxUser.primaryGroup}.
+   */
+  private primaryGroupPromise?: Promise<string>;
+
   constructor({
     sandbox,
     username,
@@ -215,7 +221,7 @@ export class SandboxUser implements ExecutionContext {
     // The files themselves belong to the user outright.
     await this.chownOrThrow(
       paths,
-      `${this.username}:${this.username}`,
+      `${this.username}:${await this.primaryGroup(opts?.signal)}`,
       opts?.signal,
     );
 
@@ -348,6 +354,48 @@ export class SandboxUser implements ExecutionContext {
       opts?.signal,
     );
     await this.chmodOrThrow(dirs, "770", opts?.signal);
+  }
+
+  /**
+   * This user's primary group. Users created via {@link Sandbox.createUser}
+   * get a group named after them, but {@link Sandbox.asUser} accepts
+   * pre-existing users whose primary group can differ (e.g. system users), so
+   * we resolve it from the sandbox rather than assuming `<username>`.
+   *
+   * The result is memoized for the lifetime of this instance.
+   */
+  private primaryGroup(signal?: AbortSignal): Promise<string> {
+    if (!this.primaryGroupPromise) {
+      this.primaryGroupPromise = this.resolvePrimaryGroup(signal).catch(
+        (err) => {
+          // Don't cache failures — allow a later call to retry.
+          this.primaryGroupPromise = undefined;
+          throw err;
+        },
+      );
+    }
+    return this.primaryGroupPromise;
+  }
+
+  private async resolvePrimaryGroup(signal?: AbortSignal): Promise<string> {
+    const result = await this.sandbox.runCommand({
+      cmd: "id",
+      args: ["-gn", this.username],
+      signal,
+    });
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      throw new Error(
+        `Failed to resolve the primary group of "${this.username}": ${stderr}`,
+      );
+    }
+    const group = (await result.stdout()).trim();
+    if (!group) {
+      throw new Error(
+        `Failed to resolve the primary group of "${this.username}"`,
+      );
+    }
+    return group;
   }
 
   /**

--- a/packages/vercel-sandbox/src/sandbox-user.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.ts
@@ -1,5 +1,7 @@
 import { Readable } from "stream";
-import { mkdir, writeFile } from "fs/promises";
+import { pipeline } from "stream/promises";
+import { createWriteStream } from "fs";
+import { mkdir } from "fs/promises";
 import { dirname, resolve } from "path";
 import type { Sandbox } from "./sandbox.js";
 import type { RunCommandParams } from "./session.js";
@@ -282,14 +284,16 @@ export class SandboxUser implements ExecutionContext {
     // `"use step"`: touches Node built-ins (`fs`, `path`), which the @workflow
     // compiler only permits inside step functions (matches Session.downloadFile).
     "use step";
-    const buffer = await this.catAsUser(src, opts);
-    if (buffer === null) return null;
+    const stream = await this.readFile(src, opts);
+    if (stream === null) return null;
 
     const dstPath = resolve(dst.cwd ?? "", dst.path);
     if (opts?.mkdirRecursive) {
       await mkdir(dirname(dstPath), { recursive: true });
     }
-    await writeFile(dstPath, buffer, { signal: opts?.signal });
+    await pipeline(stream, createWriteStream(dstPath), {
+      signal: opts?.signal,
+    });
     return dstPath;
   }
 

--- a/packages/vercel-sandbox/src/sandbox-user.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.ts
@@ -1,6 +1,6 @@
-import { Readable } from "node:stream";
-import { mkdir, writeFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { Readable } from "stream";
+import { mkdir, writeFile } from "fs/promises";
+import { dirname, resolve } from "path";
 import type { Sandbox } from "./sandbox.js";
 import type { RunCommandParams } from "./session.js";
 import type { Command, CommandFinished } from "./command.js";
@@ -252,6 +252,9 @@ export class SandboxUser implements ExecutionContext {
     file: { path: string; cwd?: string },
     opts?: { signal?: AbortSignal },
   ): Promise<NodeJS.ReadableStream | null> {
+    // `"use step"`: touches a Node built-in (`stream`), which the @workflow
+    // compiler only permits inside step functions (matches Session.readFile).
+    "use step";
     const buffer = await this.catAsUser(file, opts);
     return buffer === null ? null : Readable.from([buffer]);
   }
@@ -283,6 +286,9 @@ export class SandboxUser implements ExecutionContext {
     dst: { path: string; cwd?: string },
     opts?: { mkdirRecursive?: boolean; signal?: AbortSignal },
   ): Promise<string | null> {
+    // `"use step"`: touches Node built-ins (`fs`, `path`), which the @workflow
+    // compiler only permits inside step functions (matches Session.downloadFile).
+    "use step";
     const buffer = await this.catAsUser(src, opts);
     if (buffer === null) return null;
 

--- a/packages/vercel-sandbox/src/sandbox-user.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.ts
@@ -1,21 +1,7 @@
-import type { Writable } from "stream";
 import type { Sandbox } from "./sandbox.js";
+import type { RunCommandParams } from "./session.js";
 import type { Command, CommandFinished } from "./command.js";
 import { validateName } from "./utils/validate-name.js";
-
-/** @inline */
-interface RunCommandParams {
-  cmd: string;
-  args?: string[];
-  cwd?: string;
-  env?: Record<string, string>;
-  sudo?: boolean;
-  detached?: boolean;
-  stdout?: Writable;
-  stderr?: Writable;
-  signal?: AbortSignal;
-  timeoutMs?: number;
-}
 
 /**
  * A user context within a sandbox.
@@ -194,7 +180,7 @@ export class SandboxUser {
    * @param opts - Optional parameters.
    */
   async writeFiles(
-    files: { path: string; content: Buffer; mode?: number }[],
+    files: { path: string; content: string | Uint8Array; mode?: number }[],
     opts?: { signal?: AbortSignal },
   ) {
     // Resolve relative paths to user's home directory

--- a/packages/vercel-sandbox/src/sandbox-user.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.ts
@@ -1,7 +1,19 @@
+import { Readable } from "node:stream";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 import type { Sandbox } from "./sandbox.js";
 import type { RunCommandParams } from "./session.js";
 import type { Command, CommandFinished } from "./command.js";
 import { validateName } from "./utils/validate-name.js";
+
+/**
+ * Group that owns every user's home directory (and any directory the SDK
+ * creates inside it). The sandbox's HTTP file API runs as `vercel-sandbox`,
+ * so directories must stay group-owned by it — and mode `770` — for
+ * {@link SandboxUser.writeFiles} to be able to traverse and write into them
+ * while other users remain locked out.
+ */
+const SANDBOX_GROUP = "vercel-sandbox";
 
 /**
  * A user context within a sandbox.
@@ -33,7 +45,9 @@ export class SandboxUser {
   }) {
     this.sandbox = sandbox;
     this.username = username;
-    this.homeDir = `/home/${username}`;
+    // `root`'s home is `/root`, not `/home/root`; every other user's home
+    // follows the `/home/<username>` convention.
+    this.homeDir = username === "root" ? "/root" : `/home/${username}`;
   }
 
   /**
@@ -193,20 +207,28 @@ export class SandboxUser {
     // by vercel-sandbox)
     await this.sandbox.writeFiles(absoluteFiles, opts);
 
-    // Chown all written files to this user
     const paths = absoluteFiles.map((f) => f.path);
     if (paths.length === 0) return;
-    const chown = await this.sandbox.runCommand({
-      cmd: "chown",
-      args: [`${this.username}:${this.username}`, ...paths],
-      sudo: true,
-      signal: opts?.signal,
-    });
-    if (chown.exitCode !== 0) {
-      const stderr = await chown.stderr();
-      throw new Error(
-        `Failed to set ownership on ${paths.join(", ")}: ${stderr}`,
+
+    // The files themselves belong to the user outright.
+    await this.chownOrThrow(
+      paths,
+      `${this.username}:${this.username}`,
+      opts?.signal,
+    );
+
+    // Any directories the write implicitly created (e.g. `data/` in
+    // `data/config.json`) are owned by vercel-sandbox. Hand them to the user
+    // but keep them group-owned by vercel-sandbox with mode 770 — matching the
+    // home dir — so the HTTP API can still traverse and write into them later.
+    const dirs = this.ancestorDirsUnderHome(paths);
+    if (dirs.length > 0) {
+      await this.chownOrThrow(
+        dirs,
+        `${this.username}:${SANDBOX_GROUP}`,
+        opts?.signal,
       );
+      await this.chmodOrThrow(dirs, "770", opts?.signal);
     }
   }
 
@@ -221,10 +243,8 @@ export class SandboxUser {
     file: { path: string; cwd?: string },
     opts?: { signal?: AbortSignal },
   ): Promise<NodeJS.ReadableStream | null> {
-    return this.sandbox.readFile(
-      { path: file.path, cwd: file.cwd ?? this.homeDir },
-      opts,
-    );
+    const buffer = await this.catAsUser(file, opts);
+    return buffer === null ? null : Readable.from([buffer]);
   }
 
   /**
@@ -238,10 +258,7 @@ export class SandboxUser {
     file: { path: string; cwd?: string },
     opts?: { signal?: AbortSignal },
   ): Promise<Buffer | null> {
-    return this.sandbox.readFileToBuffer(
-      { path: file.path, cwd: file.cwd ?? this.homeDir },
-      opts,
-    );
+    return this.catAsUser(file, opts);
   }
 
   /**
@@ -257,11 +274,45 @@ export class SandboxUser {
     dst: { path: string; cwd?: string },
     opts?: { mkdirRecursive?: boolean; signal?: AbortSignal },
   ): Promise<string | null> {
-    return this.sandbox.downloadFile(
-      { path: src.path, cwd: src.cwd ?? this.homeDir },
-      dst,
-      opts,
-    );
+    const buffer = await this.catAsUser(src, opts);
+    if (buffer === null) return null;
+
+    const dstPath = resolve(dst.cwd ?? "", dst.path);
+    if (opts?.mkdirRecursive) {
+      await mkdir(dirname(dstPath), { recursive: true });
+    }
+    await writeFile(dstPath, buffer, { signal: opts?.signal });
+    return dstPath;
+  }
+
+  /**
+   * Read a file as this user and return its bytes, or null if it does not
+   * exist.
+   *
+   * Reads via `sudo -u <user> base64` rather than the HTTP file API: the API
+   * runs as `vercel-sandbox` and cannot read files this user has kept private
+   * (e.g. mode `600`), whereas reading as the user honours the user's own
+   * permissions. The payload is base64-encoded because the command output
+   * channel is UTF-8 only and would otherwise corrupt binary files.
+   */
+  private async catAsUser(
+    file: { path: string; cwd?: string },
+    opts?: { signal?: AbortSignal },
+  ): Promise<Buffer | null> {
+    const path = file.path.startsWith("/")
+      ? file.path
+      : `${file.cwd ?? this.homeDir}/${file.path}`;
+    const result = await this.runCommand({
+      cmd: "base64",
+      args: [path],
+      signal: opts?.signal,
+    });
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      if (/No such file or directory/i.test(stderr)) return null;
+      throw new Error(`Failed to read ${path}: ${stderr}`);
+    }
+    return Buffer.from(await result.stdout(), "base64");
   }
 
   /**
@@ -273,26 +324,78 @@ export class SandboxUser {
   async mkDir(path: string, opts?: { signal?: AbortSignal }): Promise<void> {
     const absPath = this.resolvePath(path);
     await this.sandbox.mkDir(absPath, opts);
+    // Own the created directory plus any parents the mkdir created under the
+    // home dir. Group-owned by vercel-sandbox with mode 770 so the HTTP file
+    // API can write into it (see SANDBOX_GROUP).
+    const dirs = [absPath, ...this.ancestorDirsUnderHome([absPath])];
+    await this.chownOrThrow(
+      dirs,
+      `${this.username}:${SANDBOX_GROUP}`,
+      opts?.signal,
+    );
+    await this.chmodOrThrow(dirs, "770", opts?.signal);
+  }
+
+  /**
+   * Run `chown <ownership> <paths...>` as root, throwing on failure.
+   */
+  private async chownOrThrow(
+    paths: string[],
+    ownership: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
     const chown = await this.sandbox.runCommand({
       cmd: "chown",
-      args: [`${this.username}:${this.username}`, absPath],
+      args: [ownership, ...paths],
       sudo: true,
-      signal: opts?.signal,
+      signal,
     });
     if (chown.exitCode !== 0) {
       const stderr = await chown.stderr();
-      throw new Error(`Failed to set ownership on ${absPath}: ${stderr}`);
+      throw new Error(
+        `Failed to set ownership on ${paths.join(", ")}: ${stderr}`,
+      );
     }
+  }
+
+  /**
+   * Run `chmod <mode> <paths...>` as root, throwing on failure.
+   */
+  private async chmodOrThrow(
+    paths: string[],
+    mode: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
     const chmod = await this.sandbox.runCommand({
       cmd: "chmod",
-      args: ["770", absPath],
+      args: [mode, ...paths],
       sudo: true,
-      signal: opts?.signal,
+      signal,
     });
     if (chmod.exitCode !== 0) {
       const stderr = await chmod.stderr();
-      throw new Error(`Failed to set permissions on ${absPath}: ${stderr}`);
+      throw new Error(
+        `Failed to set permissions on ${paths.join(", ")}: ${stderr}`,
+      );
     }
+  }
+
+  /**
+   * Given absolute leaf paths, return the directories strictly between this
+   * user's home directory and each leaf. The home dir itself is excluded, as
+   * are any paths that fall outside the home dir.
+   */
+  private ancestorDirsUnderHome(paths: string[]): string[] {
+    const dirs = new Set<string>();
+    const homePrefix = `${this.homeDir}/`;
+    for (const p of paths) {
+      let dir = p.slice(0, p.lastIndexOf("/"));
+      while (dir.length > this.homeDir.length && dir.startsWith(homePrefix)) {
+        dirs.add(dir);
+        dir = dir.slice(0, dir.lastIndexOf("/"));
+      }
+    }
+    return [...dirs];
   }
 
   /**

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -26,6 +26,7 @@ import { attachPaginator } from "./utils/paginator.js";
 import { setTimeout } from "node:timers/promises";
 import { FileSystem } from "./filesystem.js";
 import { SandboxUser } from "./sandbox-user.js";
+import type { ExecutionContext } from "./execution-context.js";
 import { validateName } from "./utils/validate-name.js";
 
 export type {
@@ -304,7 +305,7 @@ export interface SerializedSandbox {
  * Use {@link Sandbox.create} or {@link Sandbox.get} to construct.
  * @hideconstructor
  */
-export class Sandbox {
+export class Sandbox implements ExecutionContext {
   private _client: APIClient | null = null;
   private readonly projectId: string;
 

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -25,6 +25,8 @@ import { fromAPINetworkPolicy } from "./utils/network-policy.js";
 import { attachPaginator } from "./utils/paginator.js";
 import { setTimeout } from "node:timers/promises";
 import { FileSystem } from "./filesystem.js";
+import { SandboxUser } from "./sandbox-user.js";
+import { validateName } from "./utils/validate-name.js";
 
 export type {
   NetworkPolicy,
@@ -1345,6 +1347,238 @@ export class Sandbox {
       () => this.session!.extendTimeout(duration, opts),
       opts?.signal,
     );
+  }
+
+  /**
+   * Create a new Linux user in this sandbox with an isolated home directory.
+   *
+   * The home directory is group-owned by `vercel-sandbox` with `770` permissions,
+   * so the SDK's HTTP file API can read/write directly. Other users cannot access
+   * this user's home directory since they are not in the `vercel-sandbox` group.
+   *
+   * @param username - Linux username (lowercase letters, digits, hyphens, underscores)
+   * @param opts - Optional parameters.
+   * @param opts.signal - An AbortSignal to cancel the operation.
+   * @returns A {@link SandboxUser} instance for the created user.
+   *
+   * @example
+   * const alice = await sandbox.createUser("alice");
+   * await alice.runCommand("whoami"); // "alice"
+   * await alice.writeFiles([{ path: "hello.txt", content: Buffer.from("hi") }]);
+   */
+  async createUser(
+    username: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<SandboxUser> {
+    validateName(username, "username");
+
+    // Create user with home directory and default shell
+    const useradd = await this._runCommand({
+      cmd: "useradd",
+      args: ["-m", "-s", "/bin/bash", username],
+      sudo: true,
+      signal: opts?.signal,
+    });
+    if (useradd.exitCode !== 0) {
+      const stderr = await useradd.stderr();
+      throw new Error(`Failed to create user "${username}": ${stderr}`);
+    }
+
+    // Set home directory group to vercel-sandbox so the HTTP file API
+    // (which runs as the vercel-sandbox process) can read/write directly.
+    // This avoids the stale-group problem that occurs with usermod -aG,
+    // since vercel-sandbox already has gid=1000 in its process credentials.
+    const chown = await this._runCommand({
+      cmd: "chown",
+      args: [`${username}:vercel-sandbox`, `/home/${username}`],
+      sudo: true,
+      signal: opts?.signal,
+    });
+    if (chown.exitCode !== 0) {
+      const stderr = await chown.stderr();
+      throw new Error(
+        `Failed to set ownership on /home/${username}: ${stderr}`,
+      );
+    }
+
+    // Set home directory permissions: owner full, group (vercel-sandbox)
+    // read+write+execute, others none. Other users can't access because
+    // they are not in the vercel-sandbox group.
+    const chmod = await this._runCommand({
+      cmd: "chmod",
+      args: ["770", `/home/${username}`],
+      sudo: true,
+      signal: opts?.signal,
+    });
+    if (chmod.exitCode !== 0) {
+      const stderr = await chmod.stderr();
+      throw new Error(
+        `Failed to set permissions on /home/${username}: ${stderr}`,
+      );
+    }
+
+    return new SandboxUser({ sandbox: this, username });
+  }
+
+  /**
+   * Get a user handle without creating the user.
+   * Assumes the user already exists in the sandbox.
+   *
+   * @param username - Linux username
+   * @returns A {@link SandboxUser} instance.
+   *
+   * @example
+   * const root = sandbox.asUser("root");
+   * await root.runCommand("whoami"); // "root"
+   */
+  asUser(username: string): SandboxUser {
+    validateName(username, "username");
+    return new SandboxUser({ sandbox: this, username });
+  }
+
+  /**
+   * Create a new Linux group with a shared directory.
+   *
+   * Creates a shared directory at `/shared/<groupname>` with setgid permissions
+   * (`2770`), so files created inside it automatically inherit the group.
+   * All group members can read and write files in the shared directory.
+   *
+   * @param groupname - Group name (lowercase letters, digits, hyphens, underscores)
+   * @param opts - Optional parameters.
+   * @param opts.signal - An AbortSignal to cancel the operation.
+   * @returns An object with the group name and shared directory path.
+   *
+   * @example
+   * const devs = await sandbox.createGroup("devs");
+   * console.log(devs.sharedDir); // "/shared/devs"
+   * await sandbox.addUserToGroup("alice", "devs");
+   */
+  async createGroup(
+    groupname: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<{ groupname: string; sharedDir: string }> {
+    validateName(groupname, "group name");
+
+    const sharedDir = `/shared/${groupname}`;
+
+    // Create the group
+    const groupadd = await this._runCommand({
+      cmd: "groupadd",
+      args: [groupname],
+      sudo: true,
+      signal: opts?.signal,
+    });
+    if (groupadd.exitCode !== 0) {
+      const stderr = await groupadd.stderr();
+      throw new Error(`Failed to create group "${groupname}": ${stderr}`);
+    }
+
+    // Create shared directory
+    const mkdirResult = await this._runCommand({
+      cmd: "mkdir",
+      args: ["-p", sharedDir],
+      sudo: true,
+      signal: opts?.signal,
+    });
+    if (mkdirResult.exitCode !== 0) {
+      const stderr = await mkdirResult.stderr();
+      throw new Error(`Failed to create shared directory ${sharedDir}: ${stderr}`);
+    }
+
+    // Set ownership: vercel-sandbox user, group-owned by the new group
+    const chown = await this._runCommand({
+      cmd: "chown",
+      args: [`vercel-sandbox:${groupname}`, sharedDir],
+      sudo: true,
+      signal: opts?.signal,
+    });
+    if (chown.exitCode !== 0) {
+      const stderr = await chown.stderr();
+      throw new Error(`Failed to set ownership on ${sharedDir}: ${stderr}`);
+    }
+
+    // Set permissions: setgid (2) + rwx for owner and group, none for others
+    const chmod = await this._runCommand({
+      cmd: "chmod",
+      args: ["2770", sharedDir],
+      sudo: true,
+      signal: opts?.signal,
+    });
+    if (chmod.exitCode !== 0) {
+      const stderr = await chmod.stderr();
+      throw new Error(`Failed to set permissions on ${sharedDir}: ${stderr}`);
+    }
+
+    return { groupname, sharedDir };
+  }
+
+  /**
+   * Add a user to a group.
+   *
+   * After joining, the user can read and write files in the group's
+   * shared directory at `/shared/<groupname>`.
+   *
+   * @param username - The user to add
+   * @param groupname - The group to add the user to
+   * @param opts - Optional parameters.
+   * @param opts.signal - An AbortSignal to cancel the operation.
+   *
+   * @example
+   * await sandbox.addUserToGroup("alice", "devs");
+   */
+  async addUserToGroup(
+    username: string,
+    groupname: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<void> {
+    validateName(username, "username");
+    validateName(groupname, "group name");
+
+    const result = await this._runCommand({
+      cmd: "usermod",
+      args: ["-aG", groupname, username],
+      sudo: true,
+      signal: opts?.signal,
+    });
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      throw new Error(
+        `Failed to add "${username}" to group "${groupname}": ${stderr}`,
+      );
+    }
+  }
+
+  /**
+   * Remove a user from a group.
+   *
+   * @param username - The user to remove
+   * @param groupname - The group to remove the user from
+   * @param opts - Optional parameters.
+   * @param opts.signal - An AbortSignal to cancel the operation.
+   *
+   * @example
+   * await sandbox.removeUserFromGroup("alice", "devs");
+   */
+  async removeUserFromGroup(
+    username: string,
+    groupname: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<void> {
+    validateName(username, "username");
+    validateName(groupname, "group name");
+
+    const result = await this._runCommand({
+      cmd: "gpasswd",
+      args: ["-d", username, groupname],
+      sudo: true,
+      signal: opts?.signal,
+    });
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      throw new Error(
+        `Failed to remove "${username}" from group "${groupname}": ${stderr}`,
+      );
+    }
   }
 
   /**

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -330,6 +330,12 @@ export class Sandbox implements ExecutionContext {
   private readonly onResume?: (sandbox: Sandbox) => Promise<void>;
 
   /**
+   * Memoized lookup of the sandbox's default user and its primary group.
+   * See {@link Sandbox.getDefaultUser}.
+   */
+  private defaultUserPromise?: Promise<{ username: string; group: string }>;
+
+  /**
    * A `node:fs/promises`-compatible API for interacting with the sandbox filesystem.
    *
    * @example
@@ -1351,11 +1357,58 @@ export class Sandbox implements ExecutionContext {
   }
 
   /**
+   * The user that non-`sudo` commands and the HTTP file API run as, together
+   * with that user's primary group. This depends on the sandbox image: stock
+   * runtimes default to `vercel-sandbox`, while Ubuntu-based images default to
+   * `root`. The multi-user helpers group-own home and shared directories by
+   * this user's group so the file API can traverse them, so we resolve it from
+   * the running sandbox rather than assuming a fixed name.
+   *
+   * The result is memoized for the lifetime of this instance.
+   *
+   * @internal
+   */
+  getDefaultUser(opts?: {
+    signal?: AbortSignal;
+  }): Promise<{ username: string; group: string }> {
+    if (!this.defaultUserPromise) {
+      this.defaultUserPromise = this.resolveDefaultUser(opts).catch((err) => {
+        // Don't cache failures — allow a later call to retry.
+        this.defaultUserPromise = undefined;
+        throw err;
+      });
+    }
+    return this.defaultUserPromise;
+  }
+
+  private async resolveDefaultUser(opts?: {
+    signal?: AbortSignal;
+  }): Promise<{ username: string; group: string }> {
+    const result = await this.runCommand({
+      cmd: "sh",
+      args: ["-c", "id -un; id -gn"],
+      signal: opts?.signal,
+    });
+    if (result.exitCode !== 0) {
+      const stderr = await result.stderr();
+      throw new Error(`Failed to resolve the default sandbox user: ${stderr}`);
+    }
+    const [username, group] = (await result.stdout()).trim().split("\n");
+    if (!username || !group) {
+      throw new Error(
+        `Failed to resolve the default sandbox user (got "${username}:${group}")`,
+      );
+    }
+    return { username, group };
+  }
+
+  /**
    * Create a new Linux user in this sandbox with an isolated home directory.
    *
-   * The home directory is group-owned by `vercel-sandbox` with `770` permissions,
-   * so the SDK's HTTP file API can read/write directly. Other users cannot access
-   * this user's home directory since they are not in the `vercel-sandbox` group.
+   * The home directory is group-owned by the sandbox's default user group with
+   * `770` permissions, so the SDK's HTTP file API can read/write directly.
+   * Other users cannot access this user's home directory since they are not in
+   * that group.
    *
    * @param username - Linux username (lowercase letters, digits, hyphens, underscores)
    * @param opts - Optional parameters.
@@ -1373,6 +1426,8 @@ export class Sandbox implements ExecutionContext {
   ): Promise<SandboxUser> {
     validateName(username, "username");
 
+    const { group: defaultGroup } = await this.getDefaultUser(opts);
+
     // Create user with home directory and default shell
     const useradd = await this.runCommand({
       cmd: "useradd",
@@ -1385,13 +1440,14 @@ export class Sandbox implements ExecutionContext {
       throw new Error(`Failed to create user "${username}": ${stderr}`);
     }
 
-    // Set home directory group to vercel-sandbox so the HTTP file API
-    // (which runs as the vercel-sandbox process) can read/write directly.
-    // This avoids the stale-group problem that occurs with usermod -aG,
-    // since vercel-sandbox already has gid=1000 in its process credentials.
+    // Group-own the home directory by the default user's group so the HTTP
+    // file API (which runs as that user) can read/write directly. On stock
+    // runtimes this is `vercel-sandbox` (gid 1000, already in the file API
+    // process credentials, avoiding the stale-group problem of `usermod -aG`);
+    // on Ubuntu images it is `root`, which can traverse regardless.
     const chown = await this.runCommand({
       cmd: "chown",
-      args: [`${username}:vercel-sandbox`, `/home/${username}`],
+      args: [`${username}:${defaultGroup}`, `/home/${username}`],
       sudo: true,
       signal: opts?.signal,
     });
@@ -1402,9 +1458,9 @@ export class Sandbox implements ExecutionContext {
       );
     }
 
-    // Set home directory permissions: owner full, group (vercel-sandbox)
-    // read+write+execute, others none. Other users can't access because
-    // they are not in the vercel-sandbox group.
+    // Set home directory permissions: owner full, group (the default user's
+    // group) read+write+execute, others none. Other users can't access
+    // because they are not in that group.
     const chmod = await this.runCommand({
       cmd: "chmod",
       args: ["770", `/home/${username}`],
@@ -1460,6 +1516,8 @@ export class Sandbox implements ExecutionContext {
   ): Promise<{ groupname: string; sharedDir: string }> {
     validateName(groupname, "group name");
 
+    const { username: defaultUser } = await this.getDefaultUser(opts);
+
     const sharedDir = `/shared/${groupname}`;
 
     // Create the group
@@ -1486,10 +1544,11 @@ export class Sandbox implements ExecutionContext {
       throw new Error(`Failed to create shared directory ${sharedDir}: ${stderr}`);
     }
 
-    // Set ownership: vercel-sandbox user, group-owned by the new group
+    // Set ownership: the default user (so the HTTP file API can write into the
+    // shared dir), group-owned by the new group.
     const chown = await this.runCommand({
       cmd: "chown",
-      args: [`vercel-sandbox:${groupname}`, sharedDir],
+      args: [`${defaultUser}:${groupname}`, sharedDir],
       sudo: true,
       signal: opts?.signal,
     });

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -1431,7 +1431,7 @@ export class Sandbox {
    * const root = sandbox.asUser("root");
    * await root.runCommand("whoami"); // "root"
    */
-  asUser(username: string): SandboxUser {
+  asUser(username: "root" | (string & {})): SandboxUser {
     validateName(username, "username");
     return new SandboxUser({ sandbox: this, username });
   }

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -1373,7 +1373,7 @@ export class Sandbox {
     validateName(username, "username");
 
     // Create user with home directory and default shell
-    const useradd = await this._runCommand({
+    const useradd = await this.runCommand({
       cmd: "useradd",
       args: ["-m", "-s", "/bin/bash", username],
       sudo: true,
@@ -1388,7 +1388,7 @@ export class Sandbox {
     // (which runs as the vercel-sandbox process) can read/write directly.
     // This avoids the stale-group problem that occurs with usermod -aG,
     // since vercel-sandbox already has gid=1000 in its process credentials.
-    const chown = await this._runCommand({
+    const chown = await this.runCommand({
       cmd: "chown",
       args: [`${username}:vercel-sandbox`, `/home/${username}`],
       sudo: true,
@@ -1404,7 +1404,7 @@ export class Sandbox {
     // Set home directory permissions: owner full, group (vercel-sandbox)
     // read+write+execute, others none. Other users can't access because
     // they are not in the vercel-sandbox group.
-    const chmod = await this._runCommand({
+    const chmod = await this.runCommand({
       cmd: "chmod",
       args: ["770", `/home/${username}`],
       sudo: true,
@@ -1462,7 +1462,7 @@ export class Sandbox {
     const sharedDir = `/shared/${groupname}`;
 
     // Create the group
-    const groupadd = await this._runCommand({
+    const groupadd = await this.runCommand({
       cmd: "groupadd",
       args: [groupname],
       sudo: true,
@@ -1474,7 +1474,7 @@ export class Sandbox {
     }
 
     // Create shared directory
-    const mkdirResult = await this._runCommand({
+    const mkdirResult = await this.runCommand({
       cmd: "mkdir",
       args: ["-p", sharedDir],
       sudo: true,
@@ -1486,7 +1486,7 @@ export class Sandbox {
     }
 
     // Set ownership: vercel-sandbox user, group-owned by the new group
-    const chown = await this._runCommand({
+    const chown = await this.runCommand({
       cmd: "chown",
       args: [`vercel-sandbox:${groupname}`, sharedDir],
       sudo: true,
@@ -1498,7 +1498,7 @@ export class Sandbox {
     }
 
     // Set permissions: setgid (2) + rwx for owner and group, none for others
-    const chmod = await this._runCommand({
+    const chmod = await this.runCommand({
       cmd: "chmod",
       args: ["2770", sharedDir],
       sudo: true,
@@ -1534,7 +1534,7 @@ export class Sandbox {
     validateName(username, "username");
     validateName(groupname, "group name");
 
-    const result = await this._runCommand({
+    const result = await this.runCommand({
       cmd: "usermod",
       args: ["-aG", groupname, username],
       sudo: true,
@@ -1567,7 +1567,7 @@ export class Sandbox {
     validateName(username, "username");
     validateName(groupname, "group name");
 
-    const result = await this._runCommand({
+    const result = await this.runCommand({
       cmd: "gpasswd",
       args: ["-d", username, groupname],
       sudo: true,

--- a/packages/vercel-sandbox/src/session.ts
+++ b/packages/vercel-sandbox/src/session.ts
@@ -15,6 +15,7 @@ import type {
 } from "./network-policy.js";
 import { toSandboxSnapshot, type SandboxSnapshot } from "./utils/sandbox-snapshot.js";
 import { getCredentials } from "./utils/get-credentials.js";
+import type { ExecutionContext } from "./execution-context.js";
 
 export type { NetworkPolicy, NetworkPolicyRule, NetworkTransformer };
 
@@ -77,7 +78,7 @@ export interface RunCommandParams {
  *
  * Obtain a session via {@link Sandbox.currentSession}.
  */
-export class Session {
+export class Session implements ExecutionContext {
   private _client: APIClient | null = null;
 
   /**

--- a/packages/vercel-sandbox/src/utils/validate-name.test.ts
+++ b/packages/vercel-sandbox/src/utils/validate-name.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { validateName } from "./validate-name.js";
+
+describe("validateName", () => {
+  it("accepts valid names", () => {
+    expect(() => validateName("alice", "username")).not.toThrow();
+    expect(() => validateName("_user", "username")).not.toThrow();
+    expect(() => validateName("user-name", "username")).not.toThrow();
+    expect(() => validateName("user_123", "username")).not.toThrow();
+    expect(() => validateName("a", "username")).not.toThrow();
+    expect(() => validateName("a".repeat(32), "username")).not.toThrow();
+    expect(() => validateName("devs", "group name")).not.toThrow();
+  });
+
+  it("rejects empty names", () => {
+    expect(() => validateName("", "username")).toThrow("must not be empty");
+  });
+
+  it("rejects names longer than 32 characters", () => {
+    expect(() => validateName("a".repeat(33), "username")).toThrow(
+      "must be at most 32 characters",
+    );
+  });
+
+  it("rejects names with an invalid regex", () => {
+    expect(() => validateName("INVALID_REGEX", "username")).toThrow("Invalid username");
+  });
+
+  it("rejects names that do not start with a letter or underscore", () => {
+    expect(() => validateName("1user", "username")).toThrow("Invalid username");
+    expect(() => validateName("-user", "username")).toThrow("Invalid username");
+  });
+});

--- a/packages/vercel-sandbox/src/utils/validate-name.ts
+++ b/packages/vercel-sandbox/src/utils/validate-name.ts
@@ -1,0 +1,22 @@
+const VALID_NAME_RE = /^[a-z_][a-z0-9_-]*$/;
+const MAX_NAME_LENGTH = 32;
+
+/**
+ * Validate a Linux username or group name.
+ * Throws if the name is invalid or could be used for command injection.
+ */
+export function validateName(name: string, kind: "username" | "group name") {
+  if (!name) {
+    throw new Error(`Invalid ${kind}: must not be empty`);
+  }
+  if (name.length > MAX_NAME_LENGTH) {
+    throw new Error(
+      `Invalid ${kind} "${name}": must be at most ${MAX_NAME_LENGTH} characters`,
+    );
+  }
+  if (!VALID_NAME_RE.test(name)) {
+    throw new Error(
+      `Invalid ${kind} "${name}": must match ${VALID_NAME_RE} (lowercase letters, digits, hyphens, underscores)`,
+    );
+  }
+}

--- a/skills/sandbox/SKILL.md
+++ b/skills/sandbox/SKILL.md
@@ -379,6 +379,94 @@ const files = await sandbox.fs.readdir("/tmp");
 const stats = await sandbox.fs.stat("/tmp/hello.txt");
 ```
 
+## Multi-User and Groups
+
+Create isolated Linux users and shared groups inside a sandbox. This is purely
+SDK-side and is useful for isolating multiple agents or workloads within a single
+sandbox. Usernames and group names are validated to prevent command injection.
+
+### Creating Users
+
+`createUser` provisions a Linux user with an isolated home directory at
+`/home/<username>` and returns a `SandboxUser` whose operations run in that
+user's context.
+
+```typescript
+const alice = await sandbox.createUser("alice");
+alice.username; // "alice"
+alice.homeDir; // "/home/alice"
+
+// Commands run as alice; cwd defaults to /home/alice
+const whoami = await alice.runCommand("whoami");
+await whoami.stdout(); // "alice\n"
+
+// Env vars, custom cwd, sudo escalation, and detached mode all work
+await alice.runCommand({
+  cmd: "node",
+  args: ["-e", "console.log(process.env.SECRET)"],
+  env: { SECRET: "hunter2" },
+});
+await alice.runCommand({
+  cmd: "dnf",
+  args: ["install", "-y", "git"],
+  sudo: true,
+});
+const server = await alice.runCommand({
+  cmd: "node",
+  args: ["server.js"],
+  detached: true,
+});
+```
+
+Get a handle to a pre-existing user (e.g. `root`) without creating it:
+
+```typescript
+const existing = sandbox.asUser("bob");
+await existing.runCommand("whoami");
+```
+
+### File Operations Scoped to a User
+
+Relative paths resolve against the user's home directory and files are owned by
+that user. Absolute paths are also supported.
+
+```typescript
+// Written to /home/alice, owned by alice:alice
+await alice.writeFiles([
+  { path: "app.js", content: Buffer.from('console.log("hi")') },
+  { path: "data/config.json", content: Buffer.from("{}") },
+]);
+
+const buf = await alice.readFileToBuffer({ path: "app.js" });
+const stream = await alice.readFile({ path: "app.js" });
+await alice.mkDir("projects/my-app");
+```
+
+Files are isolated between users — one user cannot read, list, or write another
+user's home directory (commands return a non-zero exit code with "Permission
+denied").
+
+### Groups and Shared Directories
+
+`createGroup` creates a Linux group with a shared directory at
+`/shared/<groupname>` (setgid `2770`), so files created inside it automatically
+inherit group ownership. Group members can read and write there; non-members
+are blocked.
+
+```typescript
+const devs = await sandbox.createGroup("devs");
+devs.sharedDir; // "/shared/devs"
+
+await sandbox.addUserToGroup("alice", "devs");
+await sandbox.addUserToGroup("bob", "devs");
+
+// Or via convenience methods on SandboxUser
+await alice.addToGroup("devs");
+await alice.removeFromGroup("devs");
+
+await sandbox.removeUserFromGroup("alice", "devs");
+```
+
 ## Network Policy
 
 ### Full Internet Access (Default)


### PR DESCRIPTION
Adds `createUser`, `asUser`, `createGroup`, `addUserToGroup`, and `removeUserFromGroup` to the `Sandbox` class, plus a new `SandboxUser` class that wraps sandbox operations to run in a specific user's context.

## Creating users and running commands

```ts
import { Sandbox } from '@vercel/sandbox';

const sandbox = await Sandbox.create();

// Create a user with isolated home directory at /home/alice
const alice = await sandbox.createUser("alice");
alice.username; // "alice"
alice.homeDir;  // "/home/alice"

// Commands run as alice, cwd defaults to /home/alice
const whoami = await alice.runCommand("whoami");
await whoami.stdout(); // "alice\n"

const pwd = await alice.runCommand("pwd");
await pwd.stdout(); // "/home/alice\n"

// Pass environment variables
const cmd = await alice.runCommand({
  cmd: "node",
  args: ["-e", "console.log(process.env.SECRET)"],
  env: { SECRET: "hunter2" },
});

// Override working directory
await alice.runCommand({ cmd: "ls", cwd: "/tmp" });

// Escalate to root when needed
await alice.runCommand({
  cmd: "dnf",
  args: ["install", "-y", "git"],
  sudo: true,
});

// Detached mode for long-running processes
const server = await alice.runCommand({
  cmd: "node",
  args: ["server.js"],
  detached: true,
});
// ... later
await server.kill("SIGTERM");
```

## File operations scoped to the user

```ts
const alice = await sandbox.createUser("alice");

// Relative paths resolve to /home/alice, files owned by alice:alice
await alice.writeFiles([
  { path: "app.js", content: Buffer.from('console.log("hi")') },
  { path: "data/config.json", content: Buffer.from("{}") },
]);

// Read files back
const buf = await alice.readFileToBuffer({ path: "app.js" });
buf?.toString(); // 'console.log("hi")'

// Stream reads
const stream = await alice.readFile({ path: "app.js" });

// Absolute paths work too
await alice.writeFiles([
  { path: "/opt/alice/data.bin", content: Buffer.from([0x00, 0xff]) },
]);

// Create directories owned by the user
await alice.mkDir("projects/my-app");
```

## File isolation between users

```ts
const alice = await sandbox.createUser("alice");
const bob = await sandbox.createUser("bob");

await alice.writeFiles([
  { path: "secret.txt", content: Buffer.from("alice only") },
]);

// Bob cannot read alice's files
const cat = await bob.runCommand({
  cmd: "cat",
  args: ["/home/alice/secret.txt"],
});
cat.exitCode; // non-zero, Permission denied

// Bob cannot list alice's home directory
const ls = await bob.runCommand({ cmd: "ls", args: ["/home/alice"] });
ls.exitCode; // non-zero, Permission denied

// Bob cannot write to alice's home directory
const touch = await bob.runCommand({
  cmd: "touch",
  args: ["/home/alice/hacked.txt"],
});
touch.exitCode; // non-zero

// Each user reads their own files normally
const content = await alice.readFileToBuffer({ path: "secret.txt" });
content?.toString(); // "alice only"
```

## Group management with shared directories

```ts
// Create a group with shared dir at /shared/devs (setgid 2770)
const devs = await sandbox.createGroup("devs");
devs.sharedDir; // "/shared/devs"

// Add users to the group
await sandbox.addUserToGroup("alice", "devs");
await sandbox.addUserToGroup("bob", "devs");

// Or use convenience methods on SandboxUser
await alice.addToGroup("devs");

// Files in the shared dir automatically inherit group ownership
await alice.runCommand({
  cmd: "bash",
  args: ["-c", 'echo "shared data" > /shared/devs/notes.txt'],
});

const notes = await bob.runCommand({
  cmd: "cat",
  args: ["/shared/devs/notes.txt"],
});
await notes.stdout(); // "shared data\n"

// Non-members are blocked
const charlie = await sandbox.createUser("charlie");
const blocked = await charlie.runCommand({
  cmd: "ls",
  args: ["/shared/devs"],
});
blocked.exitCode; // non-zero, Permission denied

// Remove from group revokes access
await sandbox.removeUserFromGroup("alice", "devs");
```

## Using asUser for pre-existing users

```ts
const existing = sandbox.asUser("bob");
await existing.runCommand("whoami");
```

## Multi-user AI agent example

```ts
const sandbox = await Sandbox.create();

const researcher = await sandbox.createUser("researcher");
const coder = await sandbox.createUser("coder");
const reviewer = await sandbox.createUser("reviewer");

await sandbox.createGroup("project");
await sandbox.addUserToGroup("researcher", "project");
await sandbox.addUserToGroup("coder", "project");
await sandbox.addUserToGroup("reviewer", "project");

// Researcher writes findings to shared dir
await researcher.runCommand({
  cmd: "bash",
  args: ["-c", 'echo "API spec v2" > /shared/project/spec.txt'],
});

// Coder reads spec and writes code in their own home
const spec = await coder.runCommand({
  cmd: "cat",
  args: ["/shared/project/spec.txt"],
});
await coder.writeFiles([
  { path: "app.js", content: Buffer.from(`// Based on: ${await spec.stdout()}`) },
]);

// Reviewer can read the shared spec but not coder's private files
const blocked = await reviewer.runCommand({
  cmd: "cat",
  args: ["/home/coder/app.js"],
});
blocked.exitCode; // non-zero, isolation enforced
```

## Implementation notes

- Purely SDK-side, no backend API changes. Uses `runCommand` with `sudo` under the hood.
- Command wrapping: `sudo -u <user> -- bash -c 'cd <dir> && exec "$@"' _ <cmd> <args>`
- `writeFiles` stages to `/tmp` then `sudo mv` + `chown` (backend tar extraction can't write to user home dirs).
- `readFile`/`readFileToBuffer` use `sudo cat` (backend read process can't traverse user home dirs).
- `mkDir` uses `sudo mkdir` for the same reason.
- Username/group validation prevents command injection.
- Home dirs: `770`, `vercel-sandbox` added to each user's group.
- Shared group dirs: setgid `2770`, files inherit group ownership.