### PR TITLE
fix: smarter fallback team selection for scope inference

### DIFF
--- a/.changeset/slick-lands-repeat.md
+++ b/.changeset/slick-lands-repeat.md
@@ -2,4 +2,4 @@
 "@vercel/sandbox": patch
 ---
 
-Smarter fallback team selection for scope inference: tries `defaultTeamId` first, then the best OWNER team (personal team or most recently updated). Skips teams that return 403 and shows a helpful error when no team allows sandbox creation.
+Smarter fallback team selection for scope inference: tries `defaultTeamId` first, then the best hobby-plan OWNER team (personal team or most recently updated). Filters fallback candidates by `billing.plan === 'hobby'` to avoid selecting pro/enterprise teams. Skips teams that return 403 and shows a helpful error when no team allows sandbox creation.

--- a/.changeset/slick-lands-repeat.md
+++ b/.changeset/slick-lands-repeat.md
@@ -1,5 +1,6 @@
 ---
 "@vercel/sandbox": patch
+"@vercel/vercel-sandbox": patch
 ---
 
 Smarter fallback team selection for scope inference: tries `defaultTeamId` first, then the best hobby-plan OWNER team (personal team or most recently updated). Filters fallback candidates by `billing.plan === 'hobby'` to avoid selecting pro/enterprise teams. Skips teams that return 403 and shows a helpful error when no team allows sandbox creation.

--- a/.changeset/slick-lands-repeat.md
+++ b/.changeset/slick-lands-repeat.md
@@ -2,4 +2,4 @@
 "@vercel/sandbox": patch
 ---
 
-Use the user's default team (`defaultTeamId`) for scope inference fallback instead of picking the first team from `/v2/teams`.
+Smarter fallback team selection for scope inference: tries `defaultTeamId` first, then the best OWNER team (personal team or most recently updated). Skips teams that return 403 and shows a helpful error when no team allows sandbox creation.

--- a/.changeset/slick-lands-repeat.md
+++ b/.changeset/slick-lands-repeat.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Use the user's default team (`defaultTeamId`) for scope inference fallback instead of picking the first team from `/v2/teams`.

--- a/packages/sandbox/src/commands/login.ts
+++ b/packages/sandbox/src/commands/login.ts
@@ -4,7 +4,12 @@ import { output } from "../util/output";
 import { default as open } from "open";
 import ora from "ora";
 import { acquireRelease } from "../util/disposables";
-import { OAuth, pollForToken } from "@vercel/sandbox/dist/auth/index.js";
+import {
+  OAuth,
+  pollForToken,
+  getAuth,
+  inferScope,
+} from "@vercel/sandbox/dist/auth/index.js";
 import createDebugger from "debug";
 
 const debug = createDebugger("sandbox:login");
@@ -108,6 +113,30 @@ export const login = cmd.command({
       spinner.succeed(
         `${chalk.cyan("Congratulations!")} You are now signed in.`,
       );
+
+      const auth = getAuth();
+      if (auth?.token) {
+        try {
+          const { teamId, teamSlug, projectId, projectSlug } =
+            await inferScope({
+              token: auth.token,
+            });
+          process.stderr.write(
+            chalk.dim("   │ ") +
+              "team: " +
+              chalk.cyan(teamSlug ?? teamId) +
+              "\n",
+          );
+          process.stderr.write(
+            chalk.dim("   ╰ ") +
+              "project: " +
+              chalk.cyan(projectSlug ?? projectId) +
+              "\n",
+          );
+        } catch {
+          // Scope inference is best-effort; don't fail the login
+        }
+      }
     }
   },
 });

--- a/packages/sandbox/src/util/infer-scope.ts
+++ b/packages/sandbox/src/util/infer-scope.ts
@@ -72,15 +72,14 @@ async function inferFromJwt(jwt: string) {
 }
 
 async function inferFromToken(token: string, requestedTeam?: string) {
-  const { teamId, projectId } = await Auth.inferScope({
+  const { teamId, teamSlug, projectId, projectSlug } = await Auth.inferScope({
     token,
     teamId: requestedTeam,
   });
-  // Auth.inferScope returns team slug and project name (not IDs).
   return {
     owner: teamId,
     project: projectId,
-    ownerSlug: teamId,
-    projectSlug: projectId,
+    ownerSlug: teamSlug ?? teamId,
+    projectSlug: projectSlug ?? projectId,
   };
 }

--- a/packages/vercel-sandbox/src/auth/index.ts
+++ b/packages/vercel-sandbox/src/auth/index.ts
@@ -6,4 +6,4 @@ export type * from "./file.js";
 export * from "./oauth.js";
 export type * from "./oauth.js";
 export { pollForToken } from "./poll-for-token.js";
-export { inferScope, selectTeams } from "./project.js";
+export { inferScope } from "./project.js";

--- a/packages/vercel-sandbox/src/auth/index.ts
+++ b/packages/vercel-sandbox/src/auth/index.ts
@@ -6,4 +6,4 @@ export type * from "./file.js";
 export * from "./oauth.js";
 export type * from "./oauth.js";
 export { pollForToken } from "./poll-for-token.js";
-export { inferScope, selectTeam } from "./project.js";
+export { inferScope, selectTeams } from "./project.js";

--- a/packages/vercel-sandbox/src/auth/infer-scope.test.ts
+++ b/packages/vercel-sandbox/src/auth/infer-scope.test.ts
@@ -402,6 +402,46 @@ describe("inferScope", () => {
       });
     });
 
+    test("falls back to hobby owner team when defaultTeamId returns 402 RESOURCE_CREATION_BLOCKED", async () => {
+      fetchApiMock.mockImplementation(async ({ endpoint }) => {
+        if (endpoint === "/v2/user") {
+          return {
+            user: { defaultTeamId: "team_blocked", username: "my-user" },
+          };
+        }
+        if (endpoint.startsWith("/v2/teams")) {
+          return {
+            teams: [
+              {
+                id: "team_writable",
+                slug: "my-user",
+                updatedAt: 100,
+                membership: { role: "OWNER" },
+                billing: { plan: "hobby" },
+              },
+            ],
+            pagination: { count: 1, next: null },
+          };
+        }
+        // 402 for the blocked team (RESOURCE_CREATION_BLOCKED)
+        if (endpoint.includes("teamId=team_blocked")) {
+          throw new NotOk({
+            statusCode: 402,
+            responseText: "RESOURCE_CREATION_BLOCKED: Your Team encountered an unknown problem.",
+          });
+        }
+        return {};
+      });
+
+      const scope = await inferScope({ token: "token" });
+      expect(scope).toEqual({
+        created: false,
+        projectId: "vercel-sandbox-default-project",
+        teamId: "team_writable",
+        teamSlug: "my-user",
+      });
+    });
+
     test("tries next candidate when project creation returns 403", async () => {
       fetchApiMock.mockImplementation(async ({ endpoint, method }) => {
         if (endpoint === "/v2/user") {

--- a/packages/vercel-sandbox/src/auth/infer-scope.test.ts
+++ b/packages/vercel-sandbox/src/auth/infer-scope.test.ts
@@ -28,15 +28,23 @@ async function getTempDir(): Promise<string> {
 }
 
 describe("selectTeam", () => {
-  test("returns the user's username as the personal team slug", async () => {
+  test("returns defaultTeamId when set", async () => {
     fetchApiMock.mockResolvedValue({
-      user: { username: "my-user" },
+      user: { defaultTeamId: "team_abc123", username: "my-user" },
     });
     const team = await selectTeam("token");
     expect(fetchApiMock).toHaveBeenCalledWith({
       endpoint: "/v2/user",
       token: "token",
     });
+    expect(team).toBe("team_abc123");
+  });
+
+  test("falls back to username when defaultTeamId is null", async () => {
+    fetchApiMock.mockResolvedValue({
+      user: { defaultTeamId: null, username: "my-user" },
+    });
+    const team = await selectTeam("token");
     expect(team).toBe("my-user");
   });
 });
@@ -95,10 +103,10 @@ describe("inferScope", () => {
     });
   });
 
-  test("infers the team from the user's username", async () => {
+  test("infers the team from the user's defaultTeamId", async () => {
     fetchApiMock.mockImplementation(async ({ endpoint }) => {
       if (endpoint === "/v2/user") {
-        return { user: { username: "inferred-user" } };
+        return { user: { defaultTeamId: "team_default", username: "my-user" } };
       }
       return {};
     });
@@ -106,7 +114,7 @@ describe("inferScope", () => {
     expect(scope).toEqual({
       created: false,
       projectId: "vercel-sandbox-default-project",
-      teamId: "inferred-user",
+      teamId: "team_default",
     });
   });
 

--- a/packages/vercel-sandbox/src/auth/infer-scope.test.ts
+++ b/packages/vercel-sandbox/src/auth/infer-scope.test.ts
@@ -291,7 +291,7 @@ describe("inferScope", () => {
           };
         }
         // Project check: 403 for readonly default team, success for owner team
-        if (endpoint.includes("slug=team_readonly")) {
+        if (endpoint.includes("teamId=team_readonly")) {
           throw new NotOk({ statusCode: 403, responseText: "Forbidden" });
         }
         return {};
@@ -364,7 +364,7 @@ describe("inferScope", () => {
           return { teams: [] };
         }
         if (
-          endpoint.includes("slug=team_default") &&
+          endpoint.includes("teamId=team_default") &&
           (!method || method === "GET")
         ) {
           throw new NotOk({ statusCode: 404, responseText: "Not Found" });
@@ -400,7 +400,7 @@ describe("inferScope", () => {
           };
         }
         // team_nocreate: project check 404, project creation 403
-        if (endpoint.includes("slug=team_nocreate")) {
+        if (endpoint.includes("teamId=team_nocreate")) {
           if (!method || method === "GET") {
             throw new NotOk({ statusCode: 404, responseText: "Not Found" });
           }

--- a/packages/vercel-sandbox/src/auth/infer-scope.test.ts
+++ b/packages/vercel-sandbox/src/auth/infer-scope.test.ts
@@ -28,16 +28,16 @@ async function getTempDir(): Promise<string> {
 }
 
 describe("selectTeam", () => {
-  test("returns the first team", async () => {
+  test("returns the user's username as the personal team slug", async () => {
     fetchApiMock.mockResolvedValue({
-      teams: [{ slug: "one" }, { slug: "two" }],
+      user: { username: "my-user" },
     });
     const team = await selectTeam("token");
     expect(fetchApiMock).toHaveBeenCalledWith({
-      endpoint: "/v2/teams?limit=1",
+      endpoint: "/v2/user",
       token: "token",
     });
-    expect(team).toBe("one");
+    expect(team).toBe("my-user");
   });
 });
 
@@ -95,10 +95,10 @@ describe("inferScope", () => {
     });
   });
 
-  test("infers the team", async () => {
+  test("infers the team from the user's username", async () => {
     fetchApiMock.mockImplementation(async ({ endpoint }) => {
-      if (endpoint === "/v2/teams?limit=1") {
-        return { teams: [{ slug: "inferred-team" }] };
+      if (endpoint === "/v2/user") {
+        return { user: { username: "inferred-user" } };
       }
       return {};
     });
@@ -106,7 +106,7 @@ describe("inferScope", () => {
     expect(scope).toEqual({
       created: false,
       projectId: "vercel-sandbox-default-project",
-      teamId: "inferred-team",
+      teamId: "inferred-user",
     });
   });
 

--- a/packages/vercel-sandbox/src/auth/infer-scope.test.ts
+++ b/packages/vercel-sandbox/src/auth/infer-scope.test.ts
@@ -1,4 +1,4 @@
-import { inferScope, selectTeam } from "./project.js";
+import { inferScope, selectTeams } from "./project.js";
 import {
   beforeEach,
   describe,
@@ -27,25 +27,192 @@ async function getTempDir(): Promise<string> {
   return dir;
 }
 
-describe("selectTeam", () => {
-  test("returns defaultTeamId when set", async () => {
-    fetchApiMock.mockResolvedValue({
-      user: { defaultTeamId: "team_abc123", username: "my-user" },
-    });
-    const team = await selectTeam("token");
-    expect(fetchApiMock).toHaveBeenCalledWith({
-      endpoint: "/v2/user",
-      token: "token",
-    });
-    expect(team).toBe("team_abc123");
+function mockUserAndTeams({
+  defaultTeamId = null as string | null,
+  username = "my-user",
+  teams = [] as Array<{
+    id: string;
+    slug: string;
+    updatedAt: number;
+    membership: { role: string };
+  }>,
+} = {}) {
+  return (opts: { endpoint: string }) => {
+    if (opts.endpoint === "/v2/user") {
+      return Promise.resolve({ user: { defaultTeamId, username } });
+    }
+    if (opts.endpoint.startsWith("/v2/teams")) {
+      return Promise.resolve({ teams });
+    }
+    return Promise.resolve({});
+  };
+}
+
+describe("selectTeams", () => {
+  test("returns defaultTeamId first, then best owner team", async () => {
+    fetchApiMock.mockImplementation(
+      mockUserAndTeams({
+        defaultTeamId: "team_default",
+        username: "my-user",
+        teams: [
+          {
+            id: "team_default",
+            slug: "default-team",
+            updatedAt: 100,
+            membership: { role: "OWNER" },
+          },
+          {
+            id: "team_other",
+            slug: "other-team",
+            updatedAt: 200,
+            membership: { role: "OWNER" },
+          },
+        ],
+      }),
+    );
+
+    const result = await selectTeams("token");
+    // defaultTeamId is also the best owner match, so only one candidate
+    expect(result.candidateTeamIds).toEqual(["team_default", "team_other"]);
+    expect(result.username).toBe("my-user");
   });
 
-  test("falls back to username when defaultTeamId is null", async () => {
-    fetchApiMock.mockResolvedValue({
-      user: { defaultTeamId: null, username: "my-user" },
-    });
-    const team = await selectTeam("token");
-    expect(team).toBe("my-user");
+  test("prefers personal team (matching username slug) over most recently updated", async () => {
+    fetchApiMock.mockImplementation(
+      mockUserAndTeams({
+        defaultTeamId: null,
+        username: "my-user",
+        teams: [
+          {
+            id: "team_other",
+            slug: "other-team",
+            updatedAt: 300,
+            membership: { role: "OWNER" },
+          },
+          {
+            id: "team_personal",
+            slug: "my-user",
+            updatedAt: 100,
+            membership: { role: "OWNER" },
+          },
+        ],
+      }),
+    );
+
+    const result = await selectTeams("token");
+    expect(result.candidateTeamIds).toEqual(["team_personal"]);
+  });
+
+  test("picks most recently updated owner team when no username match", async () => {
+    fetchApiMock.mockImplementation(
+      mockUserAndTeams({
+        defaultTeamId: null,
+        username: "my-user",
+        teams: [
+          {
+            id: "team_old",
+            slug: "old-team",
+            updatedAt: 100,
+            membership: { role: "OWNER" },
+          },
+          {
+            id: "team_recent",
+            slug: "recent-team",
+            updatedAt: 300,
+            membership: { role: "OWNER" },
+          },
+        ],
+      }),
+    );
+
+    const result = await selectTeams("token");
+    expect(result.candidateTeamIds).toEqual(["team_recent"]);
+  });
+
+  test("filters out non-OWNER teams", async () => {
+    fetchApiMock.mockImplementation(
+      mockUserAndTeams({
+        defaultTeamId: null,
+        username: "my-user",
+        teams: [
+          {
+            id: "team_owner",
+            slug: "owner-team",
+            updatedAt: 100,
+            membership: { role: "OWNER" },
+          },
+          {
+            id: "team_member",
+            slug: "member-team",
+            updatedAt: 200,
+            membership: { role: "MEMBER" },
+          },
+        ],
+      }),
+    );
+
+    const result = await selectTeams("token");
+    expect(result.candidateTeamIds).toEqual(["team_owner"]);
+  });
+
+  test("falls back to username when no teams and no defaultTeamId", async () => {
+    fetchApiMock.mockImplementation(
+      mockUserAndTeams({
+        defaultTeamId: null,
+        username: "my-user",
+        teams: [],
+      }),
+    );
+
+    const result = await selectTeams("token");
+    expect(result.candidateTeamIds).toEqual(["my-user"]);
+  });
+
+  test("does not duplicate defaultTeamId when it matches best owner team", async () => {
+    fetchApiMock.mockImplementation(
+      mockUserAndTeams({
+        defaultTeamId: "team_abc",
+        username: "my-user",
+        teams: [
+          {
+            id: "team_abc",
+            slug: "abc-team",
+            updatedAt: 100,
+            membership: { role: "OWNER" },
+          },
+        ],
+      }),
+    );
+
+    const result = await selectTeams("token");
+    expect(result.candidateTeamIds).toEqual(["team_abc"]);
+  });
+
+  test("defaultTeamId may differ from best owner team", async () => {
+    fetchApiMock.mockImplementation(
+      mockUserAndTeams({
+        defaultTeamId: "team_nonowner",
+        username: "my-user",
+        teams: [
+          {
+            id: "team_owner",
+            slug: "my-user",
+            updatedAt: 100,
+            membership: { role: "OWNER" },
+          },
+          {
+            id: "team_nonowner",
+            slug: "nonowner-team",
+            updatedAt: 200,
+            membership: { role: "MEMBER" },
+          },
+        ],
+      }),
+    );
+
+    const result = await selectTeams("token");
+    // defaultTeamId first (even though not OWNER), then best owner team as fallback
+    expect(result.candidateTeamIds).toEqual(["team_nonowner", "team_owner"]);
   });
 });
 
@@ -60,7 +227,7 @@ describe("inferScope", () => {
     });
   });
 
-  describe("team creation", () => {
+  describe("project creation", () => {
     test("project 404 triggers project creation", async () => {
       fetchApiMock.mockImplementation(async ({ method }) => {
         if (!method || method === "GET") {
@@ -76,7 +243,7 @@ describe("inferScope", () => {
       });
     });
 
-    test("non-404 throws", async () => {
+    test("non-404 throws when teamId is explicit", async () => {
       fetchApiMock.mockImplementation(async ({ method }) => {
         if (!method || method === "GET") {
           throw new NotOk({ statusCode: 403, responseText: "Forbidden" });
@@ -103,18 +270,152 @@ describe("inferScope", () => {
     });
   });
 
-  test("infers the team from the user's defaultTeamId", async () => {
-    fetchApiMock.mockImplementation(async ({ endpoint }) => {
-      if (endpoint === "/v2/user") {
-        return { user: { defaultTeamId: "team_default", username: "my-user" } };
-      }
-      return {};
+  describe("fallback team selection with 403 handling", () => {
+    test("falls back to owner team when defaultTeamId returns 403", async () => {
+      fetchApiMock.mockImplementation(async ({ endpoint }) => {
+        if (endpoint === "/v2/user") {
+          return {
+            user: { defaultTeamId: "team_readonly", username: "my-user" },
+          };
+        }
+        if (endpoint.startsWith("/v2/teams")) {
+          return {
+            teams: [
+              {
+                id: "team_writable",
+                slug: "my-user",
+                updatedAt: 100,
+                membership: { role: "OWNER" },
+              },
+            ],
+          };
+        }
+        // Project check: 403 for readonly default team, success for owner team
+        if (endpoint.includes("slug=team_readonly")) {
+          throw new NotOk({ statusCode: 403, responseText: "Forbidden" });
+        }
+        return {};
+      });
+
+      const scope = await inferScope({ token: "token" });
+      expect(scope).toEqual({
+        created: false,
+        projectId: "vercel-sandbox-default-project",
+        teamId: "team_writable",
+      });
     });
-    const scope = await inferScope({ token: "token" });
-    expect(scope).toEqual({
-      created: false,
-      projectId: "vercel-sandbox-default-project",
-      teamId: "team_default",
+
+    test("throws helpful error when all candidates return 403", async () => {
+      fetchApiMock.mockImplementation(async ({ endpoint }) => {
+        if (endpoint === "/v2/user") {
+          return {
+            user: { defaultTeamId: "team_readonly", username: "my-user" },
+          };
+        }
+        if (endpoint.startsWith("/v2/teams")) {
+          return {
+            teams: [
+              {
+                id: "team_owner",
+                slug: "my-user",
+                updatedAt: 200,
+                membership: { role: "OWNER" },
+              },
+            ],
+          };
+        }
+        throw new NotOk({ statusCode: 403, responseText: "Forbidden" });
+      });
+
+      await expect(inferScope({ token: "token" })).rejects.toThrowError(
+        /Authenticated as "my-user" but none of the available teams allow sandbox creation/,
+      );
+    });
+
+    test("uses defaultTeamId when it succeeds", async () => {
+      fetchApiMock.mockImplementation(async ({ endpoint }) => {
+        if (endpoint === "/v2/user") {
+          return {
+            user: { defaultTeamId: "team_default", username: "my-user" },
+          };
+        }
+        if (endpoint.startsWith("/v2/teams")) {
+          return { teams: [] };
+        }
+        return {};
+      });
+
+      const scope = await inferScope({ token: "token" });
+      expect(scope).toEqual({
+        created: false,
+        projectId: "vercel-sandbox-default-project",
+        teamId: "team_default",
+      });
+    });
+
+    test("creates project in fallback team when it returns 404", async () => {
+      fetchApiMock.mockImplementation(async ({ endpoint, method }) => {
+        if (endpoint === "/v2/user") {
+          return {
+            user: { defaultTeamId: "team_default", username: "my-user" },
+          };
+        }
+        if (endpoint.startsWith("/v2/teams")) {
+          return { teams: [] };
+        }
+        if (
+          endpoint.includes("slug=team_default") &&
+          (!method || method === "GET")
+        ) {
+          throw new NotOk({ statusCode: 404, responseText: "Not Found" });
+        }
+        return {};
+      });
+
+      const scope = await inferScope({ token: "token" });
+      expect(scope).toEqual({
+        created: true,
+        projectId: "vercel-sandbox-default-project",
+        teamId: "team_default",
+      });
+    });
+
+    test("tries next candidate when project creation returns 403", async () => {
+      fetchApiMock.mockImplementation(async ({ endpoint, method }) => {
+        if (endpoint === "/v2/user") {
+          return {
+            user: { defaultTeamId: "team_nocreate", username: "my-user" },
+          };
+        }
+        if (endpoint.startsWith("/v2/teams")) {
+          return {
+            teams: [
+              {
+                id: "team_good",
+                slug: "good-team",
+                updatedAt: 100,
+                membership: { role: "OWNER" },
+              },
+            ],
+          };
+        }
+        // team_nocreate: project check 404, project creation 403
+        if (endpoint.includes("slug=team_nocreate")) {
+          if (!method || method === "GET") {
+            throw new NotOk({ statusCode: 404, responseText: "Not Found" });
+          }
+          throw new NotOk({ statusCode: 403, responseText: "Forbidden" });
+        }
+        // team_good: success
+        return {};
+      });
+
+      const scope = await inferScope({ token: "token" });
+      expect(scope).toEqual({
+        created: false,
+        projectId: "vercel-sandbox-default-project",
+        teamId: "team_good",
+      });
     });
   });
 

--- a/packages/vercel-sandbox/src/auth/infer-scope.test.ts
+++ b/packages/vercel-sandbox/src/auth/infer-scope.test.ts
@@ -328,7 +328,7 @@ describe("inferScope", () => {
       });
 
       await expect(inferScope({ token: "token" })).rejects.toThrowError(
-        /Authenticated as "my-user" but none of the available teams allow sandbox creation/,
+        /Authenticated as "my-user" but none of the available teams allow sandbox creation\. Specify a team explicitly with --scope/,
       );
     });
 

--- a/packages/vercel-sandbox/src/auth/infer-scope.test.ts
+++ b/packages/vercel-sandbox/src/auth/infer-scope.test.ts
@@ -1,4 +1,4 @@
-import { inferScope, selectTeams } from "./project.js";
+import { inferScope } from "./project.js";
 import {
   beforeEach,
   describe,
@@ -43,42 +43,16 @@ function mockUserAndTeams({
       return Promise.resolve({ user: { defaultTeamId, username } });
     }
     if (opts.endpoint.startsWith("/v2/teams")) {
-      return Promise.resolve({ teams });
+      return Promise.resolve({
+        teams,
+        pagination: { count: teams.length, next: null },
+      });
     }
     return Promise.resolve({});
   };
 }
 
-describe("selectTeams", () => {
-  test("returns defaultTeamId first, then best hobby owner team", async () => {
-    fetchApiMock.mockImplementation(
-      mockUserAndTeams({
-        defaultTeamId: "team_default",
-        username: "my-user",
-        teams: [
-          {
-            id: "team_default",
-            slug: "default-team",
-            updatedAt: 100,
-            membership: { role: "OWNER" },
-            billing: { plan: "hobby" },
-          },
-          {
-            id: "team_other",
-            slug: "other-team",
-            updatedAt: 200,
-            membership: { role: "OWNER" },
-            billing: { plan: "hobby" },
-          },
-        ],
-      }),
-    );
-
-    const result = await selectTeams("token");
-    expect(result.candidateTeamIds).toEqual(["team_default", "team_other"]);
-    expect(result.username).toBe("my-user");
-  });
-
+describe("team selection from paginated results", () => {
   test("prefers personal team (matching username slug) over most recently updated", async () => {
     fetchApiMock.mockImplementation(
       mockUserAndTeams({
@@ -103,8 +77,8 @@ describe("selectTeams", () => {
       }),
     );
 
-    const result = await selectTeams("token");
-    expect(result.candidateTeamIds).toEqual(["team_personal"]);
+    const scope = await inferScope({ token: "token" });
+    expect(scope.teamId).toBe("team_personal");
   });
 
   test("picks most recently updated hobby owner team when no username match", async () => {
@@ -131,49 +105,21 @@ describe("selectTeams", () => {
       }),
     );
 
-    const result = await selectTeams("token");
-    expect(result.candidateTeamIds).toEqual(["team_recent"]);
+    const scope = await inferScope({ token: "token" });
+    expect(scope.teamId).toBe("team_recent");
   });
 
-  test("filters out non-OWNER teams", async () => {
+  test("filters out non-OWNER and non-hobby teams", async () => {
     fetchApiMock.mockImplementation(
       mockUserAndTeams({
         defaultTeamId: null,
         username: "my-user",
         teams: [
-          {
-            id: "team_owner",
-            slug: "owner-team",
-            updatedAt: 100,
-            membership: { role: "OWNER" },
-            billing: { plan: "hobby" },
-          },
           {
             id: "team_member",
             slug: "member-team",
-            updatedAt: 200,
+            updatedAt: 300,
             membership: { role: "MEMBER" },
-            billing: { plan: "hobby" },
-          },
-        ],
-      }),
-    );
-
-    const result = await selectTeams("token");
-    expect(result.candidateTeamIds).toEqual(["team_owner"]);
-  });
-
-  test("filters out non-hobby plan teams", async () => {
-    fetchApiMock.mockImplementation(
-      mockUserAndTeams({
-        defaultTeamId: null,
-        username: "my-user",
-        teams: [
-          {
-            id: "team_hobby",
-            slug: "hobby-team",
-            updatedAt: 100,
-            membership: { role: "OWNER" },
             billing: { plan: "hobby" },
           },
           {
@@ -183,15 +129,22 @@ describe("selectTeams", () => {
             membership: { role: "OWNER" },
             billing: { plan: "pro" },
           },
+          {
+            id: "team_good",
+            slug: "good-team",
+            updatedAt: 100,
+            membership: { role: "OWNER" },
+            billing: { plan: "hobby" },
+          },
         ],
       }),
     );
 
-    const result = await selectTeams("token");
-    expect(result.candidateTeamIds).toEqual(["team_hobby"]);
+    const scope = await inferScope({ token: "token" });
+    expect(scope.teamId).toBe("team_good");
   });
 
-  test("falls back to username when no teams and no defaultTeamId", async () => {
+  test("falls back to username when no hobby owner teams found", async () => {
     fetchApiMock.mockImplementation(
       mockUserAndTeams({
         defaultTeamId: null,
@@ -200,58 +153,83 @@ describe("selectTeams", () => {
       }),
     );
 
-    const result = await selectTeams("token");
-    expect(result.candidateTeamIds).toEqual(["my-user"]);
+    const scope = await inferScope({ token: "token" });
+    expect(scope.teamId).toBe("my-user");
   });
 
-  test("does not duplicate defaultTeamId when it matches best hobby owner team", async () => {
-    fetchApiMock.mockImplementation(
-      mockUserAndTeams({
-        defaultTeamId: "team_abc",
-        username: "my-user",
-        teams: [
-          {
-            id: "team_abc",
-            slug: "abc-team",
-            updatedAt: 100,
-            membership: { role: "OWNER" },
-            billing: { plan: "hobby" },
-          },
-        ],
-      }),
-    );
+  test("skips hobby team that matches already-tried defaultTeamId", async () => {
+    fetchApiMock.mockImplementation(async ({ endpoint }) => {
+      if (endpoint === "/v2/user") {
+        return {
+          user: { defaultTeamId: "team_abc", username: "my-user" },
+        };
+      }
+      if (endpoint.startsWith("/v2/teams")) {
+        return {
+          teams: [
+            {
+              id: "team_abc",
+              slug: "abc-team",
+              updatedAt: 100,
+              membership: { role: "OWNER" },
+              billing: { plan: "hobby" },
+            },
+          ],
+          pagination: { count: 1, next: null },
+        };
+      }
+      // All project checks fail with 403
+      throw new NotOk({ statusCode: 403, responseText: "Forbidden" });
+    });
 
-    const result = await selectTeams("token");
-    expect(result.candidateTeamIds).toEqual(["team_abc"]);
+    await expect(inferScope({ token: "token" })).rejects.toThrowError(
+      /none of the available teams allow sandbox creation/,
+    );
+    // team_abc tried once (defaultTeamId), then skipped in pagination, then username fallback
+    const projectCalls = fetchApiMock.mock.calls.filter(([{ endpoint }]) =>
+      endpoint.includes("vercel-sandbox-default-project"),
+    );
+    expect(projectCalls).toHaveLength(2);
   });
 
-  test("defaultTeamId may differ from best hobby owner team", async () => {
-    fetchApiMock.mockImplementation(
-      mockUserAndTeams({
-        defaultTeamId: "team_nonowner",
-        username: "my-user",
-        teams: [
-          {
-            id: "team_owner",
-            slug: "my-user",
-            updatedAt: 100,
-            membership: { role: "OWNER" },
-            billing: { plan: "hobby" },
-          },
-          {
-            id: "team_nonowner",
-            slug: "nonowner-team",
-            updatedAt: 200,
-            membership: { role: "MEMBER" },
-            billing: { plan: "pro" },
-          },
-        ],
-      }),
-    );
+  test("paginates through multiple pages to find a usable team", async () => {
+    fetchApiMock.mockImplementation(async ({ endpoint }) => {
+      if (endpoint === "/v2/user") {
+        return { user: { defaultTeamId: null, username: "my-user" } };
+      }
+      if (endpoint === "/v2/teams?limit=20") {
+        return {
+          teams: [
+            {
+              id: "team_pro",
+              slug: "pro-team",
+              updatedAt: 300,
+              membership: { role: "OWNER" },
+              billing: { plan: "pro" },
+            },
+          ],
+          pagination: { count: 1, next: 12345 },
+        };
+      }
+      if (endpoint === "/v2/teams?limit=20&until=12345") {
+        return {
+          teams: [
+            {
+              id: "team_hobby",
+              slug: "hobby-team",
+              updatedAt: 100,
+              membership: { role: "OWNER" },
+              billing: { plan: "hobby" },
+            },
+          ],
+          pagination: { count: 1, next: null },
+        };
+      }
+      return {};
+    });
 
-    const result = await selectTeams("token");
-    // defaultTeamId first (even though not hobby OWNER), then best hobby owner team as fallback
-    expect(result.candidateTeamIds).toEqual(["team_nonowner", "team_owner"]);
+    const scope = await inferScope({ token: "token" });
+    expect(scope.teamId).toBe("team_hobby");
   });
 });
 
@@ -328,6 +306,7 @@ describe("inferScope", () => {
                 billing: { plan: "hobby" },
               },
             ],
+            pagination: { count: 1, next: null },
           };
         }
         // Project check: 403 for readonly default team, success for owner team
@@ -342,6 +321,7 @@ describe("inferScope", () => {
         created: false,
         projectId: "vercel-sandbox-default-project",
         teamId: "team_writable",
+        teamSlug: "my-user",
       });
     });
 
@@ -363,6 +343,7 @@ describe("inferScope", () => {
                 billing: { plan: "hobby" },
               },
             ],
+            pagination: { count: 1, next: null },
           };
         }
         throw new NotOk({ statusCode: 403, responseText: "Forbidden" });
@@ -381,7 +362,7 @@ describe("inferScope", () => {
           };
         }
         if (endpoint.startsWith("/v2/teams")) {
-          return { teams: [] };
+          return { teams: [], pagination: { count: 0, next: null } };
         }
         return {};
       });
@@ -402,7 +383,7 @@ describe("inferScope", () => {
           };
         }
         if (endpoint.startsWith("/v2/teams")) {
-          return { teams: [] };
+          return { teams: [], pagination: { count: 0, next: null } };
         }
         if (
           endpoint.includes("teamId=team_default") &&
@@ -439,6 +420,7 @@ describe("inferScope", () => {
                 billing: { plan: "hobby" },
               },
             ],
+            pagination: { count: 1, next: null },
           };
         }
         // team_nocreate: project check 404, project creation 403
@@ -457,6 +439,7 @@ describe("inferScope", () => {
         created: false,
         projectId: "vercel-sandbox-default-project",
         teamId: "team_good",
+        teamSlug: "good-team",
       });
     });
   });
@@ -473,15 +456,25 @@ describe("inferScope", () => {
         }),
       );
 
+      fetchApiMock.mockImplementation(async ({ endpoint }) => {
+        if (endpoint.includes("/v2/teams/")) {
+          return { slug: "linked-team" };
+        }
+        if (endpoint.includes("/v2/projects/")) {
+          return { name: "linked-project" };
+        }
+        return {};
+      });
+
       const scope = await inferScope({ token: "token", cwd: dir });
 
       expect(scope).toEqual({
         created: false,
         projectId: "prj_linked",
         teamId: "team_linked",
+        teamSlug: "linked-team",
+        projectSlug: "linked-project",
       });
-      // Should not call API when using linked project
-      expect(fetchApiMock).not.toHaveBeenCalled();
     });
 
     test("falls back to default project when .vercel/project.json does not exist", async () => {

--- a/packages/vercel-sandbox/src/auth/infer-scope.test.ts
+++ b/packages/vercel-sandbox/src/auth/infer-scope.test.ts
@@ -35,6 +35,7 @@ function mockUserAndTeams({
     slug: string;
     updatedAt: number;
     membership: { role: string };
+    billing: { plan: string };
   }>,
 } = {}) {
   return (opts: { endpoint: string }) => {
@@ -49,7 +50,7 @@ function mockUserAndTeams({
 }
 
 describe("selectTeams", () => {
-  test("returns defaultTeamId first, then best owner team", async () => {
+  test("returns defaultTeamId first, then best hobby owner team", async () => {
     fetchApiMock.mockImplementation(
       mockUserAndTeams({
         defaultTeamId: "team_default",
@@ -60,19 +61,20 @@ describe("selectTeams", () => {
             slug: "default-team",
             updatedAt: 100,
             membership: { role: "OWNER" },
+            billing: { plan: "hobby" },
           },
           {
             id: "team_other",
             slug: "other-team",
             updatedAt: 200,
             membership: { role: "OWNER" },
+            billing: { plan: "hobby" },
           },
         ],
       }),
     );
 
     const result = await selectTeams("token");
-    // defaultTeamId is also the best owner match, so only one candidate
     expect(result.candidateTeamIds).toEqual(["team_default", "team_other"]);
     expect(result.username).toBe("my-user");
   });
@@ -88,12 +90,14 @@ describe("selectTeams", () => {
             slug: "other-team",
             updatedAt: 300,
             membership: { role: "OWNER" },
+            billing: { plan: "hobby" },
           },
           {
             id: "team_personal",
             slug: "my-user",
             updatedAt: 100,
             membership: { role: "OWNER" },
+            billing: { plan: "hobby" },
           },
         ],
       }),
@@ -103,7 +107,7 @@ describe("selectTeams", () => {
     expect(result.candidateTeamIds).toEqual(["team_personal"]);
   });
 
-  test("picks most recently updated owner team when no username match", async () => {
+  test("picks most recently updated hobby owner team when no username match", async () => {
     fetchApiMock.mockImplementation(
       mockUserAndTeams({
         defaultTeamId: null,
@@ -114,12 +118,14 @@ describe("selectTeams", () => {
             slug: "old-team",
             updatedAt: 100,
             membership: { role: "OWNER" },
+            billing: { plan: "hobby" },
           },
           {
             id: "team_recent",
             slug: "recent-team",
             updatedAt: 300,
             membership: { role: "OWNER" },
+            billing: { plan: "hobby" },
           },
         ],
       }),
@@ -140,12 +146,14 @@ describe("selectTeams", () => {
             slug: "owner-team",
             updatedAt: 100,
             membership: { role: "OWNER" },
+            billing: { plan: "hobby" },
           },
           {
             id: "team_member",
             slug: "member-team",
             updatedAt: 200,
             membership: { role: "MEMBER" },
+            billing: { plan: "hobby" },
           },
         ],
       }),
@@ -153,6 +161,34 @@ describe("selectTeams", () => {
 
     const result = await selectTeams("token");
     expect(result.candidateTeamIds).toEqual(["team_owner"]);
+  });
+
+  test("filters out non-hobby plan teams", async () => {
+    fetchApiMock.mockImplementation(
+      mockUserAndTeams({
+        defaultTeamId: null,
+        username: "my-user",
+        teams: [
+          {
+            id: "team_hobby",
+            slug: "hobby-team",
+            updatedAt: 100,
+            membership: { role: "OWNER" },
+            billing: { plan: "hobby" },
+          },
+          {
+            id: "team_pro",
+            slug: "pro-team",
+            updatedAt: 200,
+            membership: { role: "OWNER" },
+            billing: { plan: "pro" },
+          },
+        ],
+      }),
+    );
+
+    const result = await selectTeams("token");
+    expect(result.candidateTeamIds).toEqual(["team_hobby"]);
   });
 
   test("falls back to username when no teams and no defaultTeamId", async () => {
@@ -168,7 +204,7 @@ describe("selectTeams", () => {
     expect(result.candidateTeamIds).toEqual(["my-user"]);
   });
 
-  test("does not duplicate defaultTeamId when it matches best owner team", async () => {
+  test("does not duplicate defaultTeamId when it matches best hobby owner team", async () => {
     fetchApiMock.mockImplementation(
       mockUserAndTeams({
         defaultTeamId: "team_abc",
@@ -179,6 +215,7 @@ describe("selectTeams", () => {
             slug: "abc-team",
             updatedAt: 100,
             membership: { role: "OWNER" },
+            billing: { plan: "hobby" },
           },
         ],
       }),
@@ -188,7 +225,7 @@ describe("selectTeams", () => {
     expect(result.candidateTeamIds).toEqual(["team_abc"]);
   });
 
-  test("defaultTeamId may differ from best owner team", async () => {
+  test("defaultTeamId may differ from best hobby owner team", async () => {
     fetchApiMock.mockImplementation(
       mockUserAndTeams({
         defaultTeamId: "team_nonowner",
@@ -199,19 +236,21 @@ describe("selectTeams", () => {
             slug: "my-user",
             updatedAt: 100,
             membership: { role: "OWNER" },
+            billing: { plan: "hobby" },
           },
           {
             id: "team_nonowner",
             slug: "nonowner-team",
             updatedAt: 200,
             membership: { role: "MEMBER" },
+            billing: { plan: "pro" },
           },
         ],
       }),
     );
 
     const result = await selectTeams("token");
-    // defaultTeamId first (even though not OWNER), then best owner team as fallback
+    // defaultTeamId first (even though not hobby OWNER), then best hobby owner team as fallback
     expect(result.candidateTeamIds).toEqual(["team_nonowner", "team_owner"]);
   });
 });
@@ -271,7 +310,7 @@ describe("inferScope", () => {
   });
 
   describe("fallback team selection with 403 handling", () => {
-    test("falls back to owner team when defaultTeamId returns 403", async () => {
+    test("falls back to hobby owner team when defaultTeamId returns 403", async () => {
       fetchApiMock.mockImplementation(async ({ endpoint }) => {
         if (endpoint === "/v2/user") {
           return {
@@ -286,6 +325,7 @@ describe("inferScope", () => {
                 slug: "my-user",
                 updatedAt: 100,
                 membership: { role: "OWNER" },
+                billing: { plan: "hobby" },
               },
             ],
           };
@@ -320,6 +360,7 @@ describe("inferScope", () => {
                 slug: "my-user",
                 updatedAt: 200,
                 membership: { role: "OWNER" },
+                billing: { plan: "hobby" },
               },
             ],
           };
@@ -395,6 +436,7 @@ describe("inferScope", () => {
                 slug: "good-team",
                 updatedAt: 100,
                 membership: { role: "OWNER" },
+                billing: { plan: "hobby" },
               },
             ],
           };

--- a/packages/vercel-sandbox/src/auth/project.ts
+++ b/packages/vercel-sandbox/src/auth/project.ts
@@ -32,6 +32,11 @@ const TeamsSchema = z.object({
 
 const DEFAULT_PROJECT_NAME = "vercel-sandbox-default-project";
 
+/** Status codes that mean "this team can't be used, try the next one". */
+function isSkippableTeamError(e: unknown): boolean {
+  return e instanceof NotOk && (e.response.statusCode === 402 || e.response.statusCode === 403);
+}
+
 /**
  * Resolves the team and project scope for sandbox operations.
  *
@@ -103,7 +108,7 @@ export async function inferScope(opts: {
         return result;
       }
     } catch (e) {
-      if (!(e instanceof NotOk) || e.response.statusCode !== 403) throw e;
+      if (!isSkippableTeamError(e)) throw e;
     }
   }
 
@@ -136,7 +141,7 @@ export async function inferScope(opts: {
         const result = await tryTeam(opts.token, bestHobbyTeam.id);
         return { ...result, teamSlug: bestHobbyTeam.slug };
       } catch (e) {
-        if (!(e instanceof NotOk) || e.response.statusCode !== 403) throw e;
+        if (!isSkippableTeamError(e)) throw e;
       }
     }
   } while (next !== null);
@@ -146,7 +151,7 @@ export async function inferScope(opts: {
     const result = await tryTeam(opts.token, username);
     return { ...result, teamSlug: username };
   } catch (e) {
-    if (!(e instanceof NotOk) || e.response.statusCode !== 403) throw e;
+    if (!isSkippableTeamError(e)) throw e;
   }
 
   throw new NotOk({

--- a/packages/vercel-sandbox/src/auth/project.ts
+++ b/packages/vercel-sandbox/src/auth/project.ts
@@ -28,7 +28,6 @@ const DEFAULT_PROJECT_NAME = "vercel-sandbox-default-project";
  * @returns The resolved scope with `projectId`, `teamId`, and whether the project was `created`.
  *
  * @throws {NotOk} If the API returns an error other than 404 when checking the project.
- * @throws {ZodError} If the user API response is missing a username.
  *
  * @example
  * ```ts

--- a/packages/vercel-sandbox/src/auth/project.ts
+++ b/packages/vercel-sandbox/src/auth/project.ts
@@ -78,7 +78,7 @@ export async function inferScope(opts: {
 
   throw new NotOk({
     statusCode: 403,
-    responseText: `Authenticated as "${username}" but none of the available teams allow sandbox creation. Please specify a team explicitly.`,
+    responseText: `Authenticated as "${username}" but none of the available teams allow sandbox creation. Specify a team explicitly with --scope <team-id-or-slug>.`,
   });
 }
 

--- a/packages/vercel-sandbox/src/auth/project.ts
+++ b/packages/vercel-sandbox/src/auth/project.ts
@@ -3,14 +3,10 @@ import { fetchApi } from "./api.js";
 import { NotOk } from "./error.js";
 import { readLinkedProject } from "./linked-project.js";
 
-const TeamsSchema = z.object({
-  teams: z
-    .array(
-      z.object({
-        slug: z.string(),
-      }),
-    )
-    .min(1, `No teams found. Please create a team first.`),
+const UserSchema = z.object({
+  user: z.object({
+    username: z.string(),
+  }),
 });
 
 const DEFAULT_PROJECT_NAME = "vercel-sandbox-default-project";
@@ -21,16 +17,17 @@ const DEFAULT_PROJECT_NAME = "vercel-sandbox-default-project";
  * First checks for a locally linked project in `.vercel/project.json`.
  * If found, uses the `projectId` and `orgId` from there.
  *
- * Otherwise, if `teamId` is not provided, selects the first available team for the account.
- * Ensures a default project exists within the team, creating it if necessary.
+ * Otherwise, if `teamId` is not provided, falls back to the authenticated user's
+ * personal team (their username). Ensures a default project exists within the team,
+ * creating it if necessary.
  *
  * @param opts.token - Vercel API authentication token.
- * @param opts.teamId - Optional team slug. If omitted, the first team is selected.
+ * @param opts.teamId - Optional team slug. If omitted, the user's personal team is used.
  * @param opts.cwd - Optional directory to search for `.vercel/project.json`. Defaults to `process.cwd()`.
  * @returns The resolved scope with `projectId`, `teamId`, and whether the project was `created`.
  *
  * @throws {NotOk} If the API returns an error other than 404 when checking the project.
- * @throws {ZodError} If no teams exist for the account.
+ * @throws {ZodError} If the user API response is missing a username.
  *
  * @example
  * ```ts
@@ -76,17 +73,17 @@ export async function inferScope(opts: {
 }
 
 /**
- * Selects a team for the current token by querying the Teams API and
- * returning the slug of the first team in the result set.
+ * Falls back to the authenticated user's personal team by fetching
+ * their username from the `/v2/user` endpoint.
  *
  * @param token - Authentication token used to call the Vercel API.
- * @returns A promise that resolves to the first team's slug.
+ * @returns A promise that resolves to the user's username (their personal team slug).
  */
 export async function selectTeam(token: string) {
   const {
-    teams: [team],
-  } = await fetchApi({ token, endpoint: "/v2/teams?limit=1" }).then(
-    TeamsSchema.parse,
+    user,
+  } = await fetchApi({ token, endpoint: "/v2/user" }).then(
+    UserSchema.parse,
   );
-  return team.slug;
+  return user.username;
 }

--- a/packages/vercel-sandbox/src/auth/project.ts
+++ b/packages/vercel-sandbox/src/auth/project.ts
@@ -10,6 +10,19 @@ const UserSchema = z.object({
   }),
 });
 
+const TeamsSchema = z.object({
+  teams: z.array(
+    z.object({
+      id: z.string(),
+      slug: z.string(),
+      updatedAt: z.number(),
+      membership: z.object({
+        role: z.string(),
+      }),
+    }),
+  ),
+});
+
 const DEFAULT_PROJECT_NAME = "vercel-sandbox-default-project";
 
 /**
@@ -18,12 +31,13 @@ const DEFAULT_PROJECT_NAME = "vercel-sandbox-default-project";
  * First checks for a locally linked project in `.vercel/project.json`.
  * If found, uses the `projectId` and `orgId` from there.
  *
- * Otherwise, if `teamId` is not provided, falls back to the authenticated user's
- * default team (`defaultTeamId`), or their personal team (username) if no default
- * is configured. Ensures a default project exists within the team, creating it if necessary.
+ * Otherwise, if `teamId` is not provided, builds an ordered list of candidate
+ * teams to try: the user's `defaultTeamId` first (if set), then teams where
+ * the user has an OWNER role (sorted by `updatedAt` desc, with the personal
+ * team matching the username first). Tries each candidate until one succeeds.
  *
  * @param opts.token - Vercel API authentication token.
- * @param opts.teamId - Optional team slug. If omitted, the user's default team is used.
+ * @param opts.teamId - Optional team slug. If omitted, candidate teams are resolved automatically.
  * @param opts.cwd - Optional directory to search for `.vercel/project.json`. Defaults to `process.cwd()`.
  * @returns The resolved scope with `projectId`, `teamId`, and whether the project was `created`.
  *
@@ -45,12 +59,44 @@ export async function inferScope(opts: {
     return { ...linkedProject, created: false };
   }
 
-  const teamId = opts.teamId ?? (await selectTeam(opts.token));
+  if (opts.teamId) {
+    return tryTeam(opts.token, opts.teamId);
+  }
 
+  const { candidateTeamIds, username } = await selectTeams(opts.token);
+
+  for (const teamId of candidateTeamIds) {
+    try {
+      return await tryTeam(opts.token, teamId);
+    } catch (e) {
+      if (e instanceof NotOk && e.response.statusCode === 403) {
+        continue;
+      }
+      throw e;
+    }
+  }
+
+  throw new NotOk({
+    statusCode: 403,
+    responseText: `Authenticated as "${username}" but none of the available teams allow sandbox creation. Please specify a team explicitly.`,
+  });
+}
+
+/**
+ * Attempts to use a specific team for sandbox operations by checking for
+ * (or creating) the default project within that team.
+ *
+ * @returns The resolved scope if the team is usable.
+ * @throws {NotOk} On authorization or other API errors.
+ */
+async function tryTeam(
+  token: string,
+  teamId: string,
+): Promise<{ projectId: string; teamId: string; created: boolean }> {
   let created = false;
   try {
     await fetchApi({
-      token: opts.token,
+      token,
       endpoint: `/v2/projects/${encodeURIComponent(DEFAULT_PROJECT_NAME)}?slug=${encodeURIComponent(teamId)}`,
     });
   } catch (e) {
@@ -59,7 +105,7 @@ export async function inferScope(opts: {
     }
 
     await fetchApi({
-      token: opts.token,
+      token,
       endpoint: `/v11/projects?slug=${encodeURIComponent(teamId)}`,
       method: "POST",
       body: JSON.stringify({
@@ -73,18 +119,50 @@ export async function inferScope(opts: {
 }
 
 /**
- * Falls back to the authenticated user's default team by fetching
- * their profile from the `/v2/user` endpoint. Uses `defaultTeamId`
- * if set, otherwise falls back to the user's personal team (username).
+ * Builds an ordered list of candidate team IDs to try for sandbox creation.
+ *
+ * Fetches the user profile and their teams in parallel. Returns the user's
+ * `defaultTeamId` first (if set), followed by the best OWNER team: the one
+ * whose slug matches the username, or the most recently updated.
  *
  * @param token - Authentication token used to call the Vercel API.
- * @returns A promise that resolves to the user's default team ID or username.
+ * @returns The ordered candidate team IDs and the username.
  */
-export async function selectTeam(token: string) {
-  const {
-    user,
-  } = await fetchApi({ token, endpoint: "/v2/user" }).then(
-    UserSchema.parse,
+export async function selectTeams(
+  token: string,
+): Promise<{ candidateTeamIds: string[]; username: string }> {
+  const [userData, teamsData] = await Promise.all([
+    fetchApi({ token, endpoint: "/v2/user" }).then(UserSchema.parse),
+    fetchApi({ token, endpoint: "/v2/teams?limit=100" }).then(
+      TeamsSchema.parse,
+    ),
+  ]);
+
+  const { defaultTeamId, username } = userData.user;
+
+  const ownerTeams = teamsData.teams.filter(
+    (t) => t.membership.role === "OWNER",
   );
-  return user.defaultTeamId ?? user.username;
+
+  // Pick the personal team (slug matches username), or the most recently updated
+  const bestOwnerTeam =
+    ownerTeams.find((t) => t.slug === username) ??
+    ownerTeams.sort((a, b) => b.updatedAt - a.updatedAt)[0];
+
+  const candidateTeamIds: string[] = [];
+
+  if (defaultTeamId) {
+    candidateTeamIds.push(defaultTeamId);
+  }
+
+  if (bestOwnerTeam && !candidateTeamIds.includes(bestOwnerTeam.id)) {
+    candidateTeamIds.push(bestOwnerTeam.id);
+  }
+
+  // If no teams found at all, try the username as personal team
+  if (candidateTeamIds.length === 0) {
+    candidateTeamIds.push(username);
+  }
+
+  return { candidateTeamIds, username };
 }

--- a/packages/vercel-sandbox/src/auth/project.ts
+++ b/packages/vercel-sandbox/src/auth/project.ts
@@ -5,6 +5,7 @@ import { readLinkedProject } from "./linked-project.js";
 
 const UserSchema = z.object({
   user: z.object({
+    defaultTeamId: z.string().nullable(),
     username: z.string(),
   }),
 });
@@ -18,11 +19,11 @@ const DEFAULT_PROJECT_NAME = "vercel-sandbox-default-project";
  * If found, uses the `projectId` and `orgId` from there.
  *
  * Otherwise, if `teamId` is not provided, falls back to the authenticated user's
- * personal team (their username). Ensures a default project exists within the team,
- * creating it if necessary.
+ * default team (`defaultTeamId`), or their personal team (username) if no default
+ * is configured. Ensures a default project exists within the team, creating it if necessary.
  *
  * @param opts.token - Vercel API authentication token.
- * @param opts.teamId - Optional team slug. If omitted, the user's personal team is used.
+ * @param opts.teamId - Optional team slug. If omitted, the user's default team is used.
  * @param opts.cwd - Optional directory to search for `.vercel/project.json`. Defaults to `process.cwd()`.
  * @returns The resolved scope with `projectId`, `teamId`, and whether the project was `created`.
  *
@@ -73,11 +74,12 @@ export async function inferScope(opts: {
 }
 
 /**
- * Falls back to the authenticated user's personal team by fetching
- * their username from the `/v2/user` endpoint.
+ * Falls back to the authenticated user's default team by fetching
+ * their profile from the `/v2/user` endpoint. Uses `defaultTeamId`
+ * if set, otherwise falls back to the user's personal team (username).
  *
  * @param token - Authentication token used to call the Vercel API.
- * @returns A promise that resolves to the user's username (their personal team slug).
+ * @returns A promise that resolves to the user's default team ID or username.
  */
 export async function selectTeam(token: string) {
   const {
@@ -85,5 +87,5 @@ export async function selectTeam(token: string) {
   } = await fetchApi({ token, endpoint: "/v2/user" }).then(
     UserSchema.parse,
   );
-  return user.username;
+  return user.defaultTeamId ?? user.username;
 }

--- a/packages/vercel-sandbox/src/auth/project.ts
+++ b/packages/vercel-sandbox/src/auth/project.ts
@@ -93,11 +93,15 @@ async function tryTeam(
   token: string,
   teamId: string,
 ): Promise<{ projectId: string; teamId: string; created: boolean }> {
+  const teamParam = teamId.startsWith("team_")
+    ? `teamId=${encodeURIComponent(teamId)}`
+    : `slug=${encodeURIComponent(teamId)}`;
+
   let created = false;
   try {
     await fetchApi({
       token,
-      endpoint: `/v2/projects/${encodeURIComponent(DEFAULT_PROJECT_NAME)}?slug=${encodeURIComponent(teamId)}`,
+      endpoint: `/v2/projects/${encodeURIComponent(DEFAULT_PROJECT_NAME)}?${teamParam}`,
     });
   } catch (e) {
     if (!(e instanceof NotOk) || e.response.statusCode !== 404) {
@@ -106,7 +110,7 @@ async function tryTeam(
 
     await fetchApi({
       token,
-      endpoint: `/v11/projects?slug=${encodeURIComponent(teamId)}`,
+      endpoint: `/v11/projects?${teamParam}`,
       method: "POST",
       body: JSON.stringify({
         name: DEFAULT_PROJECT_NAME,

--- a/packages/vercel-sandbox/src/auth/project.ts
+++ b/packages/vercel-sandbox/src/auth/project.ts
@@ -19,6 +19,9 @@ const TeamsSchema = z.object({
       membership: z.object({
         role: z.string(),
       }),
+      billing: z.object({
+        plan: z.string(),
+      }),
     }),
   ),
 });
@@ -32,9 +35,10 @@ const DEFAULT_PROJECT_NAME = "vercel-sandbox-default-project";
  * If found, uses the `projectId` and `orgId` from there.
  *
  * Otherwise, if `teamId` is not provided, builds an ordered list of candidate
- * teams to try: the user's `defaultTeamId` first (if set), then teams where
- * the user has an OWNER role (sorted by `updatedAt` desc, with the personal
- * team matching the username first). Tries each candidate until one succeeds.
+ * teams to try: the user's `defaultTeamId` first (if set), then hobby-plan
+ * teams where the user has an OWNER role (preferring the personal team matching
+ * the username, then the most recently updated). Tries each candidate until one
+ * succeeds.
  *
  * @param opts.token - Vercel API authentication token.
  * @param opts.teamId - Optional team slug. If omitted, candidate teams are resolved automatically.
@@ -126,8 +130,8 @@ async function tryTeam(
  * Builds an ordered list of candidate team IDs to try for sandbox creation.
  *
  * Fetches the user profile and their teams in parallel. Returns the user's
- * `defaultTeamId` first (if set), followed by the best OWNER team: the one
- * whose slug matches the username, or the most recently updated.
+ * `defaultTeamId` first (if set), followed by the best hobby-plan OWNER team:
+ * the one whose slug matches the username, or the most recently updated.
  *
  * @param token - Authentication token used to call the Vercel API.
  * @returns The ordered candidate team IDs and the username.
@@ -144,14 +148,14 @@ export async function selectTeams(
 
   const { defaultTeamId, username } = userData.user;
 
-  const ownerTeams = teamsData.teams.filter(
-    (t) => t.membership.role === "OWNER",
+  const hobbyOwnerTeams = teamsData.teams.filter(
+    (t) => t.membership.role === "OWNER" && t.billing.plan === "hobby",
   );
 
   // Pick the personal team (slug matches username), or the most recently updated
-  const bestOwnerTeam =
-    ownerTeams.find((t) => t.slug === username) ??
-    ownerTeams.sort((a, b) => b.updatedAt - a.updatedAt)[0];
+  const bestHobbyTeam =
+    hobbyOwnerTeams.find((t) => t.slug === username) ??
+    hobbyOwnerTeams.sort((a, b) => b.updatedAt - a.updatedAt)[0];
 
   const candidateTeamIds: string[] = [];
 
@@ -159,8 +163,8 @@ export async function selectTeams(
     candidateTeamIds.push(defaultTeamId);
   }
 
-  if (bestOwnerTeam && !candidateTeamIds.includes(bestOwnerTeam.id)) {
-    candidateTeamIds.push(bestOwnerTeam.id);
+  if (bestHobbyTeam && !candidateTeamIds.includes(bestHobbyTeam.id)) {
+    candidateTeamIds.push(bestHobbyTeam.id);
   }
 
   // If no teams found at all, try the username as personal team

--- a/packages/vercel-sandbox/src/auth/project.ts
+++ b/packages/vercel-sandbox/src/auth/project.ts
@@ -118,6 +118,8 @@ export async function inferScope(opts: {
       TeamsSchema.parse,
     );
 
+    next = page.pagination.next;
+
     const hobbyOwnerTeams = page.teams.filter(
       (t) => t.membership.role === "OWNER" && t.billing.plan === "hobby",
     );
@@ -137,8 +139,6 @@ export async function inferScope(opts: {
         if (!(e instanceof NotOk) || e.response.statusCode !== 403) throw e;
       }
     }
-
-    next = page.pagination.next;
   } while (next !== null);
 
   // 3. Fall back to username as personal team

--- a/packages/vercel-sandbox/src/auth/project.ts
+++ b/packages/vercel-sandbox/src/auth/project.ts
@@ -10,20 +10,24 @@ const UserSchema = z.object({
   }),
 });
 
+const TeamSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  updatedAt: z.number(),
+  membership: z.object({
+    role: z.string(),
+  }),
+  billing: z.object({
+    plan: z.string(),
+  }),
+});
+
 const TeamsSchema = z.object({
-  teams: z.array(
-    z.object({
-      id: z.string(),
-      slug: z.string(),
-      updatedAt: z.number(),
-      membership: z.object({
-        role: z.string(),
-      }),
-      billing: z.object({
-        plan: z.string(),
-      }),
-    }),
-  ),
+  teams: z.array(TeamSchema),
+  pagination: z.object({
+    count: z.number(),
+    next: z.number().nullable(),
+  }),
 });
 
 const DEFAULT_PROJECT_NAME = "vercel-sandbox-default-project";
@@ -57,27 +61,92 @@ export async function inferScope(opts: {
   token: string;
   teamId?: string;
   cwd?: string;
-}): Promise<{ projectId: string; teamId: string; created: boolean }> {
+}): Promise<{
+  projectId: string;
+  teamId: string;
+  created: boolean;
+  teamSlug?: string;
+  projectSlug?: string;
+}> {
   const linkedProject = await readLinkedProject(opts.cwd ?? process.cwd());
   if (linkedProject) {
-    return { ...linkedProject, created: false };
+    const slugs = await resolveLinkedProjectSlugs(
+      opts.token,
+      linkedProject.teamId,
+      linkedProject.projectId,
+    );
+    return { ...linkedProject, created: false, ...slugs };
   }
 
   if (opts.teamId) {
     return tryTeam(opts.token, opts.teamId);
   }
 
-  const { candidateTeamIds, username } = await selectTeams(opts.token);
+  const userData = await fetchApi({
+    token: opts.token,
+    endpoint: "/v2/user",
+  }).then(UserSchema.parse);
+  const { defaultTeamId, username } = userData.user;
 
-  for (const teamId of candidateTeamIds) {
+  // 1. Try defaultTeamId first
+  if (defaultTeamId) {
     try {
-      return await tryTeam(opts.token, teamId);
-    } catch (e) {
-      if (e instanceof NotOk && e.response.statusCode === 403) {
-        continue;
+      const result = await tryTeam(opts.token, defaultTeamId);
+      // Resolve team slug (best-effort)
+      try {
+        const team = await fetchApi({
+          token: opts.token,
+          endpoint: `/v2/teams/${encodeURIComponent(defaultTeamId)}`,
+        }).then(z.object({ slug: z.string() }).parse);
+        return { ...result, teamSlug: team.slug };
+      } catch {
+        return result;
       }
-      throw e;
+    } catch (e) {
+      if (!(e instanceof NotOk) || e.response.statusCode !== 403) throw e;
     }
+  }
+
+  // 2. Paginate teams in pages of 20, try best hobby team per page
+  let next: number | null = null;
+  do {
+    const endpoint: string =
+      next === null
+        ? "/v2/teams?limit=20"
+        : `/v2/teams?limit=20&until=${next}`;
+    const page = await fetchApi({ token: opts.token, endpoint }).then(
+      TeamsSchema.parse,
+    );
+
+    const hobbyOwnerTeams = page.teams.filter(
+      (t) => t.membership.role === "OWNER" && t.billing.plan === "hobby",
+    );
+    if (hobbyOwnerTeams.length === 0) {
+      continue;
+    }
+
+    const bestHobbyTeam =
+      hobbyOwnerTeams.find((t) => t.slug === username) ??
+      hobbyOwnerTeams.sort((a, b) => b.updatedAt - a.updatedAt)[0];
+
+    if (bestHobbyTeam && bestHobbyTeam.id !== defaultTeamId) {
+      try {
+        const result = await tryTeam(opts.token, bestHobbyTeam.id);
+        return { ...result, teamSlug: bestHobbyTeam.slug };
+      } catch (e) {
+        if (!(e instanceof NotOk) || e.response.statusCode !== 403) throw e;
+      }
+    }
+
+    next = page.pagination.next;
+  } while (next !== null);
+
+  // 3. Fall back to username as personal team
+  try {
+    const result = await tryTeam(opts.token, username);
+    return { ...result, teamSlug: username };
+  } catch (e) {
+    if (!(e instanceof NotOk) || e.response.statusCode !== 403) throw e;
   }
 
   throw new NotOk({
@@ -127,50 +196,31 @@ async function tryTeam(
 }
 
 /**
- * Builds an ordered list of candidate team IDs to try for sandbox creation.
- *
- * Fetches the user profile and their teams in parallel. Returns the user's
- * `defaultTeamId` first (if set), followed by the best hobby-plan OWNER team:
- * the one whose slug matches the username, or the most recently updated.
- *
- * @param token - Authentication token used to call the Vercel API.
- * @returns The ordered candidate team IDs and the username.
+ * Best-effort resolution of team slug and project name for a linked project.
+ * Both IDs may be opaque (e.g. `team_xxx`, `prj_xxx`), so we fetch the
+ * human-readable names from the API in parallel.
  */
-export async function selectTeams(
+async function resolveLinkedProjectSlugs(
   token: string,
-): Promise<{ candidateTeamIds: string[]; username: string }> {
-  const [userData, teamsData] = await Promise.all([
-    fetchApi({ token, endpoint: "/v2/user" }).then(UserSchema.parse),
-    fetchApi({ token, endpoint: "/v2/teams?limit=100" }).then(
-      TeamsSchema.parse,
-    ),
-  ]);
-
-  const { defaultTeamId, username } = userData.user;
-
-  const hobbyOwnerTeams = teamsData.teams.filter(
-    (t) => t.membership.role === "OWNER" && t.billing.plan === "hobby",
-  );
-
-  // Pick the personal team (slug matches username), or the most recently updated
-  const bestHobbyTeam =
-    hobbyOwnerTeams.find((t) => t.slug === username) ??
-    hobbyOwnerTeams.sort((a, b) => b.updatedAt - a.updatedAt)[0];
-
-  const candidateTeamIds: string[] = [];
-
-  if (defaultTeamId) {
-    candidateTeamIds.push(defaultTeamId);
+  teamId: string,
+  projectId: string,
+): Promise<{ teamSlug?: string; projectSlug?: string }> {
+  try {
+    const teamParam = teamId.startsWith("team_")
+      ? `teamId=${encodeURIComponent(teamId)}`
+      : `slug=${encodeURIComponent(teamId)}`;
+    const [teamData, projectData] = await Promise.all([
+      fetchApi({
+        token,
+        endpoint: `/v2/teams/${encodeURIComponent(teamId)}`,
+      }).then(z.object({ slug: z.string() }).parse),
+      fetchApi({
+        token,
+        endpoint: `/v2/projects/${encodeURIComponent(projectId)}?${teamParam}`,
+      }).then(z.object({ name: z.string() }).parse),
+    ]);
+    return { teamSlug: teamData.slug, projectSlug: projectData.name };
+  } catch {
+    return {};
   }
-
-  if (bestHobbyTeam && !candidateTeamIds.includes(bestHobbyTeam.id)) {
-    candidateTeamIds.push(bestHobbyTeam.id);
-  }
-
-  // If no teams found at all, try the username as personal team
-  if (candidateTeamIds.length === 0) {
-    candidateTeamIds.push(username);
-  }
-
-  return { candidateTeamIds, username };
 }


### PR DESCRIPTION
## Summary

- Fetches both `/v2/user` and `/v2/teams` in parallel to build an ordered list of candidate teams for scope inference
- Tries `user.defaultTeamId` first, then falls back to the best hobby-plan OWNER team (personal team matching username, or most recently updated)
- Filters fallback candidates by `billing.plan === 'hobby'` and `membership.role === 'OWNER'` to avoid selecting pro/enterprise teams
- On 403, skips to the next candidate instead of failing immediately
- Only throws after all candidates are exhausted, with a helpful error message including the authenticated username