### PR TITLE
chore(sandbox): fix the CLI tests

### DIFF
--- a/packages/sandbox/vitest.config.mts
+++ b/packages/sandbox/vitest.config.mts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      // cmd-ts ships both CJS and ESM but its "main" points to CJS, which
+      // tries to require() chalk v5 (ESM-only). Force the ESM entry.
+      "cmd-ts": path.join(
+        path.dirname(require.resolve("cmd-ts/package.json")),
+        "dist/esm/index.js",
+      ),
+    },
+  },
+});


### PR DESCRIPTION
The CLI tests are not working.

```
 FAIL  test/args/auth.test.ts [ test/args/auth.test.ts ]
 FAIL  test/args/scope.test.ts [ test/args/scope.test.ts ]
 FAIL  test/commands/cp.test.ts [ test/commands/cp.test.ts ]
 FAIL  test/types/duration.test.ts [ test/types/duration.test.ts ]
Error: require() of ES Module /Users/marc/Documents/Repositories/sandbox/node_modules/.pnpm/chalk@5.6.0/node_modules/chalk/source/index.js from /Users/marc/Documents/Repositories/sandbox/node_modules/.pnpm/cmd-ts@0.15.0/node_modules/cmd-ts/dist/cjs/subcommands.js not supported.
Instead change the require of index.js in /Users/marc/Documents/Repositories/sandbox/node_modules/.pnpm/cmd-ts@0.15.0/node_modules/cmd-ts/dist/cjs/subcommands.js to a dynamic import() which is available in all CommonJS modules.
 ❯ Object.<anonymous> ../../node_modules/.pnpm/cmd-ts@0.15.0/node_modules/cmd-ts/dist/cjs/subcommands.js:40:33
```

Fix them by adding a new vitest config file where we explicitly point `cmd-ts` to load the ESM entry.