### PR TITLE
feat(vercel-sandbox): support HTTP2 connection pooling

### DIFF
--- a/.changeset/major-taxes-wear.md
+++ b/.changeset/major-taxes-wear.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Support HTTP2 connections

--- a/packages/vercel-sandbox/src/api-client/base-client.ts
+++ b/packages/vercel-sandbox/src/api-client/base-client.ts
@@ -15,6 +15,7 @@ export interface RequestParams extends RequestInit {
 
 const DEFAULT_AGENT = new Agent({
   bodyTimeout: 0, // disable body timeout to allow long logs streaming
+  allowH2: true,
 });
 
 /**


### PR DESCRIPTION
The SDK usually makes sequential requests per operation, but sometimes we do multiple requests. Now even more that we have a shared agent pool.

When one connection is held open by a streaming response, the next request must open a brand new TCP+TLS connection.

With `allowH2: true`, undici negotiates HTTP/2 on the first TLS connection. HTTP/2 multiplexes multiple request/response streams over a single TCP+TLS connection. So even while the streaming connection is in-use, we can reuse the same connection — no new handshake.