### PR TITLE
feat(docs): add clarification for vCPUs on enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ recreate an API client using OIDC or environment credentials when needed.
 
 ## Limitations
 
-- Max resources: 8 vCPUs. You will get 2048 MB of memory per vCPU.
+- Max resources: 8 vCPUs on Hobby/Pro, 32 vCPUs on Enterprise. You will get 2048 MB of memory per vCPU.
 - Sandboxes have a maximum runtime duration of 5 hours for Pro/Enterprise and 45 minutes for Hobby,
   with a default of 5 minutes. This can be configured using the `timeout` option of `Sandbox.create()`.
 


### PR DESCRIPTION
Enterprise now supports 32 vCPUs as per https://vercel.com/changelog/vercel-sandbox-now-supports-up-to-32-vcpu-64-gb-ram-configurations . This PR updates the README.md to reflect that.