### PR TITLE
[packages/sandbox] improve timeout values and hour format

### DIFF
--- a/.changeset/some-numbers-arrive.md
+++ b/.changeset/some-numbers-arrive.md
@@ -1,0 +1,5 @@
+---
+"sandbox": patch
+---
+
+Improve timeout hour format and example values

--- a/packages/sandbox/src/args/timeout.ts
+++ b/packages/sandbox/src/args/timeout.ts
@@ -4,7 +4,7 @@ import * as cmd from "cmd-ts";
 export const timeout = cmd.option({
   long: "timeout",
   type: Duration,
-  description: "The maximum duration a sandbox can run for. Example: 5m, 1h",
+  description: "The maximum duration a sandbox can run for. Example: 5m, 30m",
   defaultValue: () => "5 minutes" as const,
   defaultValueIsSerializable: true,
 });

--- a/packages/sandbox/src/util/output.ts
+++ b/packages/sandbox/src/util/output.ts
@@ -1,4 +1,4 @@
-import { formatDistance } from "date-fns/formatDistance";
+import { formatDistanceStrict } from "date-fns/formatDistanceStrict";
 import chalk, { ChalkInstance } from "chalk";
 import { stripVTControlCharacters } from "node:util";
 
@@ -29,11 +29,9 @@ export function timeAgo(date: string | number | Date | undefined) {
     return '-';
   }
 
-  return formatDistance(date, new Date(), {
+  return formatDistanceStrict(date, new Date(), {
     addSuffix: true,
-  })
-    .replace("about ", "")
-    .replace("less than ", "");
+  });
 }
 
 export function table<T extends object>(opts: {


### PR DESCRIPTION
Fix the timeout examples so that we do not introduce `1h` because it exceeds hobby limits. Now the example is just `5m` or `30m`.

Also, fix how we show the timeout. Before, we rounded the timeout to the closes unit (in his case 1 hour):

```
❯ sandbox list
ID                                 STATUS    CREATED         MEMORY     VCPUS   RUNTIME   TIMEOUT     SNAPSHOT
sbx_MGhwG22sB5zWNiPtGcvDsUUeN7GY   running   6 minutes ago   4,096 MB   2       node24    in 1 hour   -       
sbx_tk00HLr2SZvXzjcXT24wJ4zshsCY   running   8 minutes ago   4,096 MB   2       node24    in 1 hour   - 
```

Now, we show the exact timeout value:

```
❯ sandbox list
ID                                 STATUS    CREATED         MEMORY     VCPUS   RUNTIME   TIMEOUT         SNAPSHOT
sbx_MGhwG22sB5zWNiPtGcvDsUUeN7GY   running   7 minutes ago   4,096 MB   2       node24    in 53 minutes   -       
sbx_tk00HLr2SZvXzjcXT24wJ4zshsCY   running   8 minutes ago   4,096 MB   2       node24    in 52 minutes   -  
```