### PR TITLE
feat(vercel-sandbox): propagate span-link params across sandbox endpoints

### DIFF
--- a/.changeset/early-bats-shout.md
+++ b/.changeset/early-bats-shout.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Propagate span-link private parameters across all Sandbox API endpoint calls, matching run-command behavior.

--- a/packages/vercel-sandbox/src/api-client/api-client.test.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.test.ts
@@ -4,6 +4,16 @@ import { APIError, StreamError } from "./api-error.js";
 import { createNdjsonStream } from "../../test-utils/mock-response.js";
 import { z } from "zod";
 
+const makeCommand = () => ({
+  id: "cmd_123",
+  name: "echo",
+  args: ["hello"],
+  cwd: "/",
+  sandboxId: "sbx_123",
+  exitCode: null as number | null,
+  startedAt: 1,
+});
+
 describe("APIClient", () => {
   describe("getLogs", () => {
     let client: APIClient;
@@ -249,6 +259,38 @@ describe("APIClient", () => {
       await expect(result.finished).resolves.toMatchObject({ exitCode: 0 });
     });
 
+    it("passes span-link private params to run-command body", async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ command: { ...makeCommand() } }), {
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await client.runCommand({
+        sandboxId: "sbx_123",
+        command: "echo",
+        args: ["hello"],
+        env: {},
+        sudo: false,
+        __spanId: "span-123",
+        __traceId: "trace-123",
+        __interactive: true,
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch.mock.calls[0]?.[1]?.body).toBe(
+        JSON.stringify({
+          command: "echo",
+          args: ["hello"],
+          cwd: undefined,
+          env: {},
+          sudo: false,
+          __spanId: "span-123",
+          __traceId: "trace-123",
+        }),
+      );
+    });
+
     it("throws APIError when response status is not ok", async () => {
       mockFetch.mockResolvedValue(
         new Response(JSON.stringify({ error: "gone" }), {
@@ -443,6 +485,25 @@ describe("APIClient", () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
+    it("passes span-link private params to stop body", async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ sandbox: makeSandbox("stopping") }), {
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await client.stopSandbox({
+        sandboxId: "sbx_123",
+        __spanId: "span-stop",
+        __interactive: true,
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch.mock.calls[0]?.[1]?.body).toBe(
+        JSON.stringify({ __spanId: "span-stop" }),
+      );
+    });
+
     it("polls until stopped when blocking is true", async () => {
       mockFetch
         .mockResolvedValueOnce(
@@ -581,6 +642,115 @@ describe("APIClient", () => {
 
       expect(mockFetch.mock.calls[0]?.[1]?.body).toBe(
         JSON.stringify({ expiration: 0 }),
+      );
+    });
+
+    it("passes span-link private params to snapshot creation", async () => {
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            sandbox: {
+              id: "sbx_123",
+              memory: 2048,
+              vcpus: 1,
+              region: "iad1",
+              runtime: "node24",
+              timeout: 300000,
+              status: "running",
+              requestedAt: Date.now(),
+              createdAt: Date.now(),
+              cwd: "/",
+              updatedAt: Date.now(),
+            },
+            snapshot: {
+              id: "snap_123",
+              sourceSandboxId: "sbx_123",
+              region: "iad1",
+              status: "created",
+              sizeBytes: 1024,
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+      );
+
+      await client.createSnapshot({
+        sandboxId: "sbx_123",
+        __spanId: "span-snapshot",
+        __includeSystemRoutes: true,
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch.mock.calls[0]?.[1]?.body).toBe(
+        JSON.stringify({ __spanId: "span-snapshot" }),
+      );
+    });
+  });
+
+  describe("span-link param propagation", () => {
+    let client: APIClient;
+    let mockFetch: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockFetch = vi.fn();
+      client = new APIClient({
+        teamId: "team_123",
+        token: "1234",
+        fetch: mockFetch,
+      });
+    });
+
+    it("passes span-link private params to getCommand query only", async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ command: makeCommand() }), {
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await client.getCommand({
+        sandboxId: "sbx_123",
+        cmdId: "cmd_123",
+        __spanId: "span-get-command",
+        __interactive: true,
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const calledUrl = String(mockFetch.mock.calls[0]?.[0]);
+      expect(calledUrl).toContain("__spanId=span-get-command");
+      expect(calledUrl).not.toContain("__interactive");
+    });
+
+    it("passes span-link private params to stopSandbox body only", async () => {
+      const sandbox = {
+        id: "sbx_123",
+        memory: 2048,
+        vcpus: 1,
+        region: "iad1",
+        runtime: "node24",
+        timeout: 300000,
+        status: "stopping",
+        requestedAt: Date.now(),
+        createdAt: Date.now(),
+        cwd: "/",
+        updatedAt: Date.now(),
+      };
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ sandbox }), {
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await client.stopSandbox({
+        sandboxId: "sbx_123",
+        __traceId: "trace-stop",
+        __includeSystemRoutes: true,
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch.mock.calls[0]?.[1]?.body).toBe(
+        JSON.stringify({ __traceId: "trace-stop" }),
       );
     });
   });

--- a/packages/vercel-sandbox/src/api-client/api-client.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.ts
@@ -35,9 +35,12 @@ import { getVercelOidcToken } from "@vercel/oidc";
 import { NetworkPolicy } from "../network-policy.js";
 import {
   toAPINetworkPolicy,
-  fromAPINetworkPolicy,
 } from "../utils/network-policy.js";
-import { getPrivateParams, WithPrivate } from "../utils/types.js";
+import {
+  getPrivateParams,
+  getSpanLinkPrivateParams,
+  WithPrivate,
+} from "../utils/types.js";
 import { RUNTIMES } from "../constants.js";
 import { setTimeout } from "node:timers/promises";
 
@@ -197,7 +200,7 @@ export class APIClient extends BaseClient {
     );
   }
 
-  async runCommand(params: {
+  async runCommand(params: WithPrivate<{
     sandboxId: string;
     cwd?: string;
     command: string;
@@ -206,8 +209,8 @@ export class APIClient extends BaseClient {
     sudo: boolean;
     wait: true;
     signal?: AbortSignal;
-  }): Promise<{ command: CommandData; finished: Promise<CommandFinishedData> }>;
-  async runCommand(params: {
+  }>): Promise<{ command: CommandData; finished: Promise<CommandFinishedData> }>;
+  async runCommand(params: WithPrivate<{
     sandboxId: string;
     cwd?: string;
     command: string;
@@ -216,8 +219,8 @@ export class APIClient extends BaseClient {
     sudo: boolean;
     wait?: false;
     signal?: AbortSignal;
-  }): Promise<Parsed<z.infer<typeof CommandResponse>>>;
-  async runCommand(params: {
+  }>): Promise<Parsed<z.infer<typeof CommandResponse>>>;
+  async runCommand(params: WithPrivate<{
     sandboxId: string;
     cwd?: string;
     command: string;
@@ -226,7 +229,8 @@ export class APIClient extends BaseClient {
     sudo: boolean;
     wait?: boolean;
     signal?: AbortSignal;
-  }) {
+  }>) {
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
     if (params.wait) {
       const response = await this.request(
         `/v1/sandboxes/${params.sandboxId}/cmd`,
@@ -239,6 +243,7 @@ export class APIClient extends BaseClient {
             env: params.env,
             sudo: params.sudo,
             wait: true,
+            ...spanLinkPrivateParams,
           }),
           signal: params.signal,
         },
@@ -306,72 +311,84 @@ export class APIClient extends BaseClient {
           cwd: params.cwd,
           env: params.env,
           sudo: params.sudo,
+          ...spanLinkPrivateParams,
         }),
         signal: params.signal,
       }),
     );
   }
 
-  async getCommand(params: {
+  async getCommand(params: WithPrivate<{
     sandboxId: string;
     cmdId: string;
     wait: true;
     signal?: AbortSignal;
-  }): Promise<Parsed<z.infer<typeof CommandFinishedResponse>>>;
-  async getCommand(params: {
+  }>): Promise<Parsed<z.infer<typeof CommandFinishedResponse>>>;
+  async getCommand(params: WithPrivate<{
     sandboxId: string;
     cmdId: string;
     wait?: boolean;
     signal?: AbortSignal;
-  }): Promise<Parsed<z.infer<typeof CommandResponse>>>;
-  async getCommand(params: {
+  }>): Promise<Parsed<z.infer<typeof CommandResponse>>>;
+  async getCommand(params: WithPrivate<{
     sandboxId: string;
     cmdId: string;
     wait?: boolean;
     signal?: AbortSignal;
-  }) {
+  }>) {
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
+    const query = params.wait
+      ? { wait: "true", ...spanLinkPrivateParams }
+      : { ...spanLinkPrivateParams };
     return params.wait
       ? parseOrThrow(
           CommandFinishedResponse,
           await this.request(
             `/v1/sandboxes/${params.sandboxId}/cmd/${params.cmdId}`,
-            { signal: params.signal, query: { wait: "true" } },
+            { signal: params.signal, query },
           ),
         )
       : parseOrThrow(
           CommandResponse,
           await this.request(
             `/v1/sandboxes/${params.sandboxId}/cmd/${params.cmdId}`,
-            { signal: params.signal },
+            { signal: params.signal, query },
           ),
         );
   }
 
-  async mkDir(params: {
+  async mkDir(params: WithPrivate<{
     sandboxId: string;
     path: string;
     cwd?: string;
     signal?: AbortSignal;
-  }) {
+  }>) {
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
     return parseOrThrow(
       EmptyResponse,
       await this.request(`/v1/sandboxes/${params.sandboxId}/fs/mkdir`, {
         method: "POST",
-        body: JSON.stringify({ path: params.path, cwd: params.cwd }),
+        body: JSON.stringify({
+          path: params.path,
+          cwd: params.cwd,
+          ...spanLinkPrivateParams,
+        }),
         signal: params.signal,
       }),
     );
   }
 
-  getFileWriter(params: {
+  getFileWriter(params: WithPrivate<{
     sandboxId: string;
     extractDir: string;
     signal?: AbortSignal;
-  }) {
+  }>) {
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
     const writer = new FileWriter();
     return {
       response: (async () => {
         return this.request(`/v1/sandboxes/${params.sandboxId}/fs/write`, {
+          query: { ...spanLinkPrivateParams },
           method: "POST",
           headers: {
             "content-type": "application/gzip",
@@ -385,7 +402,7 @@ export class APIClient extends BaseClient {
     };
   }
 
-  async listSandboxes(params: {
+  async listSandboxes(params: WithPrivate<{
     /**
      * The ID or name of the project to which the sandboxes belong.
      * @example "my-project"
@@ -407,7 +424,8 @@ export class APIClient extends BaseClient {
      */
     until?: number | Date;
     signal?: AbortSignal;
-  }) {
+  }>) {
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
     return parseOrThrow(
       SandboxesResponse,
       await this.request(`/v1/sandboxes`, {
@@ -422,6 +440,7 @@ export class APIClient extends BaseClient {
             typeof params.until === "number"
               ? params.until
               : params.until?.getTime(),
+          ...spanLinkPrivateParams,
         },
         method: "GET",
         signal: params.signal,
@@ -429,7 +448,7 @@ export class APIClient extends BaseClient {
     );
   }
 
-  async listSnapshots(params: {
+  async listSnapshots(params: WithPrivate<{
     /**
      * The ID or name of the project to which the snapshots belong.
      * @example "my-project"
@@ -451,7 +470,8 @@ export class APIClient extends BaseClient {
      */
     until?: number | Date;
     signal?: AbortSignal;
-  }) {
+  }>) {
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
     return parseOrThrow(
       SnapshotsResponse,
       await this.request(`/v1/sandboxes/snapshots`, {
@@ -466,6 +486,7 @@ export class APIClient extends BaseClient {
             typeof params.until === "number"
               ? params.until
               : params.until?.getTime(),
+          ...spanLinkPrivateParams,
         },
         method: "GET",
         signal: params.signal,
@@ -473,7 +494,7 @@ export class APIClient extends BaseClient {
     );
   }
 
-  async writeFiles(params: {
+  async writeFiles(params: WithPrivate<{
     sandboxId: string;
     cwd: string;
     files: {
@@ -483,11 +504,13 @@ export class APIClient extends BaseClient {
     }[];
     extractDir: string;
     signal?: AbortSignal;
-  }) {
+  }>) {
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
     const { writer, response } = this.getFileWriter({
       sandboxId: params.sandboxId,
       extractDir: params.extractDir,
       signal: params.signal,
+      ...spanLinkPrivateParams,
     });
 
     for (const file of params.files) {
@@ -506,17 +529,22 @@ export class APIClient extends BaseClient {
     await parseOrThrow(EmptyResponse, await response);
   }
 
-  async readFile(params: {
+  async readFile(params: WithPrivate<{
     sandboxId: string;
     path: string;
     cwd?: string;
     signal?: AbortSignal;
-  }): Promise<Readable | null> {
+  }>): Promise<Readable | null> {
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
     const response = await this.request(
       `/v1/sandboxes/${params.sandboxId}/fs/read`,
       {
         method: "POST",
-        body: JSON.stringify({ path: params.path, cwd: params.cwd }),
+        body: JSON.stringify({
+          path: params.path,
+          cwd: params.cwd,
+          ...spanLinkPrivateParams,
+        }),
         signal: params.signal,
       },
     );
@@ -532,30 +560,31 @@ export class APIClient extends BaseClient {
     return Readable.fromWeb(response.body);
   }
 
-  async killCommand(params: {
+  async killCommand(params: WithPrivate<{
     sandboxId: string;
     commandId: string;
     signal: number;
     abortSignal?: AbortSignal;
-  }) {
+  }>) {
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
     return parseOrThrow(
       CommandResponse,
       await this.request(
         `/v1/sandboxes/${params.sandboxId}/${params.commandId}/kill`,
         {
           method: "POST",
-          body: JSON.stringify({ signal: params.signal }),
+          body: JSON.stringify({ signal: params.signal, ...spanLinkPrivateParams }),
           signal: params.abortSignal,
         },
       ),
     );
   }
 
-  getLogs(params: {
+  getLogs(params: WithPrivate<{
     sandboxId: string;
     cmdId: string;
     signal?: AbortSignal;
-  }): AsyncGenerator<
+  }>): AsyncGenerator<
     z.infer<typeof LogLineStdout> | z.infer<typeof LogLineStderr>,
     void,
     void
@@ -566,12 +595,14 @@ export class APIClient extends BaseClient {
     const signal = !params.signal
       ? disposer.signal
       : mergeSignals(params.signal, disposer.signal);
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
 
     const generator = (async function* () {
       const url = `/v1/sandboxes/${params.sandboxId}/cmd/${params.cmdId}/logs`;
       const response = await self.request(url, {
         method: "GET",
         signal,
+        query: { ...spanLinkPrivateParams },
       });
 
       if (!response.ok) {
@@ -618,15 +649,24 @@ export class APIClient extends BaseClient {
     });
   }
 
-  async stopSandbox(params: {
+  async stopSandbox(params: WithPrivate<{
     sandboxId: string;
     signal?: AbortSignal;
     blocking?: boolean;
-  }): Promise<Parsed<z.infer<typeof SandboxResponse>>> {
+  }>): Promise<Parsed<z.infer<typeof SandboxResponse>>> {
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
+    const hasSpanLinkPrivateParams =
+      Object.keys(spanLinkPrivateParams).length > 0;
     const url = `/v1/sandboxes/${params.sandboxId}/stop`;
     const response = await parseOrThrow(
       SandboxResponse,
-      await this.request(url, { method: "POST", signal: params.signal }),
+      await this.request(url, {
+        method: "POST",
+        ...(hasSpanLinkPrivateParams && {
+          body: JSON.stringify(spanLinkPrivateParams),
+        }),
+        signal: params.signal,
+      }),
     );
 
     if (params.blocking) {
@@ -649,48 +689,61 @@ export class APIClient extends BaseClient {
     return response;
   }
 
-  async updateNetworkPolicy(params: {
+  async updateNetworkPolicy(params: WithPrivate<{
     sandboxId: string;
     networkPolicy: NetworkPolicy;
     signal?: AbortSignal;
-  }): Promise<Parsed<z.infer<typeof UpdateNetworkPolicyResponse>>> {
+  }>): Promise<Parsed<z.infer<typeof UpdateNetworkPolicyResponse>>> {
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
     const url = `/v1/sandboxes/${params.sandboxId}/network-policy`;
     return parseOrThrow(
       UpdateNetworkPolicyResponse,
       await this.request(url, {
         method: "POST",
-        body: JSON.stringify(toAPINetworkPolicy(params.networkPolicy)),
+        body: JSON.stringify({
+          ...toAPINetworkPolicy(params.networkPolicy),
+          ...spanLinkPrivateParams,
+        }),
         signal: params.signal,
       }),
     );
   }
 
-  async extendTimeout(params: {
+  async extendTimeout(params: WithPrivate<{
     sandboxId: string;
     duration: number;
     signal?: AbortSignal;
-  }): Promise<Parsed<z.infer<typeof ExtendTimeoutResponse>>> {
+  }>): Promise<Parsed<z.infer<typeof ExtendTimeoutResponse>>> {
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
     const url = `/v1/sandboxes/${params.sandboxId}/extend-timeout`;
     return parseOrThrow(
       ExtendTimeoutResponse,
       await this.request(url, {
         method: "POST",
-        body: JSON.stringify({ duration: params.duration }),
+        body: JSON.stringify({
+          duration: params.duration,
+          ...spanLinkPrivateParams,
+        }),
         signal: params.signal,
       }),
     );
   }
 
-  async createSnapshot(params: {
+  async createSnapshot(params: WithPrivate<{
     sandboxId: string;
     expiration?: number;
     signal?: AbortSignal;
-  }): Promise<Parsed<z.infer<typeof CreateSnapshotResponse>>> {
+  }>): Promise<Parsed<z.infer<typeof CreateSnapshotResponse>>> {
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
+    const bodyObj: Record<string, unknown> = {
+      ...spanLinkPrivateParams,
+    };
+    if (params.expiration !== undefined) {
+      bodyObj.expiration = params.expiration;
+    }
     const url = `/v1/sandboxes/${params.sandboxId}/snapshot`;
     const body =
-      params.expiration === undefined
-        ? undefined
-        : JSON.stringify({ expiration: params.expiration });
+      Object.keys(bodyObj).length > 0 ? JSON.stringify(bodyObj) : undefined;
     return parseOrThrow(
       CreateSnapshotResponse,
       await this.request(url, {
@@ -701,25 +754,34 @@ export class APIClient extends BaseClient {
     );
   }
 
-  async deleteSnapshot(params: {
+  async deleteSnapshot(params: WithPrivate<{
     snapshotId: string;
     signal?: AbortSignal;
-  }): Promise<Parsed<z.infer<typeof SnapshotResponse>>> {
+  }>): Promise<Parsed<z.infer<typeof SnapshotResponse>>> {
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
     const url = `/v1/sandboxes/snapshots/${params.snapshotId}`;
     return parseOrThrow(
       SnapshotResponse,
-      await this.request(url, { method: "DELETE", signal: params.signal }),
+      await this.request(url, {
+        method: "DELETE",
+        signal: params.signal,
+        query: { ...spanLinkPrivateParams },
+      }),
     );
   }
 
-  async getSnapshot(params: {
+  async getSnapshot(params: WithPrivate<{
     snapshotId: string;
     signal?: AbortSignal;
-  }): Promise<Parsed<z.infer<typeof SnapshotResponse>>> {
+  }>): Promise<Parsed<z.infer<typeof SnapshotResponse>>> {
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
     const url = `/v1/sandboxes/snapshots/${params.snapshotId}`;
     return parseOrThrow(
       SnapshotResponse,
-      await this.request(url, { signal: params.signal }),
+      await this.request(url, {
+        signal: params.signal,
+        query: { ...spanLinkPrivateParams },
+      }),
     );
   }
 }

--- a/packages/vercel-sandbox/src/command.serialize.test.ts
+++ b/packages/vercel-sandbox/src/command.serialize.test.ts
@@ -144,6 +144,28 @@ describe("CommandFinished serialization", () => {
       expect(serialized).not.toHaveProperty("client");
       expect(JSON.stringify(serialized)).not.toContain("token");
     });
+
+    it("serializes span-link private params", () => {
+      const commandFinished = new CommandFinished({
+        client: new APIClient({
+          teamId: "team_test",
+          token: "test_token",
+        }),
+        sandboxId: mockSandboxId,
+        cmd: mockCommandData,
+        exitCode: 0,
+        spanLinkPrivateParams: {
+          __spanId: "span-command-finished",
+          __traceId: "trace-command-finished",
+        },
+      });
+
+      const serialized = CommandFinished[WORKFLOW_SERIALIZE](commandFinished);
+      expect(serialized.spanLinkPrivateParams).toEqual({
+        __spanId: "span-command-finished",
+        __traceId: "trace-command-finished",
+      });
+    });
   });
 
   describe("WORKFLOW_DESERIALIZE", () => {
@@ -627,6 +649,27 @@ describe("Command serialization", () => {
 
       expect(parsed.sandboxId).toBe(mockSandboxId);
       expect(parsed.output).toEqual(mockOutput);
+    });
+
+    it("serializes span-link private params", () => {
+      const command = new Command({
+        client: new APIClient({
+          teamId: "team_test",
+          token: "test_token",
+        }),
+        sandboxId: mockSandboxId,
+        cmd: mockCommandData,
+        spanLinkPrivateParams: {
+          __spanId: "span-command",
+          __traceId: "trace-command",
+        },
+      });
+
+      const serialized = Command[WORKFLOW_SERIALIZE](command);
+      expect(serialized.spanLinkPrivateParams).toEqual({
+        __spanId: "span-command",
+        __traceId: "trace-command",
+      });
     });
   });
 

--- a/packages/vercel-sandbox/src/command.ts
+++ b/packages/vercel-sandbox/src/command.ts
@@ -19,6 +19,8 @@ export interface SerializedCommand {
   cmd: CommandData;
   /** Cached output, included if output was fetched before serialization */
   output?: CommandOutput;
+  /** Private params used to preserve trace/span links across calls */
+  spanLinkPrivateParams?: Record<string, unknown>;
 }
 
 /**
@@ -67,6 +69,7 @@ export class Command {
    * ID of the sandbox this command is running in.
    */
   protected sandboxId: string;
+  protected spanLinkPrivateParams: Record<string, unknown>;
 
   /**
    * Data for the command execution.
@@ -109,21 +112,25 @@ export class Command {
    * @param params.sandboxId - The ID of the sandbox where the command is running.
    * @param params.cmd - The command data.
    * @param params.output - Optional cached output to restore (used during deserialization).
+   * @param params.spanLinkPrivateParams - Optional private params for trace/span propagation.
    */
   constructor({
     client,
     sandboxId,
     cmd,
     output,
+    spanLinkPrivateParams,
   }: {
     client?: APIClient;
     sandboxId: string;
     cmd: CommandData;
     output?: CommandOutput;
+    spanLinkPrivateParams?: Record<string, unknown>;
   }) {
     this._client = client ?? null;
     this.sandboxId = sandboxId;
     this.cmd = cmd;
+    this.spanLinkPrivateParams = spanLinkPrivateParams ?? {};
     this.exitCode = cmd.exitCode ?? null;
     if (output) {
       this._resolvedOutput = output;
@@ -151,6 +158,9 @@ export class Command {
     if (instance._resolvedOutput) {
       serialized.output = instance._resolvedOutput;
     }
+    if (Object.keys(instance.spanLinkPrivateParams).length > 0) {
+      serialized.spanLinkPrivateParams = instance.spanLinkPrivateParams;
+    }
     return serialized;
   }
 
@@ -168,6 +178,7 @@ export class Command {
       sandboxId: data.sandboxId,
       cmd: data.cmd,
       output: data.output,
+      spanLinkPrivateParams: data.spanLinkPrivateParams,
     });
   }
 
@@ -201,6 +212,7 @@ export class Command {
       sandboxId: this.sandboxId,
       cmdId: this.cmd.id,
       signal: opts?.signal,
+      ...this.spanLinkPrivateParams,
     });
   }
 
@@ -233,6 +245,7 @@ export class Command {
       cmdId: this.cmd.id,
       wait: true,
       signal: params?.signal,
+      ...this.spanLinkPrivateParams,
     });
 
     return new CommandFinished({
@@ -240,6 +253,7 @@ export class Command {
       sandboxId: this.sandboxId,
       cmd: command.json.command,
       exitCode: command.json.command.exitCode,
+      spanLinkPrivateParams: this.spanLinkPrivateParams,
     });
   }
 
@@ -350,6 +364,7 @@ export class Command {
       commandId: this.cmd.id,
       signal: resolveSignal(signal ?? "SIGTERM"),
       abortSignal: opts?.abortSignal,
+      ...this.spanLinkPrivateParams,
     });
   }
 }
@@ -384,6 +399,7 @@ export class CommandFinished extends Command {
     cmd: CommandData;
     exitCode: number;
     output?: CommandOutput;
+    spanLinkPrivateParams?: Record<string, unknown>;
   }) {
     super({ ...params });
     this.exitCode = params.exitCode;
@@ -421,6 +437,7 @@ export class CommandFinished extends Command {
       cmd: data.cmd,
       exitCode: data.exitCode,
       output: data.output,
+      spanLinkPrivateParams: data.spanLinkPrivateParams,
     });
   }
 

--- a/packages/vercel-sandbox/src/sandbox.serialize.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.serialize.test.ts
@@ -88,6 +88,26 @@ describe("Sandbox serialization", () => {
       expect(serialized).not.toHaveProperty("client");
       expect(JSON.stringify(serialized)).not.toContain("token");
     });
+
+    it("serializes span-link private params", () => {
+      const sandbox = new Sandbox({
+        client: new APIClient({
+          teamId: "team_test",
+          token: "test_token",
+        }),
+        sandbox: toSandboxSnapshot(mockMetadata),
+        routes: mockRoutes,
+        spanLinkPrivateParams: {
+          __spanId: "span-sandbox",
+          __traceId: "trace-sandbox",
+        },
+      });
+      const serialized = serializeSandbox(sandbox);
+      expect(serialized.spanLinkPrivateParams).toEqual({
+        __spanId: "span-sandbox",
+        __traceId: "trace-sandbox",
+      });
+    });
   });
 
   describe("WORKFLOW_DESERIALIZE", () => {

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -183,6 +183,34 @@ describe("_runCommand error handling", () => {
   });
 });
 
+describe("span-link private params forwarding", () => {
+  it("forwards persisted span-link params to non-runCommand endpoints", async () => {
+    const mkDirMock = vi.fn(async () => ({ json: {} }));
+    const sandbox = new Sandbox({
+      client: {
+        mkDir: mkDirMock,
+      } as unknown as APIClient,
+      routes: [],
+      sandbox: makeSandboxMetadata(),
+      spanLinkPrivateParams: {
+        __spanId: "span-mkdir",
+        __traceId: "trace-mkdir",
+      },
+    });
+
+    await sandbox.mkDir("/tmp/test");
+
+    expect(mkDirMock).toHaveBeenCalledTimes(1);
+    expect(mkDirMock).toHaveBeenCalledWith({
+      sandboxId: "sbx_123",
+      path: "/tmp/test",
+      signal: undefined,
+      __spanId: "span-mkdir",
+      __traceId: "trace-mkdir",
+    });
+  });
+});
+
 describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")("Sandbox", () => {
   const PORTS = [3000, 4000];
   let sandbox: Sandbox;

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -21,7 +21,11 @@ import {
   type SandboxSnapshot,
   toSandboxSnapshot,
 } from "./utils/sandbox-snapshot.js";
-import { getPrivateParams, type WithPrivate } from "./utils/types.js";
+import {
+  getPrivateParams,
+  getSpanLinkPrivateParams,
+  type WithPrivate,
+} from "./utils/types.js";
 import { FileSystem } from "./filesystem.js";
 
 export type { NetworkPolicy, NetworkPolicyRule, NetworkTransformer };
@@ -126,6 +130,7 @@ interface GetSandboxParams {
 export interface SerializedSandbox {
   metadata: SandboxSnapshot;
   routes: SandboxRouteData[];
+  spanLinkPrivateParams?: Record<string, unknown>;
 }
 
 /** @inline */
@@ -180,6 +185,7 @@ interface RunCommandParams {
  */
 export class Sandbox {
   private _client: APIClient | null = null;
+  private spanLinkPrivateParams: Record<string, unknown>;
 
   /**
    * Lazily resolve credentials and construct an API client.
@@ -313,10 +319,14 @@ export class Sandbox {
    * @returns A plain object containing sandbox metadata and routes
    */
   static [WORKFLOW_SERIALIZE](instance: Sandbox): SerializedSandbox {
-    return {
+    const serialized: SerializedSandbox = {
       metadata: instance.sandbox,
       routes: instance.routes,
     };
+    if (Object.keys(instance.spanLinkPrivateParams).length > 0) {
+      serialized.spanLinkPrivateParams = instance.spanLinkPrivateParams;
+    }
+    return serialized;
   }
 
   /**
@@ -332,6 +342,7 @@ export class Sandbox {
     return new Sandbox({
       sandbox: data.metadata,
       routes: data.routes,
+      spanLinkPrivateParams: data.spanLinkPrivateParams,
     });
   }
 
@@ -362,6 +373,7 @@ export class Sandbox {
     });
 
     const privateParams = getPrivateParams(params);
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
     const sandbox = await client.createSandbox({
       source: params?.source,
       projectId: credentials.projectId,
@@ -379,6 +391,7 @@ export class Sandbox {
       client,
       sandbox: toSandboxSnapshot(sandbox.json.sandbox),
       routes: sandbox.json.routes,
+      spanLinkPrivateParams,
     });
   }
 
@@ -401,6 +414,7 @@ export class Sandbox {
     });
 
     const privateParams = getPrivateParams(params);
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
     const sandbox = await client.getSandbox({
       sandboxId: params.sandboxId,
       signal: params.signal,
@@ -411,6 +425,7 @@ export class Sandbox {
       client,
       sandbox: toSandboxSnapshot(sandbox.json.sandbox),
       routes: sandbox.json.routes,
+      spanLinkPrivateParams,
     });
   }
 
@@ -425,14 +440,17 @@ export class Sandbox {
     client,
     routes,
     sandbox,
+    spanLinkPrivateParams,
   }: {
     client?: APIClient;
     routes: SandboxRouteData[];
     sandbox: SandboxSnapshot;
+    spanLinkPrivateParams?: Record<string, unknown>;
   }) {
     this._client = client ?? null;
     this.routes = routes;
     this.sandbox = sandbox;
+    this.spanLinkPrivateParams = spanLinkPrivateParams ?? {};
     this.fs = new FileSystem(this);
   }
 
@@ -454,12 +472,14 @@ export class Sandbox {
       sandboxId: this.sandbox.id,
       cmdId,
       signal: opts?.signal,
+      ...this.spanLinkPrivateParams,
     });
 
     return new Command({
       client,
       sandboxId: this.sandbox.id,
       cmd: command.json.command,
+      spanLinkPrivateParams: this.spanLinkPrivateParams,
     });
   }
 
@@ -540,12 +560,14 @@ export class Sandbox {
         sudo: params.sudo ?? false,
         wait: true,
         signal: params.signal,
+        ...this.spanLinkPrivateParams,
       });
 
       const command = new Command({
         client,
         sandboxId: this.sandbox.id,
         cmd: commandStream.command,
+        spanLinkPrivateParams: this.spanLinkPrivateParams,
       });
 
       const [finished] = await Promise.all([
@@ -557,6 +579,7 @@ export class Sandbox {
         sandboxId: this.sandbox.id,
         cmd: finished,
         exitCode: finished.exitCode ?? 0,
+        spanLinkPrivateParams: this.spanLinkPrivateParams,
       });
     }
 
@@ -568,12 +591,14 @@ export class Sandbox {
       env: params.env ?? {},
       sudo: params.sudo ?? false,
       signal: params.signal,
+      ...this.spanLinkPrivateParams,
     });
 
     const command = new Command({
       client,
       sandboxId: this.sandbox.id,
       cmd: commandResponse.json.command,
+      spanLinkPrivateParams: this.spanLinkPrivateParams,
     });
 
     void pipeLogs(command).catch((err) => {
@@ -600,6 +625,7 @@ export class Sandbox {
       sandboxId: this.sandbox.id,
       path: path,
       signal: opts?.signal,
+      ...this.spanLinkPrivateParams,
     });
   }
 
@@ -622,6 +648,7 @@ export class Sandbox {
       path: file.path,
       cwd: file.cwd,
       signal: opts?.signal,
+      ...this.spanLinkPrivateParams,
     });
   }
 
@@ -644,6 +671,7 @@ export class Sandbox {
       path: file.path,
       cwd: file.cwd,
       signal: opts?.signal,
+      ...this.spanLinkPrivateParams,
     });
 
     if (stream === null) {
@@ -683,6 +711,7 @@ export class Sandbox {
       path: src.path,
       cwd: src.cwd,
       signal: opts?.signal,
+      ...this.spanLinkPrivateParams,
     });
 
     if (stream === null) {
@@ -735,6 +764,7 @@ export class Sandbox {
       extractDir: "/",
       files: files,
       signal: opts?.signal,
+      ...this.spanLinkPrivateParams,
     });
   }
 
@@ -772,6 +802,7 @@ export class Sandbox {
       sandboxId: this.sandbox.id,
       signal: opts?.signal,
       blocking: opts?.blocking,
+      ...this.spanLinkPrivateParams,
     });
     this.sandbox = toSandboxSnapshot(response.json.sandbox);
     return this.sandbox;
@@ -818,6 +849,7 @@ export class Sandbox {
       sandboxId: this.sandbox.id,
       networkPolicy: networkPolicy,
       signal: opts?.signal,
+      ...this.spanLinkPrivateParams,
     });
 
     // Update the internal sandbox metadata with the new timeout value
@@ -851,6 +883,7 @@ export class Sandbox {
       sandboxId: this.sandbox.id,
       duration,
       signal: opts?.signal,
+      ...this.spanLinkPrivateParams,
     });
 
     // Update the internal sandbox metadata with the new timeout value
@@ -878,6 +911,7 @@ export class Sandbox {
       sandboxId: this.sandbox.id,
       expiration: opts?.expiration,
       signal: opts?.signal,
+      ...this.spanLinkPrivateParams,
     });
 
     this.sandbox = toSandboxSnapshot(response.json.sandbox);
@@ -885,6 +919,7 @@ export class Sandbox {
     return new Snapshot({
       client,
       snapshot: response.json.snapshot,
+      spanLinkPrivateParams: this.spanLinkPrivateParams,
     });
   }
 }

--- a/packages/vercel-sandbox/src/snapshot.serialize.test.ts
+++ b/packages/vercel-sandbox/src/snapshot.serialize.test.ts
@@ -78,6 +78,25 @@ describe("Snapshot serialization", () => {
       expect(serialized).not.toHaveProperty("_client");
       expect(JSON.stringify(serialized)).not.toContain("token");
     });
+
+    it("serializes span-link private params", () => {
+      const snapshot = new Snapshot({
+        client: new APIClient({
+          teamId: "team_test",
+          token: "test_token",
+        }),
+        snapshot: mockSnapshotMetadata,
+        spanLinkPrivateParams: {
+          __spanId: "span-snapshot",
+          __traceId: "trace-snapshot",
+        },
+      });
+      const serialized = serializeSnapshot(snapshot);
+      expect(serialized.spanLinkPrivateParams).toEqual({
+        __spanId: "span-snapshot",
+        __traceId: "trace-snapshot",
+      });
+    });
   });
 
   describe("WORKFLOW_DESERIALIZE", () => {

--- a/packages/vercel-sandbox/src/snapshot.ts
+++ b/packages/vercel-sandbox/src/snapshot.ts
@@ -3,9 +3,11 @@ import type { WithFetchOptions } from "./api-client/api-client.js";
 import type { SnapshotMetadata } from "./api-client/index.js";
 import { APIClient } from "./api-client/index.js";
 import { type Credentials, getCredentials } from "./utils/get-credentials.js";
+import { getSpanLinkPrivateParams } from "./utils/types.js";
 
 export interface SerializedSnapshot {
   snapshot: SnapshotMetadata;
+  spanLinkPrivateParams?: Record<string, unknown>;
 }
 
 /** @inline */
@@ -28,6 +30,7 @@ interface GetSnapshotParams {
  */
 export class Snapshot {
   private _client: APIClient | null = null;
+  private spanLinkPrivateParams: Record<string, unknown>;
 
   /**
    * Lazily resolve credentials and construct an API client.
@@ -104,9 +107,13 @@ export class Snapshot {
    * @returns A plain object containing snapshot metadata
    */
   static [WORKFLOW_SERIALIZE](instance: Snapshot): SerializedSnapshot {
-    return {
+    const serialized: SerializedSnapshot = {
       snapshot: instance.snapshot,
     };
+    if (Object.keys(instance.spanLinkPrivateParams).length > 0) {
+      serialized.spanLinkPrivateParams = instance.spanLinkPrivateParams;
+    }
+    return serialized;
   }
 
   /**
@@ -121,18 +128,22 @@ export class Snapshot {
   static [WORKFLOW_DESERIALIZE](data: SerializedSnapshot): Snapshot {
     return new Snapshot({
       snapshot: data.snapshot,
+      spanLinkPrivateParams: data.spanLinkPrivateParams,
     });
   }
 
   constructor({
     client,
     snapshot,
+    spanLinkPrivateParams,
   }: {
     client?: APIClient;
     snapshot: SnapshotMetadata;
+    spanLinkPrivateParams?: Record<string, unknown>;
   }) {
     this._client = client ?? null;
     this.snapshot = snapshot;
+    this.spanLinkPrivateParams = spanLinkPrivateParams ?? {};
   }
 
   /**
@@ -152,9 +163,11 @@ export class Snapshot {
       token: credentials.token,
       fetch: params?.fetch,
     });
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
     return client.listSnapshots({
       ...credentials,
       ...params,
+      ...spanLinkPrivateParams,
     });
   }
 
@@ -174,14 +187,17 @@ export class Snapshot {
       token: credentials.token,
     });
 
+    const spanLinkPrivateParams = getSpanLinkPrivateParams(params);
     const sandbox = await client.getSnapshot({
       snapshotId: params.snapshotId,
       signal: params.signal,
+      ...spanLinkPrivateParams,
     });
 
     return new Snapshot({
       client,
       snapshot: sandbox.json.snapshot,
+      spanLinkPrivateParams,
     });
   }
 
@@ -198,6 +214,7 @@ export class Snapshot {
     const response = await client.deleteSnapshot({
       snapshotId: this.snapshot.id,
       signal: opts?.signal,
+      ...this.spanLinkPrivateParams,
     });
 
     this.snapshot = response.json.snapshot;

--- a/packages/vercel-sandbox/src/utils/types.test.js
+++ b/packages/vercel-sandbox/src/utils/types.test.js
@@ -1,7 +1,22 @@
 import { expect, it } from "vitest";
-import { getPrivateParams } from "./types";
+import { getPrivateParams, getSpanLinkPrivateParams } from "./types";
 
 it("getPrivateParams filters unknown params", async () => {
   const result = getPrivateParams({ foo: 123, __someParam: "abc" });
   expect(result).toEqual({ __someParam: "abc" });
+});
+
+it("getSpanLinkPrivateParams keeps only span-link keys", async () => {
+  const result = getSpanLinkPrivateParams({
+    __spanId: "span-1",
+    __traceId: "trace-1",
+    __ddParent: "dd-1",
+    __interactive: true,
+    foo: 123,
+  });
+  expect(result).toEqual({
+    __spanId: "span-1",
+    __traceId: "trace-1",
+    __ddParent: "dd-1",
+  });
 });

--- a/packages/vercel-sandbox/src/utils/types.ts
+++ b/packages/vercel-sandbox/src/utils/types.ts
@@ -8,12 +8,29 @@ export type WithPrivate<T> = T & {
   [K in `__${string}`]?: unknown;
 };
 
+const SPAN_LINK_PRIVATE_PARAM_REGEX =
+  /^__(?:span|trace|baggage|datadog|dd)/i;
+
 /**
  * Extract private parameters out of an object.
  */
 export const getPrivateParams = (params?: object) => {
   const privateEntries = Object.entries(params ?? {}).filter(([k]) =>
     k.startsWith("__"),
+  );
+  return Object.fromEntries(privateEntries) as {
+    [K in keyof typeof params as K extends `__${string}`
+      ? K
+      : never]: (typeof params)[K];
+  };
+};
+
+/**
+ * Extract private parameters used to link traces/spans across API calls.
+ */
+export const getSpanLinkPrivateParams = (params?: object) => {
+  const privateEntries = Object.entries(params ?? {}).filter(([k]) =>
+    SPAN_LINK_PRIVATE_PARAM_REGEX.test(k),
   );
   return Object.fromEntries(privateEntries) as {
     [K in keyof typeof params as K extends `__${string}`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `getSpanLinkPrivateParams()` utility to isolate trace/span private params from generic `__*` private params
- update `APIClient` to accept `WithPrivate` on all sandbox API methods and propagate only span-link private params across all `/v1/sandboxes*` endpoints (matching run-command behavior)
- persist span-link private params on `Sandbox`, `Command`, and `Snapshot` instances so follow-up endpoint calls reuse the same linkage context
- include span-link private params in workflow serialization/deserialization for sandbox/command/snapshot objects
- add a changeset for `@vercel/sandbox` patch release

## Testing
- `pnpm --filter @vercel/sandbox build`
- `pnpm --filter @vercel/sandbox typecheck`
- `pnpm --filter @vercel/sandbox test -- api-client/api-client.test.ts sandbox.test.ts command.serialize.test.ts sandbox.serialize.test.ts snapshot.serialize.test.ts utils/types.test.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://vercel.slack.com/archives/C0A85GJANNN/p1776352172821709?thread_ts=1776352172.821709&cid=C0A85GJANNN)

<div><a href="https://cursor.com/agents/bc-d1764bcd-553e-597b-934d-343e61ced790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1764bcd-553e-597b-934d-343e61ced790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

