### PR TITLE
Extract FileSystem into base IFileSystem interface

### DIFF
--- a/.changeset/bright-foxes-kiss.md
+++ b/.changeset/bright-foxes-kiss.md
@@ -1,0 +1,5 @@
+---
+"sandbox": patch
+---
+
+Extract a base `IFileSystem` interface and type `Sandbox.fs` against it while keeping the concrete `FileSystem` class API.

--- a/packages/vercel-sandbox/src/filesystem-interface.ts
+++ b/packages/vercel-sandbox/src/filesystem-interface.ts
@@ -55,7 +55,6 @@ export interface IFileSystem {
       | BufferEncoding,
   ): Promise<string>;
   readFile(path: string, options?: EncodingOption): Promise<Buffer | string>;
-  readFileBuffer(path: string, options?: SignalOptions): Promise<Buffer>;
 
   writeFile(
     path: string,
@@ -95,16 +94,13 @@ export interface IFileSystem {
     path: string,
     options?: { signal?: AbortSignal; withFileTypes?: boolean },
   ): Promise<string[] | Dirent[]>;
-  readdirWithFileTypes(path: string, options?: SignalOptions): Promise<Dirent[]>;
 
   rm(path: string, options?: RmOptions): Promise<void>;
   rmdir(path: string, options?: SignalOptions): Promise<void>;
   unlink(path: string, options?: SignalOptions): Promise<void>;
 
   rename(oldPath: string, newPath: string, options?: SignalOptions): Promise<void>;
-  mv(src: string, dest: string, options?: SignalOptions): Promise<void>;
   copyFile(src: string, dest: string, options?: SignalOptions): Promise<void>;
-  cp(src: string, dest: string, options?: SignalOptions): Promise<void>;
 
   access(path: string, options?: SignalOptions): Promise<void>;
   chmod(path: string, mode: number | string, options?: SignalOptions): Promise<void>;
@@ -121,15 +117,4 @@ export interface IFileSystem {
 
   truncate(path: string, len?: number, options?: SignalOptions): Promise<void>;
   mkdtemp(prefix: string, options?: SignalOptions): Promise<string>;
-
-  // Optional helpers kept for closer parity with just-bash IFileSystem.
-  resolvePath?(base: string, path: string): string;
-  getAllPaths?(): string[];
-  link?(existingPath: string, newPath: string, options?: SignalOptions): Promise<void>;
-  utimes?(
-    path: string,
-    atime: Date,
-    mtime: Date,
-    options?: SignalOptions,
-  ): Promise<void>;
 }

--- a/packages/vercel-sandbox/src/filesystem-interface.ts
+++ b/packages/vercel-sandbox/src/filesystem-interface.ts
@@ -1,0 +1,135 @@
+import type { Dirent, Stats } from "fs";
+
+/**
+ * File content can be text or bytes.
+ */
+export type FileContent = string | Buffer | Uint8Array;
+
+/**
+ * Options for reading files.
+ */
+export type EncodingOption =
+  | { encoding?: BufferEncoding | null; signal?: AbortSignal }
+  | BufferEncoding
+  | null;
+
+/**
+ * Options for creating directories.
+ */
+export interface MkdirOptions {
+  recursive?: boolean;
+  signal?: AbortSignal;
+}
+
+/**
+ * Options for removing files/directories.
+ */
+export interface RmOptions {
+  recursive?: boolean;
+  force?: boolean;
+  signal?: AbortSignal;
+}
+
+export interface SignalOptions {
+  signal?: AbortSignal;
+}
+
+/**
+ * Base filesystem contract for sandbox filesystem backends.
+ *
+ * The shape is intentionally close to just-bash's `IFileSystem`, while
+ * preserving this package's current `node:fs/promises`-style methods.
+ */
+export interface IFileSystem {
+  readFile(
+    path: string,
+    options?: { encoding?: null; signal?: AbortSignal } | null,
+  ): Promise<Buffer>;
+  readFile(
+    path: string,
+    options:
+      | {
+          encoding: BufferEncoding;
+          signal?: AbortSignal;
+        }
+      | BufferEncoding,
+  ): Promise<string>;
+  readFile(path: string, options?: EncodingOption): Promise<Buffer | string>;
+  readFileBuffer(path: string, options?: SignalOptions): Promise<Buffer>;
+
+  writeFile(
+    path: string,
+    content: FileContent,
+    options?:
+      | {
+          encoding?: BufferEncoding;
+          signal?: AbortSignal;
+        }
+      | BufferEncoding,
+  ): Promise<void>;
+  appendFile(
+    path: string,
+    content: FileContent,
+    options?:
+      | {
+          encoding?: BufferEncoding;
+          signal?: AbortSignal;
+        }
+      | BufferEncoding,
+  ): Promise<void>;
+
+  exists(path: string, options?: SignalOptions): Promise<boolean>;
+  stat(path: string, options?: SignalOptions): Promise<Stats>;
+  lstat(path: string, options?: SignalOptions): Promise<Stats>;
+
+  mkdir(path: string, options?: MkdirOptions | number): Promise<string | undefined>;
+  readdir(
+    path: string,
+    options?: { signal?: AbortSignal; withFileTypes?: false },
+  ): Promise<string[]>;
+  readdir(
+    path: string,
+    options: { signal?: AbortSignal; withFileTypes: true },
+  ): Promise<Dirent[]>;
+  readdir(
+    path: string,
+    options?: { signal?: AbortSignal; withFileTypes?: boolean },
+  ): Promise<string[] | Dirent[]>;
+  readdirWithFileTypes(path: string, options?: SignalOptions): Promise<Dirent[]>;
+
+  rm(path: string, options?: RmOptions): Promise<void>;
+  rmdir(path: string, options?: SignalOptions): Promise<void>;
+  unlink(path: string, options?: SignalOptions): Promise<void>;
+
+  rename(oldPath: string, newPath: string, options?: SignalOptions): Promise<void>;
+  mv(src: string, dest: string, options?: SignalOptions): Promise<void>;
+  copyFile(src: string, dest: string, options?: SignalOptions): Promise<void>;
+  cp(src: string, dest: string, options?: SignalOptions): Promise<void>;
+
+  access(path: string, options?: SignalOptions): Promise<void>;
+  chmod(path: string, mode: number | string, options?: SignalOptions): Promise<void>;
+  chown(
+    path: string,
+    uid: number,
+    gid: number,
+    options?: SignalOptions,
+  ): Promise<void>;
+
+  symlink(target: string, path: string, options?: SignalOptions): Promise<void>;
+  readlink(path: string, options?: SignalOptions): Promise<string>;
+  realpath(path: string, options?: SignalOptions): Promise<string>;
+
+  truncate(path: string, len?: number, options?: SignalOptions): Promise<void>;
+  mkdtemp(prefix: string, options?: SignalOptions): Promise<string>;
+
+  // Optional helpers kept for closer parity with just-bash IFileSystem.
+  resolvePath?(base: string, path: string): string;
+  getAllPaths?(): string[];
+  link?(existingPath: string, newPath: string, options?: SignalOptions): Promise<void>;
+  utimes?(
+    path: string,
+    atime: Date,
+    mtime: Date,
+    options?: SignalOptions,
+  ): Promise<void>;
+}

--- a/packages/vercel-sandbox/src/filesystem.test.ts
+++ b/packages/vercel-sandbox/src/filesystem.test.ts
@@ -74,6 +74,15 @@ describe("FileSystem", () => {
     });
   });
 
+  describe("readFileBuffer", () => {
+    it("returns the file content as a Buffer", async () => {
+      sandbox.readFileToBuffer.mockResolvedValue(Buffer.from("hello"));
+      const result = await fs.readFileBuffer("/test.txt");
+      expect(Buffer.isBuffer(result)).toBe(true);
+      expect(result.toString()).toBe("hello");
+    });
+  });
+
   describe("writeFile", () => {
     it("writes string data as utf8 Buffer", async () => {
       sandbox.writeFiles.mockResolvedValue(undefined);
@@ -187,6 +196,18 @@ describe("FileSystem", () => {
       await expect(fs.readdir("/missing")).rejects.toMatchObject({
         code: "ENOENT",
       });
+    });
+  });
+
+  describe("readdirWithFileTypes", () => {
+    it("returns Dirent entries", async () => {
+      sandbox.runCommand.mockResolvedValue(
+        mockCommandResult("file.txt|f\nsubdir|d\n"),
+      );
+      const result = await fs.readdirWithFileTypes("/mydir");
+      expect(result).toHaveLength(2);
+      expect(result[0].isFile()).toBe(true);
+      expect(result[1].isDirectory()).toBe(true);
     });
   });
 
@@ -326,12 +347,32 @@ describe("FileSystem", () => {
         expect.any(Object),
       );
     });
+
+    it("aliases mv to rename", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
+      await fs.mv("/old.txt", "/new.txt");
+      expect(sandbox.runCommand).toHaveBeenCalledWith(
+        "mv",
+        ["/old.txt", "/new.txt"],
+        expect.any(Object),
+      );
+    });
   });
 
   describe("copyFile", () => {
     it("copies a file", async () => {
       sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
       await fs.copyFile("/src.txt", "/dst.txt");
+      expect(sandbox.runCommand).toHaveBeenCalledWith(
+        "cp",
+        ["/src.txt", "/dst.txt"],
+        expect.any(Object),
+      );
+    });
+
+    it("aliases cp to copyFile", async () => {
+      sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
+      await fs.cp("/src.txt", "/dst.txt");
       expect(sandbox.runCommand).toHaveBeenCalledWith(
         "cp",
         ["/src.txt", "/dst.txt"],

--- a/packages/vercel-sandbox/src/filesystem.test.ts
+++ b/packages/vercel-sandbox/src/filesystem.test.ts
@@ -74,15 +74,6 @@ describe("FileSystem", () => {
     });
   });
 
-  describe("readFileBuffer", () => {
-    it("returns the file content as a Buffer", async () => {
-      sandbox.readFileToBuffer.mockResolvedValue(Buffer.from("hello"));
-      const result = await fs.readFileBuffer("/test.txt");
-      expect(Buffer.isBuffer(result)).toBe(true);
-      expect(result.toString()).toBe("hello");
-    });
-  });
-
   describe("writeFile", () => {
     it("writes string data as utf8 Buffer", async () => {
       sandbox.writeFiles.mockResolvedValue(undefined);
@@ -196,18 +187,6 @@ describe("FileSystem", () => {
       await expect(fs.readdir("/missing")).rejects.toMatchObject({
         code: "ENOENT",
       });
-    });
-  });
-
-  describe("readdirWithFileTypes", () => {
-    it("returns Dirent entries", async () => {
-      sandbox.runCommand.mockResolvedValue(
-        mockCommandResult("file.txt|f\nsubdir|d\n"),
-      );
-      const result = await fs.readdirWithFileTypes("/mydir");
-      expect(result).toHaveLength(2);
-      expect(result[0].isFile()).toBe(true);
-      expect(result[1].isDirectory()).toBe(true);
     });
   });
 
@@ -347,32 +326,12 @@ describe("FileSystem", () => {
         expect.any(Object),
       );
     });
-
-    it("aliases mv to rename", async () => {
-      sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
-      await fs.mv("/old.txt", "/new.txt");
-      expect(sandbox.runCommand).toHaveBeenCalledWith(
-        "mv",
-        ["/old.txt", "/new.txt"],
-        expect.any(Object),
-      );
-    });
   });
 
   describe("copyFile", () => {
     it("copies a file", async () => {
       sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
       await fs.copyFile("/src.txt", "/dst.txt");
-      expect(sandbox.runCommand).toHaveBeenCalledWith(
-        "cp",
-        ["/src.txt", "/dst.txt"],
-        expect.any(Object),
-      );
-    });
-
-    it("aliases cp to copyFile", async () => {
-      sandbox.runCommand.mockResolvedValue(mockCommandResult(""));
-      await fs.cp("/src.txt", "/dst.txt");
       expect(sandbox.runCommand).toHaveBeenCalledWith(
         "cp",
         ["/src.txt", "/dst.txt"],

--- a/packages/vercel-sandbox/src/filesystem.ts
+++ b/packages/vercel-sandbox/src/filesystem.ts
@@ -1,5 +1,13 @@
 import type { Stats, Dirent } from "fs";
 import * as constants from "node:constants";
+import type {
+  EncodingOption,
+  FileContent,
+  IFileSystem,
+  MkdirOptions,
+  RmOptions,
+  SignalOptions,
+} from "./filesystem-interface.js";
 
 const {
   S_IFMT,
@@ -21,24 +29,6 @@ const UV_DIRENT_FIFO = 4;
 const UV_DIRENT_SOCKET = 5;
 const UV_DIRENT_CHAR = 6;
 const UV_DIRENT_BLOCK = 7;
-
-type EncodingOption =
-  | { encoding?: BufferEncoding | null; signal?: AbortSignal }
-  | BufferEncoding
-  | null;
-
-type WriteFileData = string | Buffer | Uint8Array;
-
-interface MkdirOptions {
-  recursive?: boolean;
-  signal?: AbortSignal;
-}
-
-interface RmOptions {
-  recursive?: boolean;
-  force?: boolean;
-  signal?: AbortSignal;
-}
 
 function fsError(
   code: string,
@@ -234,7 +224,7 @@ const FIND_TYPE_TO_DIRENT: Record<string, number> = {
   s: UV_DIRENT_SOCKET,
 };
 
-export class FileSystem {
+export class FileSystem implements IFileSystem {
   /** @internal */
   private sandbox: SandboxHandle;
 
@@ -273,6 +263,24 @@ export class FileSystem {
   }
 
   /**
+   * Read the entire contents of a file as a Buffer.
+   *
+   * This alias keeps the API close to just-bash's `IFileSystem`.
+   *
+   * @param path - Path to the file
+   * @param options - Options
+   */
+  async readFileBuffer(
+    path: string,
+    options?: SignalOptions,
+  ): Promise<Buffer> {
+    return (await this.readFile(path, {
+      encoding: null,
+      signal: options?.signal,
+    })) as Buffer;
+  }
+
+  /**
    * Write data to a file, replacing the file if it already exists.
    *
    * @param path - Path to the file
@@ -281,7 +289,7 @@ export class FileSystem {
    */
   async writeFile(
     path: string,
-    data: WriteFileData,
+    data: FileContent,
     options?:
       | { encoding?: BufferEncoding; signal?: AbortSignal }
       | BufferEncoding,
@@ -311,7 +319,7 @@ export class FileSystem {
    */
   async appendFile(
     path: string,
-    data: WriteFileData,
+    data: FileContent,
     options?:
       | { encoding?: BufferEncoding; signal?: AbortSignal }
       | BufferEncoding,
@@ -421,6 +429,24 @@ export class FileSystem {
     }
     const stdout = await result.stdout();
     return stdout.trim().split("\n").filter(Boolean);
+  }
+
+  /**
+   * Read directory entries as Dirent-like objects.
+   *
+   * This alias keeps the API close to just-bash's `IFileSystem`.
+   *
+   * @param path - Path to the directory
+   * @param options - Options
+   */
+  async readdirWithFileTypes(
+    path: string,
+    options?: SignalOptions,
+  ): Promise<Dirent[]> {
+    return this.readdir(path, {
+      withFileTypes: true,
+      signal: options?.signal,
+    });
   }
 
   /**
@@ -569,6 +595,19 @@ export class FileSystem {
   }
 
   /**
+   * Move/rename a file or directory.
+   *
+   * Alias for `rename` to keep parity with just-bash's `IFileSystem`.
+   *
+   * @param src - Current path
+   * @param dest - New path
+   * @param options - Options
+   */
+  async mv(src: string, dest: string, options?: SignalOptions): Promise<void> {
+    await this.rename(src, dest, options);
+  }
+
+  /**
    * Copy a file.
    *
    * @param src - Source path
@@ -591,6 +630,19 @@ export class FileSystem {
       }
       throw fsError("EACCES", stderr.trim(), "copyfile", src);
     }
+  }
+
+  /**
+   * Copy a file.
+   *
+   * Alias for `copyFile` to keep parity with just-bash's `IFileSystem`.
+   *
+   * @param src - Source path
+   * @param dest - Destination path
+   * @param options - Options
+   */
+  async cp(src: string, dest: string, options?: SignalOptions): Promise<void> {
+    await this.copyFile(src, dest, options);
   }
 
   /**

--- a/packages/vercel-sandbox/src/filesystem.ts
+++ b/packages/vercel-sandbox/src/filesystem.ts
@@ -6,7 +6,6 @@ import type {
   IFileSystem,
   MkdirOptions,
   RmOptions,
-  SignalOptions,
 } from "./filesystem-interface.js";
 
 const {
@@ -263,24 +262,6 @@ export class FileSystem implements IFileSystem {
   }
 
   /**
-   * Read the entire contents of a file as a Buffer.
-   *
-   * This alias keeps the API close to just-bash's `IFileSystem`.
-   *
-   * @param path - Path to the file
-   * @param options - Options
-   */
-  async readFileBuffer(
-    path: string,
-    options?: SignalOptions,
-  ): Promise<Buffer> {
-    return (await this.readFile(path, {
-      encoding: null,
-      signal: options?.signal,
-    })) as Buffer;
-  }
-
-  /**
    * Write data to a file, replacing the file if it already exists.
    *
    * @param path - Path to the file
@@ -432,24 +413,6 @@ export class FileSystem implements IFileSystem {
   }
 
   /**
-   * Read directory entries as Dirent-like objects.
-   *
-   * This alias keeps the API close to just-bash's `IFileSystem`.
-   *
-   * @param path - Path to the directory
-   * @param options - Options
-   */
-  async readdirWithFileTypes(
-    path: string,
-    options?: SignalOptions,
-  ): Promise<Dirent[]> {
-    return this.readdir(path, {
-      withFileTypes: true,
-      signal: options?.signal,
-    });
-  }
-
-  /**
    * Get file status. Follows symbolic links.
    *
    * @param path - Path to the file
@@ -595,19 +558,6 @@ export class FileSystem implements IFileSystem {
   }
 
   /**
-   * Move/rename a file or directory.
-   *
-   * Alias for `rename` to keep parity with just-bash's `IFileSystem`.
-   *
-   * @param src - Current path
-   * @param dest - New path
-   * @param options - Options
-   */
-  async mv(src: string, dest: string, options?: SignalOptions): Promise<void> {
-    await this.rename(src, dest, options);
-  }
-
-  /**
    * Copy a file.
    *
    * @param src - Source path
@@ -630,19 +580,6 @@ export class FileSystem implements IFileSystem {
       }
       throw fsError("EACCES", stderr.trim(), "copyfile", src);
     }
-  }
-
-  /**
-   * Copy a file.
-   *
-   * Alias for `copyFile` to keep parity with just-bash's `IFileSystem`.
-   *
-   * @param src - Source path
-   * @param dest - Destination path
-   * @param options - Options
-   */
-  async cp(src: string, dest: string, options?: SignalOptions): Promise<void> {
-    await this.copyFile(src, dest, options);
   }
 
   /**

--- a/packages/vercel-sandbox/src/index.ts
+++ b/packages/vercel-sandbox/src/index.ts
@@ -16,3 +16,11 @@ export type {
 export { StreamError } from "./api-client/api-error.js";
 export { APIError } from "./api-client/api-error.js";
 export { FileSystem } from "./filesystem.js";
+export type {
+  IFileSystem,
+  FileContent,
+  EncodingOption,
+  MkdirOptions,
+  RmOptions,
+  SignalOptions,
+} from "./filesystem-interface.js";

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -17,6 +17,7 @@ import type {
 import { Snapshot } from "./snapshot.js";
 import { consumeReadable } from "./utils/consume-readable.js";
 import { type Credentials, getCredentials } from "./utils/get-credentials.js";
+import type { IFileSystem } from "./filesystem-interface.js";
 import {
   type SandboxSnapshot,
   toSandboxSnapshot,
@@ -214,7 +215,7 @@ export class Sandbox {
    * const files = await sandbox.fs.readdir('/tmp');
    * const stats = await sandbox.fs.stat('/tmp/hello.txt');
    */
-  public readonly fs: FileSystem;
+  public readonly fs: IFileSystem;
 
   /**
    * Unique ID of this sandbox.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- add a new `IFileSystem` base interface in `packages/vercel-sandbox/src/filesystem-interface.ts`
- make `FileSystem` implement `IFileSystem` and move shared option/content types to the interface module
- type `Sandbox.fs` as `IFileSystem` and export the new interface/types from the package entrypoint
- remove compatibility-only alias methods from the interface and implementation (no new API methods added)
- keep tests aligned with the existing API surface and include a patch changeset

## Verification

- `pnpm --filter @vercel/sandbox typecheck`
- `pnpm --filter @vercel/sandbox test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1319b207-dc99-4aaa-9a21-a9364a1b6435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1319b207-dc99-4aaa-9a21-a9364a1b6435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

