### PR TITLE
docs: Update README with Sandbox Skill installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Install the Sandbox SDK:
 pnpm i @vercel/sandbox
 ```
 
+Install the Sandbox Skill:
+
+```sh
+npx skills add vercel/sandbox
+```
+
 Create a `index.mts` file:
 
 ```ts
@@ -218,13 +224,6 @@ available [here](https://docs.aws.amazon.com/linux/al2023/release-notes/all-pack
 [hive]: https://vercel.com/blog/a-deep-dive-into-hive-vercels-builds-infrastructure
 [al-2023-packages]: https://docs.aws.amazon.com/linux/al2023/release-notes/all-packages-AL2023.7.html
 
-## Coding Assistant Skill
-
-This repo includes a [coding assistant skill](./skills/sandbox/SKILL.md) for Cursor, Codex, and other coding assistants. To install:
-
-```sh
-npx skills add vercel/sandbox
-```
 
 The skill provides comprehensive guidance on using the `@vercel/sandbox` SDK, including code patterns, best practices, and API reference.
 


### PR DESCRIPTION
Removed the section about the Coding Assistant Skill and added installation instructions for the Sandbox Skill.