### PR TITLE
chore(all): make changeset commits signed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           version: pnpm version:prepare
           publish: pnpm release
+          commitMode: github-api
 
       - name: Trigger Vercel CLI Sandbox Sync
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
We need to make the changeset commits signed. As of now, we are getting this error from the PR that changeset attempts to create:

```
remote: error: GH013: Repository rule violations found for refs/heads/changeset-release/main.        
remote: Review all repository rules at https://github.com/vercel/sandbox/rules?ref=refs%2Fheads%2Fchangeset-release%2Fmain        
remote: 
remote: - Commits must have verified signatures.        
remote:   Found 1 violation:        
remote: 
remote:   027faa7121ee9df79db623e1a2848d2cc88a8dba        
remote: 
To https://github.com/vercel/sandbox
 ! [remote rejected] HEAD -> changeset-release/main (push declined due to repository rule violations)
```