### PR TITLE
chore(workflow): pin workflow to Node24 so that we can use trusted publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,9 +30,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ inputs.node-version }}
+          node-version: "24"
           cache: "pnpm"
-          node-version-file: .node-version # node-version takes precedence if both are specified
 
       - run: pnpm install
         shell: bash


### PR DESCRIPTION
Enforce Github Actions to use Node24 instead of the default (Node 22) because we need at least npm ≥ 11.5.1 to use trusted publishing.

Node 22 ships with npm 10.x, which is too old and does not support it. We are trying to fix this CI error now:

```
> changeset publish
🦋  info npm info sandbox
🦋  info npm info @vercel/sandbox
🦋  info sandbox is being published because our local version (2.5.11) has not been published on npm
🦋  info @vercel/sandbox is being published because our local version (1.10.1) has not been published on npm
🦋  info Publishing "sandbox" at "2.5.11"
🦋  info Publishing "@vercel/sandbox" at "1.10.1"
🦋  error an error occurred while publishing @vercel/sandbox: ENEEDAUTH This command requires you to be logged in to https://registry.npmjs.org/ 
🦋  error You need to authorize this machine using `npm adduser`
🦋  error npm error code ENEEDAUTH
🦋  error npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
🦋  error npm error need auth You need to authorize this machine using `npm adduser`
🦋  error npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-29T10_02_05_534Z-debug-0.log
🦋  error 
🦋  error an error occurred while publishing sandbox: ENEEDAUTH This command requires you to be logged in to https://registry.npmjs.org/ 
🦋  error You need to authorize this machine using `npm adduser`
🦋  error npm error code ENEEDAUTH
🦋  error npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
🦋  error npm error need auth You need to authorize this machine using `npm adduser`
🦋  error npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-29T10_02_05_755Z-debug-0.log
🦋  error 
🦋  error packages failed to publish:
🦋  sandbox@2.5.11
🦋  @vercel/sandbox@1.10.1
```