### PR TITLE
fix(vercel-sandbox): disable headers timeout on default agent

### DIFF
--- a/.changeset/disable-headers-timeout.md
+++ b/.changeset/disable-headers-timeout.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Disable `headersTimeout` on the default undici Agent so long-running `cmd.wait()` long-polls don't abort at undici's 5-minute default. Previously `bodyTimeout` was disabled but `headersTimeout` was left at the default, which cut off `cmd.wait()` when a sandbox command took longer than 5 minutes — even though the sandbox itself was still alive.

--- a/packages/vercel-sandbox/src/api-client/base-client.ts
+++ b/packages/vercel-sandbox/src/api-client/base-client.ts
@@ -15,6 +15,7 @@ export interface RequestParams extends RequestInit {
 
 const DEFAULT_AGENT = new Agent({
   bodyTimeout: 0, // disable body timeout to allow long logs streaming
+  headersTimeout: 0, // disable headers timeout so long-poll cmd.wait() doesn't abort after undici's 5-min default
 });
 
 /**


### PR DESCRIPTION
## Problem

`DEFAULT_AGENT` in `base-client.ts` disables `bodyTimeout` but leaves undici's `headersTimeout` at its 5-min default:

```ts
const DEFAULT_AGENT = new Agent({
  bodyTimeout: 0, // disable body timeout to allow long logs streaming
});
```

That breaks `cmd.wait()`. It issues a single GET to `/v1/sandboxes/{id}/cmd/{cmdId}?wait=true` — the API holds the connection open and only sends response headers once the command finishes. If the underlying command takes longer than 5 min, undici aborts the request before headers arrive and throws `TimeoutError` (`code: 23`), even though the sandbox itself is still happily running.

## Repro

Hit this via `@remotion/vercel`'s `createSandbox`. Set `Sandbox.create({ timeout: 15 * 60 * 1000 })`. Sandbox lived its full 15 min per the Vercel dashboard. Script died at exactly 5 min with `TimeoutError: The operation timed out.` mid-`pnpm install`. So the `timeout` option is effectively capped at 5 min for any command (cold pnpm install, browser download, etc.) that runs longer.

## Fix

Also set `headersTimeout: 0` on `DEFAULT_AGENT`. Matches the existing intent — the comment on `bodyTimeout: 0` says "disable body timeout to allow long logs streaming", and the long-poll endpoint is just as much a long-running pattern as streaming logs.

No public API change.