### PR TITLE
feat(sdk): add L7 request matchers and forward URLs to network policies

### DIFF
--- a/.changeset/beige-dogs-melt.md
+++ b/.changeset/beige-dogs-melt.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": minor
+---
+
+Add L7 request matchers and forward URLs support to network policy rules.

--- a/packages/vercel-sandbox/src/api-client/validators.ts
+++ b/packages/vercel-sandbox/src/api-client/validators.ts
@@ -2,22 +2,22 @@ import { z } from "zod";
 
 export type SessionMetaData = z.infer<typeof Session>;
 
-const InjectionRuleMatcherValidator = z.object({
+const RuleMatcherValidator = z.object({
   exact: z.string().optional(),
   startsWith: z.string().optional(),
   regex: z.string().optional(),
 });
 
-const InjectionRuleKeyValueMatcherValidator = z.object({
-  key: InjectionRuleMatcherValidator.optional(),
-  value: InjectionRuleMatcherValidator.optional(),
+const KeyValueMatcherValidator = z.object({
+  key: RuleMatcherValidator.optional(),
+  value: RuleMatcherValidator.optional(),
 });
 
-const InjectionRuleMatchValidator = z.object({
-  path: InjectionRuleMatcherValidator.optional(),
+const RuleMatchValidator = z.object({
+  path: RuleMatcherValidator.optional(),
   method: z.array(z.string()).optional(),
-  queryString: z.array(InjectionRuleKeyValueMatcherValidator).optional(),
-  headers: z.array(InjectionRuleKeyValueMatcherValidator).optional(),
+  queryString: z.array(KeyValueMatcherValidator).optional(),
+  headers: z.array(KeyValueMatcherValidator).optional(),
 });
 
 export const InjectionRuleValidator = z.object({
@@ -26,13 +26,13 @@ export const InjectionRuleValidator = z.object({
   headers: z.record(z.string()).optional(),
   // headerNames are returned in responses
   headerNames: z.array(z.string()).optional(),
-  match: InjectionRuleMatchValidator.optional(),
+  match: RuleMatchValidator.optional(),
 });
 
 export const ForwardRuleValidator = z.object({
   domain: z.string(),
   forwardURL: z.string(),
-  match: InjectionRuleMatchValidator.optional(),
+  match: RuleMatchValidator.optional(),
 });
 
 export const NetworkPolicyValidator = z.union([

--- a/packages/vercel-sandbox/src/api-client/validators.ts
+++ b/packages/vercel-sandbox/src/api-client/validators.ts
@@ -2,12 +2,37 @@ import { z } from "zod";
 
 export type SessionMetaData = z.infer<typeof Session>;
 
+const InjectionRuleMatcherValidator = z.object({
+  exact: z.string().optional(),
+  startsWith: z.string().optional(),
+  regex: z.string().optional(),
+});
+
+const InjectionRuleKeyValueMatcherValidator = z.object({
+  key: InjectionRuleMatcherValidator.optional(),
+  value: InjectionRuleMatcherValidator.optional(),
+});
+
+const InjectionRuleMatchValidator = z.object({
+  path: InjectionRuleMatcherValidator.optional(),
+  method: z.array(z.string()).optional(),
+  queryString: z.array(InjectionRuleKeyValueMatcherValidator).optional(),
+  headers: z.array(InjectionRuleKeyValueMatcherValidator).optional(),
+});
+
 export const InjectionRuleValidator = z.object({
   domain: z.string(),
   // headers are only sent in requests
   headers: z.record(z.string()).optional(),
   // headerNames are returned in responses
   headerNames: z.array(z.string()).optional(),
+  match: InjectionRuleMatchValidator.optional(),
+});
+
+export const ForwardRuleValidator = z.object({
+  domain: z.string(),
+  forwardURL: z.string(),
+  match: InjectionRuleMatchValidator.optional(),
 });
 
 export const NetworkPolicyValidator = z.union([
@@ -20,6 +45,7 @@ export const NetworkPolicyValidator = z.union([
       allowedCIDRs: z.array(z.string()).optional(),
       deniedCIDRs: z.array(z.string()).optional(),
       injectionRules: z.array(InjectionRuleValidator).optional(),
+      forwardRules: z.array(ForwardRuleValidator).optional(),
     })
     .passthrough(),
 ]);

--- a/packages/vercel-sandbox/src/index.ts
+++ b/packages/vercel-sandbox/src/index.ts
@@ -1,5 +1,8 @@
 export {
   type NetworkPolicy,
+  type NetworkPolicyKeyValueMatcher,
+  type NetworkPolicyMatch,
+  type NetworkPolicyMatcher,
   Sandbox,
 } from "./sandbox.js";
 export {

--- a/packages/vercel-sandbox/src/network-policy.ts
+++ b/packages/vercel-sandbox/src/network-policy.ts
@@ -12,11 +12,63 @@ export type NetworkTransformer = {
 };
 
 /**
+ * Defines how a request value is matched.
+ */
+export type NetworkPolicyMatcher = {
+  /** Match the value exactly. */
+  exact?: string;
+} | {
+  /** Match values that start with the provided prefix. */
+  startsWith?: string;
+} | {
+  /** Match values against an RE2 regular expression. */
+  regex?: string;
+};
+
+/**
+ * Matcher for key/value request entries such as headers and query parameters.
+ */
+export type NetworkPolicyKeyValueMatcher = {
+  /** Matcher for the entry key. */
+  key?: NetworkPolicyMatcher;
+  /** Matcher for the entry value. */
+  value?: NetworkPolicyMatcher;
+};
+
+/**
+ * Request matcher for a network policy rule.
+ *
+ * All specified dimensions must match. Multiple methods are ORed; multiple
+ * header and query-string matchers are ANDed.
+ */
+export type NetworkPolicyMatch = {
+  /** Match on the request path. */
+  path?: NetworkPolicyMatcher;
+  /** Match on the HTTP method. */
+  method?: string[];
+  /** Match on query-string entries. */
+  queryString?: NetworkPolicyKeyValueMatcher[];
+  /** Match on request headers. */
+  headers?: NetworkPolicyKeyValueMatcher[];
+};
+
+/**
  * A rule applied to requests matching a domain in the network policy.
  */
 export type NetworkPolicyRule = {
-  /** Transforms to apply to matching requests. */
+  /**
+   * Optional request matcher. When provided, transforms only apply to requests
+   * that match every specified dimension.
+   */
+  match?: NetworkPolicyMatch;
+  /**
+   * Transforms to apply to matching requests.
+   */
   transform?: NetworkTransformer[];
+  /**
+   * HTTPS proxy URL to forward matching requests to. Must not include query string or fragment.
+   */
+  forwardURL?: string;
 };
 
 /**
@@ -60,6 +112,13 @@ export type NetworkPolicyRule = {
  *   allow: {
  *     "ai-gateway.vercel.sh": [
  *       {
+ *         match: {
+ *           method: ["POST"],
+ *           path: { startsWith: "/v1/" },
+ *           headers: [
+ *             { key: { exact: "x-api-key" }, value: { exact: "placeholder" } }
+ *           ]
+ *         },
  *         transform: [{
  *           headers: { authorization: "Bearer ..." }
  *         }]

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -15,13 +15,23 @@ import { Session, type RunCommandParams } from "./session.js";
 import type { Command, CommandFinished } from "./command.js";
 import type { Snapshot } from "./snapshot.js";
 import type { SandboxSnapshot } from "./utils/sandbox-snapshot.js";
-import type { NetworkPolicy } from "./network-policy.js";
+import type {
+  NetworkPolicy,
+  NetworkPolicyKeyValueMatcher,
+  NetworkPolicyMatch,
+  NetworkPolicyMatcher,
+} from "./network-policy.js";
 import { fromAPINetworkPolicy } from "./utils/network-policy.js";
 import { attachPaginator } from "./utils/paginator.js";
 import { setTimeout } from "node:timers/promises";
 import { FileSystem } from "./filesystem.js";
 
-export type { NetworkPolicy };
+export type {
+  NetworkPolicy,
+  NetworkPolicyKeyValueMatcher,
+  NetworkPolicyMatch,
+  NetworkPolicyMatcher,
+};
 
 /** @inline */
 export interface BaseCreateSandboxParams {

--- a/packages/vercel-sandbox/src/utils/network-policy.test.ts
+++ b/packages/vercel-sandbox/src/utils/network-policy.test.ts
@@ -111,6 +111,95 @@ describe("toAPINetworkPolicy", () => {
     });
   });
 
+  it("preserves matcher-bearing rules as ordered injectionRules", () => {
+    expect(
+      toAPINetworkPolicy({
+        allow: {
+          "api.example.com": [
+            {
+              match: {
+                method: ["POST"],
+                path: { startsWith: "/v1/" },
+                headers: [
+                  {
+                    key: { exact: "x-api-key" },
+                    value: { exact: "placeholder" },
+                  },
+                ],
+              },
+              transform: [{ headers: { "x-api-key": "real-secret" } }],
+            },
+            {
+              transform: [{ headers: { "x-api-key": "fallback-secret" } }],
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      mode: "custom",
+      allowedDomains: ["api.example.com"],
+      injectionRules: [
+        {
+          domain: "api.example.com",
+          headers: { "x-api-key": "real-secret" },
+          match: {
+            method: ["POST"],
+            path: { startsWith: "/v1/" },
+            headers: [
+              {
+                key: { exact: "x-api-key" },
+                value: { exact: "placeholder" },
+              },
+            ],
+          },
+        },
+        {
+          domain: "api.example.com",
+          headers: { "x-api-key": "fallback-secret" },
+        },
+      ],
+    });
+  });
+
+  it("converts record-form forwardURL rules to forwardRules", () => {
+    expect(
+      toAPINetworkPolicy({
+        allow: {
+          "api.example.com": [
+            {
+              match: {
+                method: ["POST"],
+                path: { startsWith: "/v1/" },
+              },
+              forwardURL: "https://proxy.example.com",
+            },
+            {
+              forwardURL: "https://fallback-proxy.example.com",
+            },
+          ],
+          "registry.npmjs.org": [],
+        },
+      }),
+    ).toEqual({
+      mode: "custom",
+      allowedDomains: ["api.example.com", "registry.npmjs.org"],
+      forwardRules: [
+        {
+          domain: "api.example.com",
+          match: {
+            method: ["POST"],
+            path: { startsWith: "/v1/" },
+          },
+          forwardURL: "https://proxy.example.com",
+        },
+        {
+          domain: "api.example.com",
+          forwardURL: "https://fallback-proxy.example.com",
+        },
+      ],
+    });
+  });
+
   it("converts empty custom object", () => {
     expect(toAPINetworkPolicy({})).toEqual({ mode: "custom" });
   });
@@ -181,6 +270,11 @@ describe("fromAPINetworkPolicy", () => {
         allow: ["*.npmjs.org"],
         subnets: { allow: ["10.0.0.0/8"], deny: ["10.1.0.0/16"] },
       },
+      {
+        allow: {
+          "api.example.com": [{ forwardURL: "https://proxy.example.com" }],
+        },
+      },
     ];
 
     for (const policy of policies) {
@@ -235,6 +329,128 @@ describe("fromAPINetworkPolicy", () => {
         "*": [],
       },
       subnets: { allow: ["10.0.0.0/8"], deny: ["10.1.0.0/16"] },
+    });
+  });
+
+  it("converts ordered injectionRules with matchers", () => {
+    expect(
+      fromAPINetworkPolicy({
+        mode: "custom",
+        allowedDomains: ["api.example.com"],
+        injectionRules: [
+          {
+            domain: "api.example.com",
+            headerNames: ["x-api-key"],
+            match: {
+              method: ["POST"],
+              path: { startsWith: "/v1/" },
+              queryString: [{ key: { exact: "model" } }],
+            },
+          },
+          {
+            domain: "api.example.com",
+            headerNames: ["x-api-key"],
+          },
+        ],
+      }),
+    ).toEqual({
+      allow: {
+        "api.example.com": [
+          {
+            match: {
+              method: ["POST"],
+              path: { startsWith: "/v1/" },
+              queryString: [{ key: { exact: "model" } }],
+            },
+            transform: [{ headers: { "x-api-key": "<redacted>" } }],
+          },
+          {
+            transform: [{ headers: { "x-api-key": "<redacted>" } }],
+          },
+        ],
+      },
+    });
+  });
+
+  it("converts forwardRules with matchers", () => {
+    expect(
+      fromAPINetworkPolicy({
+        mode: "custom",
+        allowedDomains: ["api.example.com", "registry.npmjs.org"],
+        forwardRules: [
+          {
+            domain: "api.example.com",
+            match: {
+              method: ["POST"],
+              path: { startsWith: "/v1/" },
+              headers: [{ key: { exact: "x-route" }, value: { exact: "proxy" } }],
+            },
+            forwardURL: "https://proxy.example.com",
+          },
+          {
+            domain: "api.example.com",
+            forwardURL: "https://fallback-proxy.example.com",
+          },
+        ],
+      }),
+    ).toEqual({
+      allow: {
+        "api.example.com": [
+          {
+            match: {
+              method: ["POST"],
+              path: { startsWith: "/v1/" },
+              headers: [{ key: { exact: "x-route" }, value: { exact: "proxy" } }],
+            },
+            forwardURL: "https://proxy.example.com",
+          },
+          {
+            forwardURL: "https://fallback-proxy.example.com",
+          },
+        ],
+        "registry.npmjs.org": [],
+      },
+    });
+  });
+
+  it("converts mixed injectionRules and forwardRules", () => {
+    expect(
+      fromAPINetworkPolicy({
+        mode: "custom",
+        allowedDomains: ["api.example.com"],
+        injectionRules: [
+          {
+            domain: "api.example.com",
+            headerNames: ["authorization"],
+          },
+        ],
+        forwardRules: [
+          {
+            domain: "api.example.com",
+            forwardURL: "https://proxy.example.com",
+          },
+          {
+            domain: "proxy-only.example.com",
+            forwardURL: "https://proxy-only.example.com",
+          },
+        ],
+      }),
+    ).toEqual({
+      allow: {
+        "api.example.com": [
+          {
+            transform: [{ headers: { authorization: "<redacted>" } }],
+          },
+          {
+            forwardURL: "https://proxy.example.com",
+          },
+        ],
+        "proxy-only.example.com": [
+          {
+            forwardURL: "https://proxy-only.example.com",
+          },
+        ],
+      },
     });
   });
 });

--- a/packages/vercel-sandbox/src/utils/network-policy.ts
+++ b/packages/vercel-sandbox/src/utils/network-policy.ts
@@ -3,6 +3,7 @@ import { NetworkPolicy, NetworkPolicyRule } from "../network-policy.js";
 import {
   NetworkPolicyValidator,
   InjectionRuleValidator,
+  ForwardRuleValidator,
 } from "../api-client/validators.js";
 
 type APINetworkPolicy = z.infer<typeof NetworkPolicyValidator>;
@@ -14,16 +15,37 @@ export function toAPINetworkPolicy(policy: NetworkPolicy): APINetworkPolicy {
   if (policy.allow && !Array.isArray(policy.allow)) {
     const allowedDomains = Object.keys(policy.allow);
     const injectionRules: z.infer<typeof InjectionRuleValidator>[] = [];
+    const forwardRules: z.infer<typeof ForwardRuleValidator>[] = [];
 
     for (const [domain, rules] of Object.entries(policy.allow)) {
-      const merged: Record<string, string> = {};
-      for (const rule of rules) {
-        for (const t of rule.transform ?? []) {
-          Object.assign(merged, t.headers);
+      if (rules.some((rule) => rule.match !== undefined)) {
+        for (const rule of rules) {
+          const headers = mergeTransformHeaders(rule);
+          if (Object.keys(headers).length > 0) {
+            injectionRules.push({
+              domain,
+              headers,
+              ...(rule.match ? { match: rule.match } : {}),
+            });
+          }
+        }
+      } else {
+        const headers = rules.reduce(
+          (merged, rule) => Object.assign(merged, mergeTransformHeaders(rule)),
+          {} as Record<string, string>,
+        );
+        if (Object.keys(headers).length > 0) {
+          injectionRules.push({ domain, headers });
         }
       }
-      if (Object.keys(merged).length > 0) {
-        injectionRules.push({ domain, headers: merged });
+
+      for (const rule of rules) {
+        if (!rule.forwardURL) continue;
+        forwardRules.push({
+          domain,
+          forwardURL: rule.forwardURL,
+          ...(rule.match ? { match: rule.match } : {}),
+        });
       }
     }
 
@@ -31,6 +53,7 @@ export function toAPINetworkPolicy(policy: NetworkPolicy): APINetworkPolicy {
       mode: "custom",
       ...(allowedDomains.length > 0 && { allowedDomains }),
       ...(injectionRules.length > 0 && { injectionRules }),
+      ...(forwardRules.length > 0 && { forwardRules }),
       ...(policy.subnets?.allow && { allowedCIDRs: policy.subnets.allow }),
       ...(policy.subnets?.deny && { deniedCIDRs: policy.subnets.deny }),
     };
@@ -42,6 +65,14 @@ export function toAPINetworkPolicy(policy: NetworkPolicy): APINetworkPolicy {
     ...(policy.subnets?.allow && { allowedCIDRs: policy.subnets.allow }),
     ...(policy.subnets?.deny && { deniedCIDRs: policy.subnets.deny }),
   };
+}
+
+function mergeTransformHeaders(rule: NetworkPolicyRule): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const transform of rule.transform ?? []) {
+    Object.assign(headers, transform.headers);
+  }
+  return headers;
 }
 
 export function fromAPINetworkPolicy(api: APINetworkPolicy): NetworkPolicy {
@@ -58,33 +89,42 @@ export function fromAPINetworkPolicy(api: APINetworkPolicy): NetworkPolicy {
         }
       : undefined;
 
-  // If injectionRules are present, reconstruct the record form.
+  // If L7 rules are present, reconstruct the record form.
   // The API returns headerNames (secret values are stripped), so we
   // populate each header value with "<redacted>".
-  if (api.injectionRules && api.injectionRules.length > 0) {
-    const rulesByDomain = new Map(
-      api.injectionRules.map((r) => [r.domain, r.headerNames ?? []]),
-    );
+  if (
+    (api.injectionRules && api.injectionRules.length > 0) ||
+    (api.forwardRules && api.forwardRules.length > 0)
+  ) {
+    const rulesByDomain = new Map<string, NetworkPolicyRule[]>();
+    for (const rule of api.injectionRules ?? []) {
+      const headers = Object.fromEntries(
+        (rule.headerNames ?? []).map((n) => [n, "<redacted>"]),
+      );
+      const rules = rulesByDomain.get(rule.domain) ?? [];
+      rules.push({
+        ...(rule.match ? { match: rule.match } : {}),
+        transform: [{ headers }],
+      });
+      rulesByDomain.set(rule.domain, rules);
+    }
+    for (const rule of api.forwardRules ?? []) {
+      const rules = rulesByDomain.get(rule.domain) ?? [];
+      rules.push({
+        ...(rule.match ? { match: rule.match } : {}),
+        forwardURL: rule.forwardURL,
+      });
+      rulesByDomain.set(rule.domain, rules);
+    }
 
     const allow: Record<string, NetworkPolicyRule[]> = {};
     for (const domain of api.allowedDomains ?? []) {
-      const headerNames = rulesByDomain.get(domain);
-      if (headerNames && headerNames.length > 0) {
-        const headers = Object.fromEntries(
-          headerNames.map((n) => [n, "<redacted>"]),
-        );
-        allow[domain] = [{ transform: [{ headers }] }];
-      } else {
-        allow[domain] = [];
-      }
+      allow[domain] = rulesByDomain.get(domain) ?? [];
     }
-    // Include injection rules for domains not in allowedDomains
-    for (const rule of api.injectionRules) {
+    // Include L7 rules for domains not in allowedDomains
+    for (const rule of [...(api.injectionRules ?? []), ...(api.forwardRules ?? [])]) {
       if (!(rule.domain in allow)) {
-        const headers = Object.fromEntries(
-          (rule.headerNames ?? []).map((n) => [n, "<redacted>"]),
-        );
-        allow[rule.domain] = [{ transform: [{ headers }] }];
+        allow[rule.domain] = rulesByDomain.get(rule.domain) ?? [];
       }
     }
 


### PR DESCRIPTION
This PR adds support for L7 requests matcher and forward URLs in network policies

⚠️ A follow-up PR will update to support the V2 API schema for network policies, which will clean up the `toAPINetworkPolicy` / `fromAPINetworkPolicy` logic

### Request matchers

For each `NetworkPolicyRule`, you can apply a matcher on:
- the request method 
- the request path
- the request query strings
- the request headers

Each matcher can target to either exactly match, start with, or regex match, a provided value. For example, to inject an authorization header on requests to Vercel's AI gateway but only on specific requests:

```
allow: {
  "ai-gateway.vercel.sh": [
    {
      match: {
        method: ["POST"],
        path: { startsWith: "/v1/" },
        headers: [
          { key: { exact: "x-api-key" }, value: { exact: "placeholder" } }
        ]
      },
      transform: [{
        headers: { authorization: "Bearer ..." }
      }]
    }
  ],
  "*": []
}
```

### Forward URLs

For each `NetworkPolicyRule`, you can define a `forwardURL` field that serves as an HTTPS proxy to forward matching requests to. Since it's a `NetworkPolicyRule`, you can also define matchers on it:

```
allow: {
  "ai-gateway.vercel.sh": [
    {
      match: {
        method: ["POST"],
        path: { startsWith: "/v1/" },
        headers: [
          { key: { exact: "x-api-key" }, value: { exact: "placeholder" } }
        ]
      },
      forwardURL: 'https://my-proxy.vercel.app'
    }
  ],
  "*": []
}
```