### PR TITLE
feat(sdk): update to V2 API schema for network policies

### DIFF
--- a/packages/vercel-sandbox/src/api-client/validators.ts
+++ b/packages/vercel-sandbox/src/api-client/validators.ts
@@ -35,19 +35,55 @@ export const ForwardRuleValidator = z.object({
   match: RuleMatchValidator.optional(),
 });
 
-export const NetworkPolicyValidator = z.union([
+export const NetworkPolicyTransformValidator = z.object({
+  headers: z.record(z.string()).optional(),
+});
+
+export const NetworkPolicyRuleValidator = z.object({
+  match: RuleMatchValidator.optional(),
+  transform: z.array(NetworkPolicyTransformValidator).optional(),
+  forwardURL: z.string().optional(),
+});
+
+export const V2NetworkPolicyObjectValidator = z.object({
+  allow: z
+    .union([
+      z.array(z.string()),
+      z.record(z.array(NetworkPolicyRuleValidator)),
+    ])
+    .optional(),
+  subnets: z
+    .object({
+      allow: z.array(z.string()).optional(),
+      deny: z.array(z.string()).optional(),
+    })
+    .optional(),
+});
+
+const NetworkPolicyModeValidator = z.union([
   z.object({ mode: z.literal("allow-all") }).passthrough(),
   z.object({ mode: z.literal("deny-all") }).passthrough(),
-  z
-    .object({
-      mode: z.literal("custom"),
-      allowedDomains: z.array(z.string()).optional(),
-      allowedCIDRs: z.array(z.string()).optional(),
-      deniedCIDRs: z.array(z.string()).optional(),
-      injectionRules: z.array(InjectionRuleValidator).optional(),
-      forwardRules: z.array(ForwardRuleValidator).optional(),
-    })
-    .passthrough(),
+]);
+
+const LegacyCustomNetworkPolicyValidator = z
+  .object({
+    mode: z.literal("custom"),
+    allowedDomains: z.array(z.string()).optional(),
+    allowedCIDRs: z.array(z.string()).optional(),
+    deniedCIDRs: z.array(z.string()).optional(),
+    injectionRules: z.array(InjectionRuleValidator).optional(),
+    forwardRules: z.array(ForwardRuleValidator).optional(),
+  })
+  .passthrough();
+
+export const NetworkPolicyRequestValidator = z.union([
+  NetworkPolicyModeValidator,
+  V2NetworkPolicyObjectValidator.passthrough(),
+]);
+
+export const NetworkPolicyResponseValidator = z.union([
+  NetworkPolicyModeValidator,
+  LegacyCustomNetworkPolicyValidator,
 ]);
 
 export const Session = z.object({
@@ -78,7 +114,7 @@ export const Session = z.object({
   cwd: z.string(),
   updatedAt: z.number(),
   interactivePort: z.number().optional(),
-  networkPolicy: NetworkPolicyValidator.optional(),
+  networkPolicy: NetworkPolicyResponseValidator.optional(),
   activeCpuDurationMs: z.number().optional(),
   networkTransfer: z.object({
     ingress: z.number(),
@@ -197,7 +233,7 @@ export const Sandbox = z.object({
   memory: z.number().optional(),
   runtime: z.string().optional(),
   timeout: z.number().optional(),
-  networkPolicy: NetworkPolicyValidator.optional(),
+  networkPolicy: NetworkPolicyResponseValidator.optional(),
   totalEgressBytes: z.number().optional(),
   totalIngressBytes: z.number().optional(),
   totalActiveCpuDurationMs: z.number().optional(),

--- a/packages/vercel-sandbox/src/utils/network-policy.test.ts
+++ b/packages/vercel-sandbox/src/utils/network-policy.test.ts
@@ -14,8 +14,7 @@ describe("toAPINetworkPolicy", () => {
     expect(
       toAPINetworkPolicy({ allow: ["*.npmjs.org", "github.com"] }),
     ).toEqual({
-      mode: "custom",
-      allowedDomains: ["*.npmjs.org", "github.com"],
+      allow: ["*.npmjs.org", "github.com"],
     });
   });
 
@@ -25,9 +24,10 @@ describe("toAPINetworkPolicy", () => {
         subnets: { allow: ["10.0.0.0/8"], deny: ["10.1.0.0/16"] },
       }),
     ).toEqual({
-      mode: "custom",
-      allowedCIDRs: ["10.0.0.0/8"],
-      deniedCIDRs: ["10.1.0.0/16"],
+      subnets: {
+        allow: ["10.0.0.0/8"],
+        deny: ["10.1.0.0/16"],
+      },
     });
   });
 
@@ -38,25 +38,25 @@ describe("toAPINetworkPolicy", () => {
         subnets: { allow: ["10.0.0.0/8"], deny: ["10.1.0.0/16"] },
       }),
     ).toEqual({
-      mode: "custom",
-      allowedDomains: ["github.com"],
-      allowedCIDRs: ["10.0.0.0/8"],
-      deniedCIDRs: ["10.1.0.0/16"],
+      allow: ["github.com"],
+      subnets: {
+        allow: ["10.0.0.0/8"],
+        deny: ["10.1.0.0/16"],
+      },
     });
   });
 
-  it("converts record-form domains to allowedDomains list", () => {
+  it("converts record-form domains to allow map", () => {
     expect(
       toAPINetworkPolicy({
         allow: { "api.github.com": [], "github.com": [] },
       }),
     ).toEqual({
-      mode: "custom",
-      allowedDomains: ["api.github.com", "github.com"],
+      allow: { "api.github.com": [], "github.com": [] },
     });
   });
 
-  it("converts record-form with multiple domains and transforms to injectionRules", () => {
+  it("keeps record-form rules in v2 allow-map shape", () => {
     expect(
       toAPINetworkPolicy({
         allow: {
@@ -86,32 +86,38 @@ describe("toAPINetworkPolicy", () => {
         subnets: { allow: ["10.0.0.0/8"], deny: ["10.1.0.0/16"] },
       }),
     ).toEqual({
-      mode: "custom",
-      allowedDomains: [
-        "api.github.com",
-        "ai-gateway.vercel.sh",
-        "registry.npmjs.org",
-        "*",
-      ],
-      injectionRules: [
-        {
-          domain: "api.github.com",
-          headers: { authorization: "Bearer sk-openai", "x-org-id": "org-123" },
-        },
-        {
-          domain: "ai-gateway.vercel.sh",
-          headers: {
-            "x-api-key": "sk-ant-test",
-            "anthropic-version": "2024-01-01",
+      allow: {
+        "api.github.com": [
+          {
+            transform: [
+              {
+                headers: {
+                  authorization: "Bearer sk-openai",
+                  "x-org-id": "org-123",
+                },
+              },
+            ],
           },
-        },
-      ],
-      allowedCIDRs: ["10.0.0.0/8"],
-      deniedCIDRs: ["10.1.0.0/16"],
+        ],
+        "ai-gateway.vercel.sh": [
+          {
+            transform: [
+              { headers: { "x-api-key": "sk-ant-test" } },
+              { headers: { "anthropic-version": "2024-01-01" } },
+            ],
+          },
+        ],
+        "registry.npmjs.org": [],
+        "*": [],
+      },
+      subnets: {
+        allow: ["10.0.0.0/8"],
+        deny: ["10.1.0.0/16"],
+      },
     });
   });
 
-  it("preserves matcher-bearing rules as ordered injectionRules", () => {
+  it("preserves matcher-bearing rules as ordered allow-map transform rules", () => {
     expect(
       toAPINetworkPolicy({
         allow: {
@@ -136,32 +142,30 @@ describe("toAPINetworkPolicy", () => {
         },
       }),
     ).toEqual({
-      mode: "custom",
-      allowedDomains: ["api.example.com"],
-      injectionRules: [
-        {
-          domain: "api.example.com",
-          headers: { "x-api-key": "real-secret" },
-          match: {
-            method: ["POST"],
-            path: { startsWith: "/v1/" },
-            headers: [
-              {
-                key: { exact: "x-api-key" },
-                value: { exact: "placeholder" },
-              },
-            ],
+      allow: {
+        "api.example.com": [
+          {
+            match: {
+              method: ["POST"],
+              path: { startsWith: "/v1/" },
+              headers: [
+                {
+                  key: { exact: "x-api-key" },
+                  value: { exact: "placeholder" },
+                },
+              ],
+            },
+            transform: [{ headers: { "x-api-key": "real-secret" } }],
           },
-        },
-        {
-          domain: "api.example.com",
-          headers: { "x-api-key": "fallback-secret" },
-        },
-      ],
+          {
+            transform: [{ headers: { "x-api-key": "fallback-secret" } }],
+          },
+        ],
+      },
     });
   });
 
-  it("converts record-form forwardURL rules to forwardRules", () => {
+  it("converts record-form forwardURL rules to allow-map forwardURL rules", () => {
     expect(
       toAPINetworkPolicy({
         allow: {
@@ -181,33 +185,31 @@ describe("toAPINetworkPolicy", () => {
         },
       }),
     ).toEqual({
-      mode: "custom",
-      allowedDomains: ["api.example.com", "registry.npmjs.org"],
-      forwardRules: [
-        {
-          domain: "api.example.com",
-          match: {
-            method: ["POST"],
-            path: { startsWith: "/v1/" },
+      allow: {
+        "api.example.com": [
+          {
+            match: {
+              method: ["POST"],
+              path: { startsWith: "/v1/" },
+            },
+            forwardURL: "https://proxy.example.com",
           },
-          forwardURL: "https://proxy.example.com",
-        },
-        {
-          domain: "api.example.com",
-          forwardURL: "https://fallback-proxy.example.com",
-        },
-      ],
+          {
+            forwardURL: "https://fallback-proxy.example.com",
+          },
+        ],
+        "registry.npmjs.org": [],
+      },
     });
   });
 
   it("converts empty custom object", () => {
-    expect(toAPINetworkPolicy({})).toEqual({ mode: "custom" });
+    expect(toAPINetworkPolicy({})).toEqual({});
   });
 
   it("omits undefined subnet fields", () => {
     expect(toAPINetworkPolicy({ subnets: { allow: ["10.0.0.0/8"] } })).toEqual({
-      mode: "custom",
-      allowedCIDRs: ["10.0.0.0/8"],
+      subnets: { allow: ["10.0.0.0/8"] },
     });
   });
 });
@@ -260,26 +262,24 @@ describe("fromAPINetworkPolicy", () => {
     expect(fromAPINetworkPolicy({ mode: "custom" })).toEqual({});
   });
 
-  it("roundtrips string-form policies through both conversions", () => {
-    const policies = [
-      "allow-all" as const,
-      "deny-all" as const,
-      { allow: ["github.com"] },
-      { subnets: { allow: ["10.0.0.0/8"], deny: ["10.1.0.0/16"] } },
-      {
-        allow: ["*.npmjs.org"],
-        subnets: { allow: ["10.0.0.0/8"], deny: ["10.1.0.0/16"] },
-      },
-      {
-        allow: {
-          "api.example.com": [{ forwardURL: "https://proxy.example.com" }],
-        },
-      },
-    ];
-
-    for (const policy of policies) {
-      expect(fromAPINetworkPolicy(toAPINetworkPolicy(policy))).toEqual(policy);
-    }
+  it("parses legacy/mode-form responses", () => {
+    expect(fromAPINetworkPolicy({ mode: "allow-all" })).toEqual("allow-all");
+    expect(fromAPINetworkPolicy({ mode: "deny-all" })).toEqual("deny-all");
+    expect(
+      fromAPINetworkPolicy({
+        mode: "custom",
+        allowedDomains: ["github.com"],
+      }),
+    ).toEqual({ allow: ["github.com"] });
+    expect(
+      fromAPINetworkPolicy({
+        mode: "custom",
+        allowedCIDRs: ["10.0.0.0/8"],
+        deniedCIDRs: ["10.1.0.0/16"],
+      }),
+    ).toEqual({
+      subnets: { allow: ["10.0.0.0/8"], deny: ["10.1.0.0/16"] },
+    });
   });
 
   it("converts injectionRules with multiple domains, headers, and subnets", () => {

--- a/packages/vercel-sandbox/src/utils/network-policy.ts
+++ b/packages/vercel-sandbox/src/utils/network-policy.ts
@@ -1,83 +1,29 @@
 import { z } from "zod";
 import { NetworkPolicy, NetworkPolicyRule } from "../network-policy.js";
 import {
-  NetworkPolicyValidator,
-  InjectionRuleValidator,
-  ForwardRuleValidator,
+  NetworkPolicyRequestValidator,
+  NetworkPolicyResponseValidator,
 } from "../api-client/validators.js";
 
-type APINetworkPolicy = z.infer<typeof NetworkPolicyValidator>;
+type APIRequestNetworkPolicy = z.infer<typeof NetworkPolicyRequestValidator>;
+type APIResponseNetworkPolicy = z.infer<typeof NetworkPolicyResponseValidator>;
 
-export function toAPINetworkPolicy(policy: NetworkPolicy): APINetworkPolicy {
-  if (policy === "allow-all") return { mode: "allow-all" };
-  if (policy === "deny-all") return { mode: "deny-all" };
-
-  if (policy.allow && !Array.isArray(policy.allow)) {
-    const allowedDomains = Object.keys(policy.allow);
-    const injectionRules: z.infer<typeof InjectionRuleValidator>[] = [];
-    const forwardRules: z.infer<typeof ForwardRuleValidator>[] = [];
-
-    for (const [domain, rules] of Object.entries(policy.allow)) {
-      if (rules.some((rule) => rule.match !== undefined)) {
-        for (const rule of rules) {
-          const headers = mergeTransformHeaders(rule);
-          if (Object.keys(headers).length > 0) {
-            injectionRules.push({
-              domain,
-              headers,
-              ...(rule.match ? { match: rule.match } : {}),
-            });
-          }
-        }
-      } else {
-        const headers = rules.reduce(
-          (merged, rule) => Object.assign(merged, mergeTransformHeaders(rule)),
-          {} as Record<string, string>,
-        );
-        if (Object.keys(headers).length > 0) {
-          injectionRules.push({ domain, headers });
-        }
-      }
-
-      for (const rule of rules) {
-        if (!rule.forwardURL) continue;
-        forwardRules.push({
-          domain,
-          forwardURL: rule.forwardURL,
-          ...(rule.match ? { match: rule.match } : {}),
-        });
-      }
-    }
-
-    return {
-      mode: "custom",
-      ...(allowedDomains.length > 0 && { allowedDomains }),
-      ...(injectionRules.length > 0 && { injectionRules }),
-      ...(forwardRules.length > 0 && { forwardRules }),
-      ...(policy.subnets?.allow && { allowedCIDRs: policy.subnets.allow }),
-      ...(policy.subnets?.deny && { deniedCIDRs: policy.subnets.deny }),
-    };
+export function toAPINetworkPolicy(
+  policy: NetworkPolicy,
+): APIRequestNetworkPolicy {
+  if (policy === "allow-all" || policy === "deny-all") {
+    return { mode: policy };
   }
 
-  return {
-    mode: "custom",
-    ...(policy.allow && { allowedDomains: policy.allow }),
-    ...(policy.subnets?.allow && { allowedCIDRs: policy.subnets.allow }),
-    ...(policy.subnets?.deny && { deniedCIDRs: policy.subnets.deny }),
-  };
+  return policy;
 }
 
-function mergeTransformHeaders(rule: NetworkPolicyRule): Record<string, string> {
-  const headers: Record<string, string> = {};
-  for (const transform of rule.transform ?? []) {
-    Object.assign(headers, transform.headers);
+export function fromAPINetworkPolicy(
+  api: APIResponseNetworkPolicy,
+): NetworkPolicy {
+  if (api.mode === "allow-all" || api.mode === "deny-all") {
+    return api.mode;
   }
-  return headers;
-}
-
-export function fromAPINetworkPolicy(api: APINetworkPolicy): NetworkPolicy {
-  if (api.mode === "allow-all") return "allow-all";
-  if (api.mode === "deny-all") return "deny-all";
 
   const subnets =
     api.allowedCIDRs || api.deniedCIDRs


### PR DESCRIPTION
Follow-up to https://github.com/vercel/sandbox/pull/173, update the network policies requests to use the V2 schema, which supports matchers and forward URLs

For now, the API responses are still under the V1 schema, because changing it would be a breaking change. Only the requests are using the V2 schema with this PR, which greatly simplifies `toAPINetworkPolicy`