### PR TITLE
docs(sandbox): update max timeout to 24 hours for Pro/Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ const sandbox = await Sandbox.create({
     type: "git",
   },
   resources: { vcpus: 4 },
-  // Defaults to 5 minutes. The maximum is 5 hours for Pro/Enterprise, and 45 minutes for Hobby.
+  // Defaults to 5 minutes. The maximum is 24 hours for Pro/Enterprise, and 45 minutes for Hobby.
   timeout: ms("5m"),
   ports: [3000],
   runtime: "node24",
@@ -153,7 +153,7 @@ recreate an API client using OIDC or environment credentials when needed.
 ## Limitations
 
 - Max resources: 8 vCPUs on Hobby/Pro, 32 vCPUs on Enterprise. You will get 2048 MB of memory per vCPU.
-- Sandboxes have a maximum runtime duration of 5 hours for Pro/Enterprise and 45 minutes for Hobby,
+- Sandboxes have a maximum runtime duration of 24 hours for Pro/Enterprise and 45 minutes for Hobby,
   with a default of 5 minutes. This can be configured using the `timeout` option of `Sandbox.create()`.
 
 ## System

--- a/packages/vercel-sandbox/README.md
+++ b/packages/vercel-sandbox/README.md
@@ -135,7 +135,7 @@ const sandbox = await Sandbox.create({
     type: "git",
   },
   resources: { vcpus: 4 },
-  // Defaults to 5 minutes. The maximum is 5 hours for Pro/Enterprise, and 45 minutes for Hobby.
+  // Defaults to 5 minutes. The maximum is 24 hours for Pro/Enterprise, and 45 minutes for Hobby.
   timeout: ms("5m"),
   ports: [3000],
   runtime: "node24",
@@ -153,7 +153,7 @@ recreate an API client using OIDC or environment credentials when needed.
 ## Limitations
 
 - Max resources: 8 vCPUs. You will get 2048 MB of memory per vCPU.
-- Sandboxes have a maximum runtime duration of 5 hours for Pro/Enterprise and 45 minutes for Hobby,
+- Sandboxes have a maximum runtime duration of 24 hours for Pro/Enterprise and 45 minutes for Hobby,
   with a default of 5 minutes. This can be configured using the `timeout` option of `Sandbox.create()`.
 
 ## System

--- a/skills/sandbox/SKILL.md
+++ b/skills/sandbox/SKILL.md
@@ -406,7 +406,7 @@ const result = await sandbox.runCommand({
 | --------------- | -------------------------------------------- |
 | Max vCPUs       | 8 vCPUs (2048 MB RAM per vCPU)               |
 | Max ports       | 15 exposed ports                             |
-| Max timeout     | 5 hours (Pro/Enterprise), 45 minutes (Hobby) |
+| Max timeout     | 24 hours (Pro/Enterprise), 45 minutes (Hobby) |
 | Default timeout | 5 minutes                                    |
 | Base system     | Amazon Linux 2023                            |
 | User context    | `vercel-sandbox` user                        |


### PR DESCRIPTION
## Problem

The documentation across the SDK README, the `vercel-sandbox` package README, and the sandbox skill guide still states that the maximum sandbox runtime duration is **5 hours** for Pro/Enterprise customers. The platform limit will be raised to **24 hours** for Pro/Enterprise, so these references are now stale and misleading to users planning long-running workloads.

No code-level constants needed changes — the cap is enforced server-side.