### PR TITLE
feat(sandbox, vercel-sandbox): add Node 26 support

### DIFF
--- a/.changeset/odd-toes-smoke.md
+++ b/.changeset/odd-toes-smoke.md
@@ -1,0 +1,6 @@
+---
+"@vercel/sandbox": patch
+"sandbox": patch
+---
+
+Add Node 26 support.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ whois
 zstd
 ```
 
-- The `node24` and `node22` images ship Node runtimes under `/vercel/runtimes/node{22,24}`.
+- The `node` images ship their respective runtimes under `/vercel/runtimes/node{22,24,26}`.
 - The `python3.13` image ships a Python 3.13 runtime under `/vercel/runtimes/python`.
 - User code is executed as the `vercel-sandbox` user.
 - `/vercel/sandbox` is writable.

--- a/packages/sandbox/docs/index.md
+++ b/packages/sandbox/docs/index.md
@@ -69,7 +69,7 @@ Create and run a command in a sandbox
 
 Options:
 
-    --runtime <runtime>                One of 'node22', 'node24', 'python3.13' [default: node24]
+    --runtime <runtime>                One of 'node22', 'node24', 'node26', 'python3.13' [default: node24]
     --timeout <num UNIT>               The maximum duration a sandbox can run for. Example: 5m, 30m [default: 5 minutes]
     --vcpus <COUNT>                    Number of vCPUs to allocate (each vCPU includes 2048 MB of memory) [optional]
     --publish-port <PORT>, -p=<PORT>   Publish sandbox port(s) to DOMAIN.vercel.run
@@ -118,7 +118,7 @@ Create a sandbox in the specified account and project.
 
 Options:
 
-    --runtime <runtime>                One of 'node22', 'node24', 'python3.13' [default: node24]
+    --runtime <runtime>                One of 'node22', 'node24', 'node26', 'python3.13' [default: node24]
     --timeout <num UNIT>               The maximum duration a sandbox can run for. Example: 5m, 30m [default: 5 minutes]
     --vcpus <COUNT>                    Number of vCPUs to allocate (each vCPU includes 2048 MB of memory) [optional]
     --publish-port <PORT>, -p=<PORT>   Publish sandbox port(s) to DOMAIN.vercel.run

--- a/packages/sandbox/src/args/runtime.ts
+++ b/packages/sandbox/src/args/runtime.ts
@@ -3,7 +3,7 @@ import * as cmd from "cmd-ts";
 export const runtime = cmd.option({
   long: "runtime",
   type: {
-    ...cmd.oneOf(["node22", "node24", "python3.13"] as const),
+    ...cmd.oneOf(["node22", "node24", "node26", "python3.13"] as const),
     displayName: "runtime",
   },
   defaultValue: () => "node24" as const,

--- a/packages/vercel-sandbox/src/constants.ts
+++ b/packages/vercel-sandbox/src/constants.ts
@@ -1,1 +1,1 @@
-export type RUNTIMES = "node24" | "node22" | "python3.13";
+export type RUNTIMES = "node26" | "node24" | "node22" | "python3.13";

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -71,7 +71,7 @@ export interface BaseCreateSandboxParams {
   resources?: { vcpus: number };
 
   /**
-   * The runtime of the sandbox, currently only `node24`, `node22` and `python3.13` are supported.
+   * The runtime of the sandbox, currently only `node24`, `node22`, `node26` and `python3.13` are supported.
    * If not specified, the default runtime `node24` will be used.
    */
   runtime?: RUNTIMES | (string & {});


### PR DESCRIPTION
Add support for booting sandboxes with Node 26. Intentionally not set as default until Node 26 becomes LTS.