### PR TITLE
feat(sandbox, vercel-sandbox): add node26 support

### DIFF
--- a/.changeset/funny-areas-boil.md
+++ b/.changeset/funny-areas-boil.md
@@ -1,0 +1,6 @@
+---
+"@vercel/sandbox": patch
+"sandbox": patch
+---
+
+Add Node 26 support.

--- a/packages/sandbox/docs/index.md
+++ b/packages/sandbox/docs/index.md
@@ -81,7 +81,7 @@ Create and run a command in a sandbox
 Options:
 
     --name <str>                           A user-chosen name for the sandbox. It must be unique per project. [optional]
-    --runtime <runtime>                    One of 'node22', 'node24', 'python3.13' [default: node24]
+    --runtime <runtime>                    One of 'node22', 'node24', 'node26', 'python3.13' [default: node24]
     --timeout <num UNIT>                   The maximum duration a sandbox can run for. Example: 5m, 30m [default: 5 minutes]
     --vcpus <COUNT>                        Number of vCPUs to allocate (each vCPU includes 2048 MB of memory) [optional]
     --publish-port <PORT>, -p=<PORT>       Publish sandbox port(s) to DOMAIN.vercel.run
@@ -135,7 +135,7 @@ Create a sandbox in the specified account and project.
 Options:
 
     --name <str>                           A user-chosen name for the sandbox. It must be unique per project. [optional]
-    --runtime <runtime>                    One of 'node22', 'node24', 'python3.13' [default: node24]
+    --runtime <runtime>                    One of 'node22', 'node24', 'node26', 'python3.13' [default: node24]
     --timeout <num UNIT>                   The maximum duration a sandbox can run for. Example: 5m, 30m [default: 5 minutes]
     --vcpus <COUNT>                        Number of vCPUs to allocate (each vCPU includes 2048 MB of memory) [optional]
     --publish-port <PORT>, -p=<PORT>       Publish sandbox port(s) to DOMAIN.vercel.run

--- a/packages/sandbox/src/args/runtime.ts
+++ b/packages/sandbox/src/args/runtime.ts
@@ -1,7 +1,7 @@
 import * as cmd from "cmd-ts";
 
 export const runtimeType = {
-  ...cmd.oneOf(["node22", "node24", "python3.13"] as const),
+  ...cmd.oneOf(["node22", "node24", "node26", "python3.13"] as const),
   displayName: "runtime",
 };
 

--- a/packages/vercel-sandbox/src/constants.ts
+++ b/packages/vercel-sandbox/src/constants.ts
@@ -1,1 +1,1 @@
-export type RUNTIMES = "node24" | "node22" | "python3.13";
+export type RUNTIMES = "node26" | "node24" | "node22" | "python3.13";

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -81,7 +81,7 @@ export interface BaseCreateSandboxParams {
    */
   resources?: { vcpus: number };
   /**
-   * The runtime of the sandbox, currently only `node24`, `node22` and `python3.13` are supported.
+   * The runtime of the sandbox, currently only `node24`, `node22`, `node26` and `python3.13` are supported.
    * If not specified, the default runtime `node24` will be used.
    */
   runtime?: RUNTIMES | (string & {});


### PR DESCRIPTION
Add support for booting sandboxes with Node 26 on named sandboxes.