### PR TITLE
feat(dynamic ports): support dynamic update of sandbox ports

### DIFF
--- a/.changeset/fluffy-ports-update.md
+++ b/.changeset/fluffy-ports-update.md
@@ -2,4 +2,4 @@
 "@vercel/sandbox": minor
 ---
 
-Add sandbox port replacement support through `updatePorts` and `update`.
+Add sandbox port replacement support through `update`.

--- a/.changeset/fluffy-ports-update.md
+++ b/.changeset/fluffy-ports-update.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": minor
+---
+
+Add sandbox port replacement support through `updatePorts` and `update`.

--- a/packages/vercel-sandbox/src/api-client/api-client.test.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.test.ts
@@ -844,6 +844,7 @@ describe("APIClient", () => {
         projectId: "proj_123",
         persistent: true,
         timeout: 600000,
+        ports: [3000, 4000],
         snapshotExpiration: 604800000,
         currentSnapshotId: "snap_abc123",
       });
@@ -858,6 +859,7 @@ describe("APIClient", () => {
       const parsedBody = JSON.parse(opts.body);
       expect(parsedBody.persistent).toBe(true);
       expect(parsedBody.timeout).toBe(600000);
+      expect(parsedBody.ports).toEqual([3000, 4000]);
       expect(parsedBody.snapshotExpiration).toBe(604800000);
       expect(parsedBody.currentSnapshotId).toBe("snap_abc123");
     });

--- a/packages/vercel-sandbox/src/api-client/api-client.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.ts
@@ -770,6 +770,7 @@ export class APIClient extends BaseClient {
     timeout?: number;
     networkPolicy?: NetworkPolicy;
     tags?: Record<string, string>;
+    ports?: number[];
     snapshotExpiration?: number;
     currentSnapshotId?: string;
     signal?: AbortSignal;
@@ -790,6 +791,7 @@ export class APIClient extends BaseClient {
             ? toAPINetworkPolicy(params.networkPolicy)
             : undefined,
           tags: params.tags,
+          ports: params.ports,
           snapshotExpiration: params.snapshotExpiration,
           currentSnapshotId: params.currentSnapshotId,
         }),

--- a/packages/vercel-sandbox/src/api-client/validators.ts
+++ b/packages/vercel-sandbox/src/api-client/validators.ts
@@ -271,4 +271,5 @@ export const SandboxesPaginationResponse = z.object({
 
 export const UpdateSandboxResponse = z.object({
   sandbox: Sandbox,
+  routes: z.array(SandboxRoute).optional(),
 });

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -94,6 +94,53 @@ const makeCommand = (): CommandData => ({
   startedAt: 1,
 });
 
+describe("updatePorts", () => {
+  it.each([
+    ["updatePorts", (sandbox: Sandbox) => sandbox.updatePorts([4000])],
+    ["update", (sandbox: Sandbox) => sandbox.update({ ports: [4000] })],
+  ])("%s sends a full port list to updateSandbox", async (_, updatePorts) => {
+    const updatedSandbox = makeSandboxMetadata();
+    const routes = [
+      {
+        url: "https://test-4000.vercel.run",
+        subdomain: "test-4000",
+        port: 4000,
+      },
+    ];
+    const updateSandboxMock = vi.fn(async () => ({
+      json: { sandbox: updatedSandbox, routes },
+    }));
+    const sandbox = new Sandbox({
+      client: {
+        updateSandbox: updateSandboxMock,
+      } as unknown as APIClient,
+      routes: [
+        {
+          url: "https://test-3000.vercel.run",
+          subdomain: "test-3000",
+          port: 3000,
+        },
+      ],
+      sandbox: makeSandboxMetadata(),
+      session: {} as any,
+      projectId: "test-project",
+    });
+
+    await updatePorts(sandbox);
+
+    expect(updateSandboxMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "test-name",
+        projectId: "test-project",
+        ports: [4000],
+      }),
+    );
+    expect(sandbox.routes).toEqual(routes);
+    expect(sandbox.domain(4000)).toBe("https://test-4000.vercel.run");
+    expect(() => sandbox.domain(3000)).toThrow("No route for port 3000");
+  });
+});
+
 describe("_runCommand error handling", () => {
   it("rejects non-detached runCommand when log streaming fails", async () => {
     const command = makeCommand();

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -96,7 +96,7 @@ const makeCommand = (): CommandData => ({
 
 describe("updatePorts", () => {
   it.each([
-    ["updatePorts", (sandbox: Sandbox) => sandbox.updatePorts([4000])],
+    ["updatePorts", (sandbox: Sandbox) => sandbox.update({ports: [4000]})],
     ["update", (sandbox: Sandbox) => sandbox.update({ ports: [4000] })],
   ])("%s sends a full port list to updateSandbox", async (_, updatePorts) => {
     const updatedSandbox = makeSandboxMetadata();

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -1154,22 +1154,6 @@ export class Sandbox {
   }
 
   /**
-   * Replace the exposed ports for this sandbox.
-   *
-   * This is a full-state update: any currently exposed port omitted from
-   * `ports` will be deregistered.
-   *
-   * @param ports - Complete list of ports to expose.
-   * @param opts - Optional abort signal.
-   */
-  async updatePorts(
-    ports: number[],
-    opts?: { signal?: AbortSignal },
-  ): Promise<void> {
-    await this.update({ ports }, opts);
-  }
-
-  /**
    * Update the sandbox configuration.
    *
    * When `ports` is provided, it is treated as the full desired port list:

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -1154,7 +1154,26 @@ export class Sandbox {
   }
 
   /**
+   * Replace the exposed ports for this sandbox.
+   *
+   * This is a full-state update: any currently exposed port omitted from
+   * `ports` will be deregistered.
+   *
+   * @param ports - Complete list of ports to expose.
+   * @param opts - Optional abort signal.
+   */
+  async updatePorts(
+    ports: number[],
+    opts?: { signal?: AbortSignal },
+  ): Promise<void> {
+    await this.update({ ports }, opts);
+  }
+
+  /**
    * Update the sandbox configuration.
+   *
+   * When `ports` is provided, it is treated as the full desired port list:
+   * any currently exposed port omitted from the array will be deregistered.
    *
    * @param params - Fields to update.
    * @param opts - Optional abort signal.
@@ -1166,6 +1185,7 @@ export class Sandbox {
       timeout?: number;
       networkPolicy?: NetworkPolicy;
       tags?: Record<string, string>;
+      ports?: number[];
       snapshotExpiration?: number;
       currentSnapshotId?: string;
     },
@@ -1190,11 +1210,15 @@ export class Sandbox {
       timeout: params.timeout,
       networkPolicy: params.networkPolicy,
       tags: params.tags,
+      ports: params.ports,
       snapshotExpiration: params.snapshotExpiration,
       currentSnapshotId: params.currentSnapshotId,
       signal: opts?.signal,
     });
     this.sandbox = response.json.sandbox;
+    if (params.ports !== undefined && response.json.routes) {
+      this.session?.updateRoutes(response.json.routes);
+    }
 
     // Update the current session config. This only applies to network policy.
     if (params.networkPolicy) {

--- a/packages/vercel-sandbox/src/session.ts
+++ b/packages/vercel-sandbox/src/session.ts
@@ -315,6 +315,11 @@ export class Session {
     }
   }
 
+  /** @internal */
+  updateRoutes(routes: SandboxRouteData[]): void {
+    (this as { routes: SandboxRouteData[] }).routes = routes;
+  }
+
   /**
    * Get a previously run command by its ID.
    *


### PR DESCRIPTION
Users are currently required to provide the exact list of ports they will use when creating their sandbox. This can be constraining, and we received requests to support dynamically adding or removing ports on a running sandbox (akin to the network policy model)
This PR adds support for the latest `sandbox update` API extension for ports. Users can provide a new list of ports to expose (as a full state). New ports will become exposed and ones no longer presents will be deregistered from the sandbox.
The port number limit (currently 15) remains applicable