### PR TITLE
feat(sdk): add `defineSandboxProxy` helper

### DIFF
--- a/.changeset/cold-pillows-wave.md
+++ b/.changeset/cold-pillows-wave.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": minor
+---
+
+Add `defineSandboxProxy` helper in `@vercel/sandbox/proxy` to easily implement network policies forwarding rules

--- a/packages/vercel-sandbox/package.json
+++ b/packages/vercel-sandbox/package.json
@@ -13,6 +13,12 @@
       "require": "./dist/index.cjs",
       "default": "./dist/index.cjs"
     },
+    "./proxy": {
+      "types": "./dist/proxy.d.ts",
+      "import": "./dist/proxy.js",
+      "require": "./dist/proxy.cjs",
+      "default": "./dist/proxy.cjs"
+    },
     "./dist/auth/index.js": {
       "types": "./dist/auth/index.d.ts",
       "import": "./dist/auth/index.js",
@@ -50,6 +56,7 @@
     "@vercel/oidc": "3.2.0",
     "@workflow/serde": "4.1.0-beta.2",
     "async-retry": "1.3.3",
+    "jose": "6.2.3",
     "jsonlines": "0.1.1",
     "ms": "2.1.3",
     "picocolors": "^1.1.1",

--- a/packages/vercel-sandbox/src/index.ts
+++ b/packages/vercel-sandbox/src/index.ts
@@ -22,3 +22,9 @@ export type {
 export { StreamError } from "./api-client/api-error.js";
 export { APIError } from "./api-client/api-error.js";
 export { FileSystem } from "./filesystem.js";
+export { defineSandboxProxy } from "./proxy.js";
+export type {
+  InvalidRequestProxyHandler,
+  ProxyMeta,
+  ProxyHandler,
+} from "./proxy.js";

--- a/packages/vercel-sandbox/src/network-policy.ts
+++ b/packages/vercel-sandbox/src/network-policy.ts
@@ -67,6 +67,11 @@ export type NetworkPolicyRule = {
   transform?: NetworkTransformer[];
   /**
    * HTTPS proxy URL to forward matching requests to. Must not include query string or fragment.
+   *
+   * You can use the `defineSandboxProxy` helper from `@vercel/sandbox/proxy` to implement the proxy handler
+   * automatically, which handles authorization and extracts metadata about the request and sandbox.
+   *
+   * @see https://vercel.com/docs/vercel-sandbox/concepts/firewall#requests-proxying
    */
   forwardURL?: string;
 };

--- a/packages/vercel-sandbox/src/package-exports.test.ts
+++ b/packages/vercel-sandbox/src/package-exports.test.ts
@@ -11,6 +11,9 @@ it("defines import/require export targets", () => {
   expect(packageJson.exports?.["."]?.import).toBe("./dist/index.js");
   expect(packageJson.exports?.["."]?.require).toBe("./dist/index.cjs");
   expect(packageJson.exports?.["."]?.types).toBe("./dist/index.d.ts");
+  expect(packageJson.exports?.["./proxy"]?.import).toBe("./dist/proxy.js");
+  expect(packageJson.exports?.["./proxy"]?.require).toBe("./dist/proxy.cjs");
+  expect(packageJson.exports?.["./proxy"]?.types).toBe("./dist/proxy.d.ts");
   expect(packageJson.exports?.["./dist/auth/index.js"]?.import).toBe(
     "./dist/auth/index.js",
   );
@@ -20,6 +23,31 @@ it("defines import/require export targets", () => {
   expect(packageJson.exports?.["./dist/auth/index.js"]?.types).toBe(
     "./dist/auth/index.d.ts",
   );
+});
+
+it("resolves proxy subpath with format-appropriate files", () => {
+  const packageRoot = resolve(__dirname, "..");
+
+  const cjsResolution = execFileSync(
+    process.execPath,
+    ["-e", "console.log(require.resolve('@vercel/sandbox/proxy'))"],
+    { cwd: packageRoot, encoding: "utf8" },
+  ).trim();
+
+  const esmResolutionUrl = execFileSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      "console.log(await import.meta.resolve('@vercel/sandbox/proxy'))",
+    ],
+    { cwd: packageRoot, encoding: "utf8" },
+  ).trim();
+
+  const esmResolution = fileURLToPath(esmResolutionUrl);
+
+  expect(cjsResolution).toBe(resolve(packageRoot, "dist/proxy.cjs"));
+  expect(esmResolution).toBe(resolve(packageRoot, "dist/proxy.js"));
 });
 
 it("resolves import and require to different entrypoints", () => {

--- a/packages/vercel-sandbox/src/proxy.test.ts
+++ b/packages/vercel-sandbox/src/proxy.test.ts
@@ -1,0 +1,286 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createRemoteJWKSet, decodeJwt, jwtVerify } from "jose";
+import { defineSandboxProxy } from "./proxy.js";
+
+vi.mock("jose", () => ({
+  createRemoteJWKSet: vi.fn(() => vi.fn()),
+  decodeJwt: vi.fn(),
+  jwtVerify: vi.fn(),
+}));
+
+const createRemoteJWKSetMock = vi.mocked(createRemoteJWKSet);
+const decodeJwtMock = vi.mocked(decodeJwt);
+const jwtVerifyMock = vi.mocked(jwtVerify);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  createRemoteJWKSetMock.mockReturnValue(
+    vi.fn() as unknown as ReturnType<typeof createRemoteJWKSet>,
+  );
+  decodeJwtMock.mockReturnValue({ iss: "https://oidc.vercel.com/team_123" });
+  jwtVerifyMock.mockResolvedValue(
+    makeJwtVerifyResult({
+      team_id: "team_123",
+      project_id: "prj_123",
+      sandbox_id: "sbx_123",
+      sandbox_name: "sandbox-name",
+    }),
+  );
+});
+
+describe("defineSandboxProxy", () => {
+  it("sanitizes and forwards valid proxied requests with sandbox metadata", async () => {
+    const handler = vi.fn(async (request: Request, meta) => {
+      expect(request.url).toBe("https://example.com/some/path?foo=bar");
+      expect(request.method).toBe("POST");
+      expect(request.headers.get("host")).toBe("example.com");
+      expect(request.headers.get("x-client-header")).toBe("kept");
+      expect(request.headers.get("vercel-forwarded-host")).toBeNull();
+      expect(request.headers.get("vercel-forwarded-scheme")).toBeNull();
+      expect(request.headers.get("vercel-forwarded-port")).toBeNull();
+      expect(request.headers.get("vercel-forwarded-path")).toBeNull();
+      expect(request.headers.get("vercel-sandbox-oidc-token")).toBeNull();
+      expect(await request.text()).toBe("request body");
+      expect(meta).toEqual({
+        host: "proxy.vercel.app",
+        teamId: "team_123",
+        projectId: "prj_123",
+        sandboxId: "sbx_123",
+        sandboxName: "sandbox-name",
+      });
+
+      return new Response("ok");
+    });
+    const proxy = defineSandboxProxy(handler);
+
+    const response = await proxy(
+      new Request("https://proxy.vercel.app/proxy/some/path?foo=bar", {
+        method: "POST",
+        body: "request body",
+        headers: {
+          "x-client-header": "kept",
+          "vercel-forwarded-host": "example.com",
+          "vercel-forwarded-scheme": "https",
+          "vercel-forwarded-port": "443",
+          "vercel-forwarded-path": "/some/path?foo=bar",
+          "vercel-sandbox-oidc-token": "token_123",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("ok");
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("verifies OIDC tokens against the forward URL instead of the appended proxied path", async () => {
+    const handler = vi.fn(() => new Response("ok"));
+    const proxy = defineSandboxProxy(handler);
+
+    await proxy(makeProxyRequest());
+
+    expect(jwtVerifyMock).toHaveBeenCalledWith(
+      "token_123",
+      expect.any(Function),
+      expect.objectContaining({
+        audience: "https://proxy.vercel.app/proxy",
+      }),
+    );
+  });
+
+  it("defaults sandboxName to sandboxId when the token has no sandbox_name claim", async () => {
+    jwtVerifyMock.mockResolvedValue(
+      makeJwtVerifyResult({
+        team_id: "team_123",
+        project_id: "prj_123",
+        sandbox_id: "sbx_123",
+      }),
+    );
+
+    const handler = vi.fn(() => new Response("ok"));
+    const proxy = defineSandboxProxy(handler);
+
+    await proxy(makeProxyRequest());
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.objectContaining({ sandboxName: "sbx_123" }),
+    );
+  });
+
+  it("uses the default 403 response for missing proxy headers", async () => {
+    const handler = vi.fn(() => new Response("ok"));
+    const proxy = defineSandboxProxy(handler);
+
+    const response = await proxy(new Request("https://proxy.vercel.app/proxy"));
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe("Forbidden");
+    expect(handler).not.toHaveBeenCalled();
+    expect(jwtVerifyMock).not.toHaveBeenCalled();
+  });
+
+  it("calls the invalid request handler with the original request when required headers are missing", async () => {
+    const handler = vi.fn(() => new Response("ok"));
+    const invalidRequestHandler = vi.fn(
+      (request: Request, error: Error) =>
+        new Response(
+          JSON.stringify({
+            error: error.message,
+            forwardedHost: request.headers.get("vercel-forwarded-host"),
+          }),
+          { status: 401 },
+        ),
+    );
+    const proxy = defineSandboxProxy(handler, invalidRequestHandler);
+
+    const response = await proxy(
+      makeProxyRequest({
+        headers: { "vercel-sandbox-oidc-token": null },
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      error: "Missing required proxy headers",
+      forwardedHost: "example.com",
+    });
+    expect(response.status).toBe(401);
+    expect(handler).not.toHaveBeenCalled();
+    expect(jwtVerifyMock).not.toHaveBeenCalled();
+  });
+
+  it("calls the invalid request handler with stripped headers when the forwarded URL is invalid", async () => {
+    const handler = vi.fn(() => new Response("ok"));
+    const invalidRequestHandler = vi.fn(
+      (request: Request, error: Error) =>
+        new Response(
+          JSON.stringify({
+            error: error.message,
+            forwardedHost: request.headers.get("vercel-forwarded-host"),
+            oidcToken: request.headers.get("vercel-sandbox-oidc-token"),
+          }),
+          { status: 400 },
+        ),
+    );
+    const proxy = defineSandboxProxy(handler, invalidRequestHandler);
+
+    const response = await proxy(
+      makeProxyRequest({
+        headers: { "vercel-forwarded-host": "exa mple.com" },
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid proxied request URL",
+      forwardedHost: null,
+      oidcToken: null,
+    });
+    expect(response.status).toBe(400);
+    expect(handler).not.toHaveBeenCalled();
+    expect(jwtVerifyMock).not.toHaveBeenCalled();
+  });
+
+  it("calls the invalid request handler with the sanitized request when OIDC verification fails", async () => {
+    jwtVerifyMock.mockRejectedValue(new Error("bad token"));
+    const handler = vi.fn(() => new Response("ok"));
+    const invalidRequestHandler = vi.fn(
+      (request: Request, error: Error) =>
+        new Response(
+          JSON.stringify({
+            error: error.message,
+            url: request.url,
+            forwardedHost: request.headers.get("vercel-forwarded-host"),
+            host: request.headers.get("host"),
+          }),
+          { status: 401 },
+        ),
+    );
+    const proxy = defineSandboxProxy(handler, invalidRequestHandler);
+
+    const response = await proxy(makeProxyRequest());
+
+    await expect(response.json()).resolves.toEqual({
+      error: "bad token",
+      url: "https://example.com/some/path?foo=bar",
+      forwardedHost: null,
+      host: "example.com",
+    });
+    expect(response.status).toBe(401);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("rejects tokens without a Vercel OIDC issuer before verifying the signature", async () => {
+    decodeJwtMock.mockReturnValue({ iss: "https://example.com/team_123" });
+    const handler = vi.fn(() => new Response("ok"));
+    const invalidRequestHandler = vi.fn(
+      (_request: Request, error: Error) =>
+        new Response(error.message, { status: 401 }),
+    );
+    const proxy = defineSandboxProxy(handler, invalidRequestHandler);
+
+    const response = await proxy(makeProxyRequest());
+
+    expect(response.status).toBe(401);
+    expect(await response.text()).toBe("Invalid OIDC issuer");
+    expect(handler).not.toHaveBeenCalled();
+    expect(jwtVerifyMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects tokens missing required sandbox claims", async () => {
+    jwtVerifyMock.mockResolvedValue(
+      makeJwtVerifyResult({
+        team_id: "team_123",
+        project_id: "prj_123",
+      }),
+    );
+    const handler = vi.fn(() => new Response("ok"));
+    const invalidRequestHandler = vi.fn(
+      (_request: Request, error: Error) =>
+        new Response(error.message, { status: 401 }),
+    );
+    const proxy = defineSandboxProxy(handler, invalidRequestHandler);
+
+    const response = await proxy(makeProxyRequest());
+
+    expect(response.status).toBe(401);
+    expect(await response.text()).toBe("Missing required claims in OIDC token");
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+function makeProxyRequest({
+  url = "https://proxy.vercel.app/proxy/some/path?foo=bar",
+  headers: headerOverrides = {},
+}: {
+  url?: string;
+  headers?: Record<string, string | null>;
+} = {}): Request {
+  const headers = new Headers({
+    "vercel-forwarded-host": "example.com",
+    "vercel-forwarded-scheme": "https",
+    "vercel-forwarded-port": "443",
+    "vercel-forwarded-path": "/some/path?foo=bar",
+    "vercel-sandbox-oidc-token": "token_123",
+  });
+
+  for (const [key, value] of Object.entries(headerOverrides)) {
+    if (value === null) {
+      headers.delete(key);
+    } else {
+      headers.set(key, value);
+    }
+  }
+
+  return new Request(url, { headers });
+}
+
+function makeJwtVerifyResult(
+  payload: Record<string, unknown>,
+): Awaited<ReturnType<typeof jwtVerify>> {
+  return {
+    payload,
+    protectedHeader: { alg: "RS256" },
+    key: {},
+  } as Awaited<ReturnType<typeof jwtVerify>>;
+}

--- a/packages/vercel-sandbox/src/proxy.test.ts
+++ b/packages/vercel-sandbox/src/proxy.test.ts
@@ -89,6 +89,21 @@ describe("defineSandboxProxy", () => {
     );
   });
 
+  it("accepts origin-only forward URL audiences", async () => {
+    const handler = vi.fn(() => new Response("ok"));
+    const proxy = defineSandboxProxy(handler);
+
+    await proxy(makeProxyRequest({ url: "https://proxy.vercel.app/some/path" }));
+
+    expect(jwtVerifyMock).toHaveBeenCalledWith(
+      "token_123",
+      expect.any(Function),
+      expect.objectContaining({
+        audience: ["https://proxy.vercel.app", "https://proxy.vercel.app/"],
+      }),
+    );
+  });
+
   it("defaults sandboxName to sandboxId when the token has no sandbox_name claim", async () => {
     jwtVerifyMock.mockResolvedValue(
       makeJwtVerifyResult({

--- a/packages/vercel-sandbox/src/proxy.test.ts
+++ b/packages/vercel-sandbox/src/proxy.test.ts
@@ -74,6 +74,25 @@ describe("defineSandboxProxy", () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
+  it("sanitizes and forwards root proxied requests", async () => {
+    const handler = vi.fn((request: Request) => {
+      expect(request.url).toBe("https://example.com/");
+
+      return new Response("ok");
+    });
+    const proxy = defineSandboxProxy(handler);
+
+    const response = await proxy(
+      makeProxyRequest({
+        url: "https://proxy.vercel.app/proxy",
+        headers: { "vercel-forwarded-path": "/" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
   it("verifies OIDC tokens against the forward URL instead of the appended proxied path", async () => {
     const handler = vi.fn(() => new Response("ok"));
     const proxy = defineSandboxProxy(handler);
@@ -99,7 +118,47 @@ describe("defineSandboxProxy", () => {
       "token_123",
       expect.any(Function),
       expect.objectContaining({
-        audience: ["https://proxy.vercel.app", "https://proxy.vercel.app/"],
+        audience: "https://proxy.vercel.app",
+      }),
+    );
+  });
+
+  it("normalizes trailing slashes before verifying forward URL audiences", async () => {
+    const handler = vi.fn(() => new Response("ok"));
+    const proxy = defineSandboxProxy(handler);
+
+    await proxy(
+      makeProxyRequest({
+        url: "https://proxy.vercel.app/proxy/some/path/",
+        headers: { "vercel-forwarded-path": "/some/path/" },
+      }),
+    );
+
+    expect(jwtVerifyMock).toHaveBeenCalledWith(
+      "token_123",
+      expect.any(Function),
+      expect.objectContaining({
+        audience: "https://proxy.vercel.app/proxy",
+      }),
+    );
+  });
+
+  it("accepts forwarded paths with a trailing slash when the proxy request URL omits it", async () => {
+    const handler = vi.fn(() => new Response("ok"));
+    const proxy = defineSandboxProxy(handler);
+
+    await proxy(
+      makeProxyRequest({
+        url: "https://proxy.vercel.app/api/proxy/docs",
+        headers: { "vercel-forwarded-path": "/docs/" },
+      }),
+    );
+
+    expect(jwtVerifyMock).toHaveBeenCalledWith(
+      "token_123",
+      expect.any(Function),
+      expect.objectContaining({
+        audience: "https://proxy.vercel.app/api/proxy",
       }),
     );
   });

--- a/packages/vercel-sandbox/src/proxy.ts
+++ b/packages/vercel-sandbox/src/proxy.ts
@@ -58,6 +58,20 @@ export type InvalidRequestProxyHandler = (
  * 
  * This function automatically verifies the OIDC token included in proxied requests to ensure the request
  * is legitimate: if invalid, the `invalidRequestHandler` is called (by default, a 403 response is returned).
+ *
+ * @example
+ * ```ts
+ * export default {
+ *   fetch: defineSandboxProxy(async (request, meta) => {
+ *     console.log(meta) // contains the original host/scheme/port & source team/project/sandbox ids
+ *
+ *     return new Response("Response from my proxy");
+ *   }, (request, error) => {
+ *     // optional, handle any authorization error
+ *     return new Response("Forbidden", { status: 403 });
+ *   })
+ * }
+ * ```
  * 
  * @see https://vercel.com/docs/vercel-sandbox/concepts/firewall#requests-proxying
  */

--- a/packages/vercel-sandbox/src/proxy.ts
+++ b/packages/vercel-sandbox/src/proxy.ts
@@ -63,12 +63,19 @@ export type InvalidRequestProxyHandler = (
  * ```ts
  * export default {
  *   fetch: defineSandboxProxy(async (request, meta) => {
- *     console.log(meta) // contains the original host/scheme/port & source team/project/sandbox ids
+ *     // meta contains the original host/scheme/port & source team/project/sandbox ids
+ *     console.log(meta)
  *
- *     return new Response("Response from my proxy");
+ *     // return a custom response, or proxy upstream:
+ *     const url = new URL(request.url)
+ *     return await fetch(`${meta.scheme}://${meta.host}:${meta.port}/${url.pathname}${url.search}`, {
+ *       method: request.method,
+ *       headers: request.headers,
+ *       body: request.body
+ *     })
  *   }, (request, error) => {
  *     // optional, handle any authorization error
- *     return new Response("Forbidden", { status: 403 });
+ *     return new Response("Forbidden", { status: 403 })
  *   })
  * }
  * ```

--- a/packages/vercel-sandbox/src/proxy.ts
+++ b/packages/vercel-sandbox/src/proxy.ts
@@ -48,7 +48,7 @@ export type InvalidRequestProxyHandler = (
  * Creates a Web Handler for proxied requests from Vercel Sandboxes using the network policy `forwardURL`
  * option. The provided `handler` is called for each valid proxied request, with the original request
  * alongside extracted metadata used to identify the source sandbox and request details.
- * 
+ *
  * This function automatically verifies the OIDC token included in proxied requests to ensure the request
  * is legitimate: if invalid, the `invalidRequestHandler` is called (by default, a 403 response is returned).
  *
@@ -67,7 +67,7 @@ export type InvalidRequestProxyHandler = (
  *   })
  * }
  * ```
- * 
+ *
  * @see https://vercel.com/docs/vercel-sandbox/concepts/firewall#requests-proxying
  */
 export function defineSandboxProxy(
@@ -98,15 +98,12 @@ export function defineSandboxProxy(
     let sanitizedRequest: Request;
 
     try {
-      sanitizedRequest = new Request(
-        `${scheme}://${host}:${port}${path}`,
-        {
-          method: request.method,
-          body: request.body,
-          headers,
-          duplex: "half",
-        },
-      );
+      sanitizedRequest = new Request(`${scheme}://${host}:${port}${path}`, {
+        method: request.method,
+        body: request.body,
+        headers,
+        duplex: "half",
+      });
     } catch {
       return invalidRequestHandler(
         new Request(request, { headers }),
@@ -117,7 +114,7 @@ export function defineSandboxProxy(
     sanitizedRequest.headers.set("host", host);
 
     try {
-      const originalUrl = new URL(request.url);
+      const originalUrl = normalizeForwardUrl(new URL(request.url), path);
       const claims = await verifyOidcToken(oidcToken, originalUrl);
       const meta = getProxyMeta(originalUrl.host, claims);
 
@@ -133,6 +130,22 @@ export function defineSandboxProxy(
 
 function defaultInvalidRequestHandler(): Response {
   return new Response("Forbidden", { status: 403 });
+}
+
+function normalizeForwardUrl(url: URL, forwardedPath: string): URL {
+  const forwardedUrl = new URL(forwardedPath, url.origin);
+  const forwardedPathname = forwardedUrl.pathname;
+  const normalizedUrl = new URL(url);
+
+  if (
+    forwardedPathname !== "/" &&
+    normalizedUrl.pathname.endsWith(forwardedPathname)
+  ) {
+    normalizedUrl.pathname =
+      normalizedUrl.pathname.slice(0, -forwardedPathname.length) || "/";
+  }
+
+  return normalizedUrl;
 }
 
 function getProxyMeta(

--- a/packages/vercel-sandbox/src/proxy.ts
+++ b/packages/vercel-sandbox/src/proxy.ts
@@ -12,17 +12,9 @@ const jwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
 
 export interface ProxyMeta {
   /**
-   * The original host of the proxied request.
+   * The host of the request as received by this proxy.
    */
   host: string;
-  /**
-   * The original scheme of the proxied request.
-   */
-  scheme: string;
-  /**
-   * The original port of the proxied request.
-   */
-  port: string;
   /**
    * The ID of the team that owns the sandbox that proxied the request.
    */
@@ -63,16 +55,11 @@ export type InvalidRequestProxyHandler = (
  * ```ts
  * export default {
  *   fetch: defineSandboxProxy(async (request, meta) => {
- *     // meta contains the original host/scheme/port & source team/project/sandbox ids
+ *     // meta contains the original host & source team/project/sandbox ids
  *     console.log(meta)
  *
  *     // return a custom response, or proxy upstream:
- *     const url = new URL(request.url)
- *     return await fetch(`${meta.scheme}://${meta.host}:${meta.port}/${url.pathname}${url.search}`, {
- *       method: request.method,
- *       headers: request.headers,
- *       body: request.body
- *     })
+ *     return await fetch(request)
  *   }, (request, error) => {
  *     // optional, handle any authorization error
  *     return new Response("Forbidden", { status: 403 })
@@ -98,18 +85,40 @@ export function defineSandboxProxy(
     headers.delete(FORWARDED_PORT_HEADER);
     headers.delete(SANDBOX_OIDC_TOKEN_HEADER);
 
-    const sanitizedRequest = new Request(request, { headers });
-
     if (!host || !scheme || !port || !oidcToken) {
       return invalidRequestHandler(
-        sanitizedRequest,
+        request,
         new Error("Missing required proxy headers"),
       );
     }
 
+    let sanitizedRequest: Request;
+
     try {
-      const claims = await verifyOidcToken(oidcToken);
-      const meta = getProxyMeta({ host, scheme, port }, claims);
+      const url = new URL(request.url);
+      sanitizedRequest = new Request(
+        `${scheme}://${host}:${port}${url.pathname}${url.search}${url.hash}`,
+        {
+          method: request.method,
+          body: request.body,
+          headers,
+          duplex: "half",
+        },
+      );
+    } catch {
+      return invalidRequestHandler(
+        new Request(request, { headers }),
+        new Error("Invalid proxied request URL"),
+      );
+    }
+
+    sanitizedRequest.headers.set("host", host);
+    sanitizedRequest.headers.set("x-forwarded-host", host);
+
+    try {
+      const originalUrl = new URL(request.url);
+      const claims = await verifyOidcToken(oidcToken, originalUrl);
+      const meta = getProxyMeta(originalUrl.host, claims);
 
       return handler(sanitizedRequest, meta);
     } catch (error) {
@@ -126,7 +135,7 @@ function defaultInvalidRequestHandler(): Response {
 }
 
 function getProxyMeta(
-  forwarded: Pick<ProxyMeta, "host" | "scheme" | "port">,
+  host: string,
   claims: Record<string, unknown>,
 ): ProxyMeta {
   const teamId = getClaim(claims, "team_id");
@@ -139,7 +148,7 @@ function getProxyMeta(
   }
 
   return {
-    ...forwarded,
+    host,
     teamId,
     projectId,
     sandboxId,
@@ -149,6 +158,7 @@ function getProxyMeta(
 
 async function verifyOidcToken(
   token: string,
+  originalUrl: URL,
 ): Promise<Record<string, unknown>> {
   const claims = decodeJwt(token);
   const issuer = getClaim(claims, "iss");
@@ -173,6 +183,7 @@ async function verifyOidcToken(
   }
 
   const { payload } = await jwtVerify(token, getJwks(issuer), {
+    audience: originalUrl.origin + originalUrl.pathname,
     algorithms: ["RS256"],
     clockTolerance: CLOCK_TOLERANCE_SECONDS,
     issuer,

--- a/packages/vercel-sandbox/src/proxy.ts
+++ b/packages/vercel-sandbox/src/proxy.ts
@@ -197,13 +197,21 @@ async function verifyOidcToken(
   }
 
   const { payload } = await jwtVerify(token, getJwks(issuer), {
-    audience: originalUrl.origin + originalUrl.pathname,
+    audience: getForwardUrlAudiences(originalUrl),
     algorithms: ["RS256"],
     clockTolerance: CLOCK_TOLERANCE_SECONDS,
     issuer,
   });
 
   return payload;
+}
+
+function getForwardUrlAudiences(url: URL): string | string[] {
+  if (url.pathname === "/") {
+    return [url.origin, `${url.origin}/`];
+  }
+
+  return url.origin + url.pathname;
 }
 
 function getJwks(issuer: string): ReturnType<typeof createRemoteJWKSet> {

--- a/packages/vercel-sandbox/src/proxy.ts
+++ b/packages/vercel-sandbox/src/proxy.ts
@@ -1,0 +1,188 @@
+import { createRemoteJWKSet, decodeJwt, jwtVerify } from "jose";
+
+const FORWARDED_HOST_HEADER = "vercel-forwarded-host";
+const FORWARDED_SCHEME_HEADER = "vercel-forwarded-scheme";
+const FORWARDED_PORT_HEADER = "vercel-forwarded-port";
+const SANDBOX_OIDC_TOKEN_HEADER = "vercel-sandbox-oidc-token";
+
+const VERCEL_OIDC_HOSTNAME = "oidc.vercel.com";
+const CLOCK_TOLERANCE_SECONDS = 60;
+
+const jwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
+
+export interface ProxyMeta {
+  /**
+   * The original host of the proxied request.
+   */
+  host: string;
+  /**
+   * The original scheme of the proxied request.
+   */
+  scheme: string;
+  /**
+   * The original port of the proxied request.
+   */
+  port: string;
+  /**
+   * The ID of the team that owns the sandbox that proxied the request.
+   */
+  teamId: string;
+  /**
+   * The ID of the project that owns the sandbox that proxied the request.
+   */
+  projectId: string;
+  /**
+   * The ID of the sandbox that proxied the request.
+   */
+  sandboxId: string;
+  /**
+   * The name of the sandbox that proxied the request, when using persistent sandboxes.
+   */
+  sandboxName: string;
+}
+
+export type ProxyHandler = (
+  request: Request,
+  meta: ProxyMeta,
+) => Response | Promise<Response>;
+
+export type InvalidRequestProxyHandler = (
+  request: Request,
+  error: Error,
+) => Response | Promise<Response>;
+
+/**
+ * Creates a Web Handler for proxied requests from Vercel Sandboxes using the network policy `forwardURL`
+ * option. The provided `handler` is called for each valid proxied request, with the original request
+ * alongside extracted metadata used to identify the source sandbox and request details.
+ * 
+ * This function automatically verifies the OIDC token included in proxied requests to ensure the request
+ * is legitimate: if invalid, the `invalidRequestHandler` is called (by default, a 403 response is returned).
+ * 
+ * @see https://vercel.com/docs/vercel-sandbox/concepts/firewall#requests-proxying
+ */
+export function defineSandboxProxy(
+  handler: ProxyHandler,
+  invalidRequestHandler: InvalidRequestProxyHandler = defaultInvalidRequestHandler,
+) {
+  return async function sandboxProxy(request: Request): Promise<Response> {
+    const headers = new Headers(request.headers);
+    const host = headers.get(FORWARDED_HOST_HEADER);
+    const scheme = headers.get(FORWARDED_SCHEME_HEADER);
+    const port = headers.get(FORWARDED_PORT_HEADER);
+    const oidcToken = headers.get(SANDBOX_OIDC_TOKEN_HEADER);
+
+    headers.delete(FORWARDED_HOST_HEADER);
+    headers.delete(FORWARDED_SCHEME_HEADER);
+    headers.delete(FORWARDED_PORT_HEADER);
+    headers.delete(SANDBOX_OIDC_TOKEN_HEADER);
+
+    const sanitizedRequest = new Request(request, { headers });
+
+    if (!host || !scheme || !port || !oidcToken) {
+      return invalidRequestHandler(
+        sanitizedRequest,
+        new Error("Missing required proxy headers"),
+      );
+    }
+
+    try {
+      const claims = await verifyOidcToken(oidcToken);
+      const meta = getProxyMeta({ host, scheme, port }, claims);
+
+      return handler(sanitizedRequest, meta);
+    } catch (error) {
+      return invalidRequestHandler(
+        sanitizedRequest,
+        error instanceof Error ? error : new Error("Invalid OIDC token"),
+      );
+    }
+  };
+}
+
+function defaultInvalidRequestHandler(): Response {
+  return new Response("Forbidden", { status: 403 });
+}
+
+function getProxyMeta(
+  forwarded: Pick<ProxyMeta, "host" | "scheme" | "port">,
+  claims: Record<string, unknown>,
+): ProxyMeta {
+  const teamId = getClaim(claims, "team_id");
+  const projectId = getClaim(claims, "project_id");
+  const sandboxId = getClaim(claims, "sandbox_id");
+  const sandboxName = getClaim(claims, "sandbox_name") ?? sandboxId;
+
+  if (!teamId || !projectId || !sandboxId || !sandboxName) {
+    throw new Error("Missing required claims in OIDC token");
+  }
+
+  return {
+    ...forwarded,
+    teamId,
+    projectId,
+    sandboxId,
+    sandboxName,
+  };
+}
+
+async function verifyOidcToken(
+  token: string,
+): Promise<Record<string, unknown>> {
+  const claims = decodeJwt(token);
+  const issuer = getClaim(claims, "iss");
+
+  if (!issuer) {
+    throw new Error("Missing OIDC issuer");
+  }
+
+  let issuerUrl: URL;
+
+  try {
+    issuerUrl = new URL(issuer);
+  } catch {
+    throw new Error("Invalid OIDC issuer");
+  }
+
+  if (
+    issuerUrl.protocol !== "https:" ||
+    issuerUrl.hostname !== VERCEL_OIDC_HOSTNAME
+  ) {
+    throw new Error("Invalid OIDC issuer");
+  }
+
+  const { payload } = await jwtVerify(token, getJwks(issuer), {
+    algorithms: ["RS256"],
+    clockTolerance: CLOCK_TOLERANCE_SECONDS,
+    issuer,
+  });
+
+  return payload;
+}
+
+function getJwks(issuer: string): ReturnType<typeof createRemoteJWKSet> {
+  const cached = jwksCache.get(issuer);
+
+  if (cached) {
+    return cached;
+  }
+
+  const jwks = createRemoteJWKSet(
+    new URL(`${issuer.replace(/\/$/, "")}/.well-known/jwks`),
+  );
+
+  jwksCache.set(issuer, jwks);
+
+  return jwks;
+}
+
+function getClaim(
+  claims: Record<string, unknown>,
+  name: string,
+): string | undefined {
+  const value = claims[name];
+
+  if (typeof value === "string" && value) {
+    return value;
+  }
+}

--- a/packages/vercel-sandbox/src/proxy.ts
+++ b/packages/vercel-sandbox/src/proxy.ts
@@ -98,12 +98,15 @@ export function defineSandboxProxy(
     let sanitizedRequest: Request;
 
     try {
-      sanitizedRequest = new Request(`${scheme}://${host}:${port}${path}`, {
-        method: request.method,
-        body: request.body,
-        headers,
-        duplex: "half",
-      });
+      sanitizedRequest = new Request(
+        getProxiedRequestUrl(scheme, host, port, path),
+        {
+          method: request.method,
+          body: request.body,
+          headers,
+          duplex: "half",
+        },
+      );
     } catch {
       return invalidRequestHandler(
         new Request(request, { headers }),
@@ -132,20 +135,37 @@ function defaultInvalidRequestHandler(): Response {
   return new Response("Forbidden", { status: 403 });
 }
 
+function getProxiedRequestUrl(
+  scheme: string,
+  host: string,
+  port: string,
+  path: string,
+): string {
+  const origin = `${scheme}://${host}:${port}`;
+
+  return path === "/" ? origin : `${origin}${path}`;
+}
+
 function normalizeForwardUrl(url: URL, forwardedPath: string): URL {
   const forwardedUrl = new URL(forwardedPath, url.origin);
-  const forwardedPathname = forwardedUrl.pathname;
+  const forwardedPathname = stripTrailingPathSlash(forwardedUrl.pathname);
   const normalizedUrl = new URL(url);
+  normalizedUrl.pathname = stripTrailingPathSlash(normalizedUrl.pathname);
 
   if (
     forwardedPathname !== "/" &&
     normalizedUrl.pathname.endsWith(forwardedPathname)
   ) {
-    normalizedUrl.pathname =
-      normalizedUrl.pathname.slice(0, -forwardedPathname.length) || "/";
+    normalizedUrl.pathname = stripTrailingPathSlash(
+      normalizedUrl.pathname.slice(0, -forwardedPathname.length),
+    );
   }
 
   return normalizedUrl;
+}
+
+function stripTrailingPathSlash(pathname: string): string {
+  return pathname.replace(/\/+$/, "") || "/";
 }
 
 function getProxyMeta(
@@ -197,7 +217,7 @@ async function verifyOidcToken(
   }
 
   const { payload } = await jwtVerify(token, getJwks(issuer), {
-    audience: getForwardUrlAudiences(originalUrl),
+    audience: getForwardUrlAudience(originalUrl),
     algorithms: ["RS256"],
     clockTolerance: CLOCK_TOLERANCE_SECONDS,
     issuer,
@@ -206,12 +226,10 @@ async function verifyOidcToken(
   return payload;
 }
 
-function getForwardUrlAudiences(url: URL): string | string[] {
-  if (url.pathname === "/") {
-    return [url.origin, `${url.origin}/`];
-  }
+function getForwardUrlAudience(url: URL): string {
+  const pathname = stripTrailingPathSlash(url.pathname);
 
-  return url.origin + url.pathname;
+  return pathname === "/" ? url.origin : url.origin + pathname;
 }
 
 function getJwks(issuer: string): ReturnType<typeof createRemoteJWKSet> {

--- a/packages/vercel-sandbox/src/proxy.ts
+++ b/packages/vercel-sandbox/src/proxy.ts
@@ -3,6 +3,7 @@ import { createRemoteJWKSet, decodeJwt, jwtVerify } from "jose";
 const FORWARDED_HOST_HEADER = "vercel-forwarded-host";
 const FORWARDED_SCHEME_HEADER = "vercel-forwarded-scheme";
 const FORWARDED_PORT_HEADER = "vercel-forwarded-port";
+const FORWARDED_PATH_HEADER = "vercel-forwarded-path";
 const SANDBOX_OIDC_TOKEN_HEADER = "vercel-sandbox-oidc-token";
 
 const VERCEL_OIDC_HOSTNAME = "oidc.vercel.com";
@@ -78,14 +79,16 @@ export function defineSandboxProxy(
     const host = headers.get(FORWARDED_HOST_HEADER);
     const scheme = headers.get(FORWARDED_SCHEME_HEADER);
     const port = headers.get(FORWARDED_PORT_HEADER);
+    const path = headers.get(FORWARDED_PATH_HEADER);
     const oidcToken = headers.get(SANDBOX_OIDC_TOKEN_HEADER);
 
     headers.delete(FORWARDED_HOST_HEADER);
     headers.delete(FORWARDED_SCHEME_HEADER);
     headers.delete(FORWARDED_PORT_HEADER);
+    headers.delete(FORWARDED_PATH_HEADER);
     headers.delete(SANDBOX_OIDC_TOKEN_HEADER);
 
-    if (!host || !scheme || !port || !oidcToken) {
+    if (!host || !scheme || !port || !path || !oidcToken) {
       return invalidRequestHandler(
         request,
         new Error("Missing required proxy headers"),
@@ -95,9 +98,8 @@ export function defineSandboxProxy(
     let sanitizedRequest: Request;
 
     try {
-      const url = new URL(request.url);
       sanitizedRequest = new Request(
-        `${scheme}://${host}:${port}${url.pathname}${url.search}${url.hash}`,
+        `${scheme}://${host}:${port}${path}`,
         {
           method: request.method,
           body: request.body,
@@ -113,7 +115,6 @@ export function defineSandboxProxy(
     }
 
     sanitizedRequest.headers.set("host", host);
-    sanitizedRequest.headers.set("x-forwarded-host", host);
 
     try {
       const originalUrl = new URL(request.url);

--- a/packages/vercel-sandbox/tsdown.config.ts
+++ b/packages/vercel-sandbox/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/auth/index.ts"],
+  entry: ["src/index.ts", "src/auth/index.ts", "src/proxy.ts"],
   outDir: "dist",
   format: ["esm", "cjs"],
   outExtensions: ({ format }) => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,6 +390,9 @@ importers:
       async-retry:
         specifier: 1.3.3
         version: 1.3.3
+      jose:
+        specifier: 6.2.3
+        version: 6.2.3
       jsonlines:
         specifier: 0.1.1
         version: 0.1.1
@@ -4159,6 +4162,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -10040,6 +10046,8 @@ snapshots:
   jiti@2.5.1: {}
 
   jiti@2.6.1: {}
+
+  jose@6.2.3: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
This PR adds a new `defineSandboxProxy` helper in `@vercel/sandbox/proxy` to integrate [network policies forwarding rules](https://vercel.com/changelog/vercel-sandbox-firewall-now-supports-request-proxying-and-filtering) easily within a Vercel Function, or any other platform that supports the Web Handlers syntax (`Request`/`Response` objects)

We use `jose` to verify the OIDC token, then extract the metadata (original host, scheme, port, path, and source team/project/sandbox ids) before calling a user-defined Web Handler. If the request cannot be authorized, we return a 403 by default, but the user can also override this behavior with a separate Web Handler. A new `Request` is constructed to correspond to the original sandbox request before being proxied by the sandbox firewall

Example usage in a Vercel Function:

```ts
export default {
  fetch: defineSandboxProxy(async (request, meta) => {
    // meta contains the original host & source team/project/sandbox ids
    console.log(meta)

    // return a custom response, or proxy upstream:
    return await fetch(request)
  }, (request, error) => {
    // optional, handle any authorization error
    return new Response("Forbidden", { status: 403 })
  })
}
```