### PR TITLE
feat(vercel-sandbox): support new Snapshot.fromSandbox method

### DIFF
--- a/.changeset/big-cats-worry.md
+++ b/.changeset/big-cats-worry.md
@@ -1,0 +1,6 @@
+---
+"@vercel/sandbox": minor
+"sandbox": minor
+---
+
+Support new CLI --sandbox-snapshot parameter and new SDK static method Snapshot.fromSandbox(<sandbox-name>)

--- a/packages/sandbox/src/client.ts
+++ b/packages/sandbox/src/client.ts
@@ -21,10 +21,17 @@ export const sandboxClient: Pick<typeof Sandbox, "get" | "list" | "create"> = {
     ),
 };
 
-export const snapshotClient: Pick<typeof Snapshot, "get" | "list"> = {
+export const snapshotClient: Pick<
+  typeof Snapshot,
+  "get" | "list" | "fromSandbox"
+> = {
   list: (params) =>
     withErrorHandling(Snapshot.list({ fetch: fetchWithUserAgent, ...params })),
   get: (params) => withErrorHandling(Snapshot.get({ ...params })),
+  fromSandbox: (name, opts) =>
+    withErrorHandling(
+      Snapshot.fromSandbox(name, { fetch: fetchWithUserAgent, ...opts }),
+    ),
 };
 
 const fetchWithUserAgent: typeof globalThis.fetch = (input, init) => {

--- a/packages/sandbox/src/commands/create.ts
+++ b/packages/sandbox/src/commands/create.ts
@@ -5,8 +5,9 @@ import { timeout } from "../args/timeout";
 import { vcpus } from "../args/vcpus";
 import chalk from "chalk";
 import { scope } from "../args/scope";
-import { sandboxClient } from "../client";
+import { sandboxClient, snapshotClient } from "../client";
 import { snapshotId } from "../args/snapshot-id";
+import { sandboxName } from "../args/sandbox-name";
 import ora from "ora";
 import * as Exec from "./exec";
 import { networkPolicyArgs } from "../args/network-policy";
@@ -59,6 +60,12 @@ export const args = {
     description: "Start the sandbox from a snapshot ID",
     type: cmd.optional(snapshotId),
   }),
+  sandboxSnapshot: cmd.option({
+    long: "sandbox-snapshot",
+    description:
+      "Start the sandbox from another sandbox's current snapshot",
+    type: cmd.optional(sandboxName),
+  }),
   connect: cmd.flag({
     long: "connect",
     description:
@@ -105,6 +112,7 @@ export const create = cmd.command({
     vcpus,
     silent,
     snapshot,
+    sandboxSnapshot,
     connect,
     envVars,
     tags,
@@ -114,6 +122,15 @@ export const create = cmd.command({
     allowedCIDRs,
     deniedCIDRs,
   }) {
+    if (snapshot && sandboxSnapshot) {
+      throw new Error(
+        [
+          `Cannot use --snapshot and --sandbox-snapshot together.`,
+          `${chalk.bold("hint:")} Pick one source for the new sandbox.`,
+        ].join("\n"),
+      );
+    }
+
     const networkPolicy = buildNetworkPolicy({
       networkPolicy: networkPolicyMode,
       allowedDomains,
@@ -124,11 +141,20 @@ export const create = cmd.command({
     const persistent = !nonPersistent
     const resources = vcpus ? { vcpus } : undefined;
     const tagsObj = Object.keys(tags).length > 0 ? tags : undefined;
+    const resolvedSnapshot =
+      snapshot ??
+      (sandboxSnapshot
+        ? await snapshotClient.fromSandbox(sandboxSnapshot, {
+            teamId: scope.team,
+            projectId: scope.project,
+            token: scope.token,
+          })
+        : undefined);
     const spinner = silent ? undefined : ora("Creating sandbox...").start();
-    const sandbox = snapshot
+    const sandbox = resolvedSnapshot
       ? await sandboxClient.create({
           name,
-          source: { type: "snapshot", snapshotId: snapshot },
+          source: { type: "snapshot", snapshotId: resolvedSnapshot },
           teamId: scope.team,
           projectId: scope.project,
           token: scope.token,

--- a/packages/vercel-sandbox/src/snapshot.test.ts
+++ b/packages/vercel-sandbox/src/snapshot.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { Sandbox } from "./sandbox.js";
+import { Snapshot } from "./snapshot.js";
+
+describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")(
+  "Snapshot.fromSandbox",
+  () => {
+    it("resolves a snapshot ID that can seed a new sandbox", async () => {
+      const baseSandbox = await Sandbox.create({ persistent: true });
+      await baseSandbox.writeFiles([
+        { path: "from-base.txt", content: Buffer.from("base content") },
+      ]);
+      await baseSandbox.stop();
+
+      const derived = await Sandbox.create({
+        source: {
+          type: "snapshot",
+          snapshotId: await Snapshot.fromSandbox(baseSandbox.name),
+        },
+      });
+
+      try {
+        expect(derived.sourceSnapshotId).toBe(baseSandbox.currentSnapshotId);
+        const content = await derived.readFileToBuffer({
+          path: "from-base.txt",
+        });
+        expect(content?.toString()).toBe("base content");
+      } finally {
+        await derived.stop();
+      }
+    });
+
+    it("throws when the sandbox has no current snapshot", async () => {
+      const baseSandbox = await Sandbox.create();
+      expect(baseSandbox.currentSnapshotId).toBeUndefined();
+
+      await expect(Snapshot.fromSandbox(baseSandbox.name)).rejects.toThrow(
+        /has no current snapshot/,
+      );
+    });
+  },
+);

--- a/packages/vercel-sandbox/src/snapshot.ts
+++ b/packages/vercel-sandbox/src/snapshot.ts
@@ -2,6 +2,7 @@ import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from "@workflow/serde";
 import type { WithFetchOptions } from "./api-client/api-client.js";
 import type { SnapshotMetadata } from "./api-client/index.js";
 import { APIClient } from "./api-client/index.js";
+import { Sandbox } from "./sandbox.js";
 import { type Credentials, getCredentials } from "./utils/get-credentials.js";
 import { attachPaginator } from "./utils/paginator.js";
 
@@ -176,6 +177,45 @@ export class Snapshot {
       fetchNext: fetchPage,
       signal: params?.signal,
     });
+  }
+
+  /**
+   * Resolve the current snapshot ID of an existing sandbox by name.
+   *
+   * Useful to feed into {@link Sandbox.create} as `source.snapshotId` without
+   * having to first look up the sandbox yourself.
+   *
+   * @param name - The name of the source sandbox.
+   * @param opts - Optional credentials, fetch override, and abort signal.
+   * @returns The current snapshot ID of the named sandbox.
+   * @throws If the sandbox has no current snapshot.
+   *
+   * @example
+   * const sandbox = await Sandbox.create({
+   *   source: {
+   *     type: "snapshot",
+   *     snapshotId: await Snapshot.fromSandbox("my-sandbox"),
+   *   },
+   * });
+   */
+  static async fromSandbox(
+    name: string,
+    opts?: Partial<Credentials> & WithFetchOptions & { signal?: AbortSignal },
+  ): Promise<string> {
+    "use step";
+    const sandbox = await Sandbox.get({
+      name,
+      resume: false,
+      signal: opts?.signal,
+      fetch: opts?.fetch,
+      teamId: opts?.teamId,
+      projectId: opts?.projectId,
+      token: opts?.token,
+    });
+    if (!sandbox.currentSnapshotId) {
+      throw new Error(`Sandbox "${name}" has no current snapshot.`);
+    }
+    return sandbox.currentSnapshotId;
   }
 
   /**

--- a/packages/vercel-sandbox/src/snapshot.ts
+++ b/packages/vercel-sandbox/src/snapshot.ts
@@ -2,7 +2,6 @@ import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from "@workflow/serde";
 import type { WithFetchOptions } from "./api-client/api-client.js";
 import type { SnapshotMetadata } from "./api-client/index.js";
 import { APIClient } from "./api-client/index.js";
-import { Sandbox } from "./sandbox.js";
 import { type Credentials, getCredentials } from "./utils/get-credentials.js";
 import { attachPaginator } from "./utils/paginator.js";
 
@@ -203,19 +202,25 @@ export class Snapshot {
     opts?: Partial<Credentials> & WithFetchOptions & { signal?: AbortSignal },
   ): Promise<string> {
     "use step";
-    const sandbox = await Sandbox.get({
+    const credentials = await getCredentials(opts);
+    const client = new APIClient({
+      teamId: credentials.teamId,
+      token: credentials.token,
+      fetch: opts?.fetch,
+    });
+
+    const response = await client.getSandbox({
       name,
+      projectId: credentials.projectId,
       resume: false,
       signal: opts?.signal,
-      fetch: opts?.fetch,
-      teamId: opts?.teamId,
-      projectId: opts?.projectId,
-      token: opts?.token,
     });
-    if (!sandbox.currentSnapshotId) {
+
+    const snapshotId = response.json.sandbox.currentSnapshotId;
+    if (!snapshotId) {
       throw new Error(`Sandbox "${name}" has no current snapshot.`);
     }
-    return sandbox.currentSnapshotId;
+    return snapshotId;
   }
 
   /**


### PR DESCRIPTION
Re-apply the closed PR https://github.com/vercel/sandbox/pull/161 but into the `main` branch.

---

Support the new static method `Snapshot.fromSandbox(...)` to get the latest snapshot of a sandbox. Example:

```
const childSandbox = Sandbox.create({
  source: {
    type: 'snapshot',
    snapshotId: Snapshot.fromSandbox('main-sandbox')
  }
});
```

At the CLI level, is it with the parameter `--sandbox-snapshot`. It follows the same pattern as `--snapshot`. I do not think this is 100% clear and maybe we should iterate to `sandbox create --from-snapshot` and `sandbox create --from-sandbox-snapshot`?

For example:

```
> sandbox create --sandbox-snapshot main-sandbox
```