### PR TITLE
chore(vercel-sandbox): fix tryOrCreate - replace error code 400 for 410

### DIFF
--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -188,7 +188,7 @@ function isNotFoundError(err: unknown): boolean {
 function isSnapshotNotFoundError(err: unknown): boolean {
   return (
     err instanceof APIError &&
-    err.response.status === 400 &&
+    err.response.status === 410 &&
     (err.json as any)?.error?.code === "snapshot_not_found"
   );
 }


### PR DESCRIPTION
Change the error code from 400 to 410 when the snapshot is expired, deleted or does not exist.