### PR TITLE
feat(vercel-sandbox,sandbox): introduce keepLast parameters for SDK/CLI

### DIFF
--- a/.changeset/evil-results-hope.md
+++ b/.changeset/evil-results-hope.md
@@ -1,0 +1,6 @@
+---
+"@vercel/sandbox": minor
+"sandbox": minor
+---
+
+Support keepLastSnapshots feature for CLI and SDK

--- a/packages/sandbox/src/commands/config.ts
+++ b/packages/sandbox/src/commands/config.ts
@@ -202,6 +202,144 @@ const snapshotExpirationCommand = cmd.command({
   },
 });
 
+const keepLastCountType = cmd.extendType(cmd.number, {
+  displayName: "COUNT",
+  async from(n) {
+    if (!Number.isInteger(n) || n < 1 || n > 10) {
+      throw new Error(
+        `Invalid count: ${n}. Must be an integer between 1 and 10.`,
+      );
+    }
+    return n;
+  },
+});
+
+const keepLastSnapshotsCommand = cmd.command({
+  name: "keep-last-snapshots",
+  description:
+    "Update the snapshot retention policy (keep only the N most recent snapshots) of a sandbox",
+  args: {
+    sandbox: cmd.positional({
+      type: sandboxName,
+      description: "Sandbox name to update",
+    }),
+    count: cmd.positional({
+      type: cmd.optional(keepLastCountType),
+      description:
+        "Number of most recent snapshots to keep (1-10). Omit with --clear to remove the policy.",
+    }),
+    keepLastSnapshotsFor: cmd.option({
+      long: "keep-last-snapshots-for",
+      type: cmd.optional(SnapshotExpiration),
+      description:
+        'Expiration for kept snapshots. Use "none" or 0 for no expiration. Example: 7d, 30d',
+    }),
+    deleteEvictedSnapshots: cmd.option({
+      long: "delete-evicted-snapshots",
+      type: cmd.optional({
+        ...cmd.oneOf(["true", "false"]),
+        displayName: "true|false",
+      }),
+      description:
+        'When "true" (the default), evicted snapshots are deleted immediately; when "false", they keep the default expiration.',
+    }),
+    clear: cmd.flag({
+      long: "clear",
+      description:
+        "Remove the snapshot retention policy from this sandbox.",
+    }),
+    scope,
+  },
+  async handler({
+    scope: { token, team, project },
+    sandbox: name,
+    count,
+    keepLastSnapshotsFor,
+    deleteEvictedSnapshots,
+    clear,
+  }) {
+    if (
+      clear &&
+      (count !== undefined ||
+        keepLastSnapshotsFor !== undefined ||
+        deleteEvictedSnapshots !== undefined)
+    ) {
+      throw new Error(
+        "--clear cannot be combined with <count>, --keep-last-snapshots-for, or --delete-evicted-snapshots.",
+      );
+    }
+    if (!clear && count === undefined) {
+      throw new Error(
+        [
+          "Missing <count> argument.",
+          `${chalk.bold("hint:")} Pass a count between 1 and 10, or --clear to remove the policy.`,
+        ].join("\n"),
+      );
+    }
+
+    const sandbox = await sandboxClient.get({
+      name,
+      projectId: project,
+      teamId: team,
+      token,
+    });
+
+    const spinner = ora("Updating sandbox configuration...").start();
+    try {
+      if (clear) {
+        await sandbox.update({ keepLastSnapshots: null });
+      } else {
+        await sandbox.update({
+          keepLastSnapshots: {
+            count: count!,
+            expiration:
+              keepLastSnapshotsFor !== undefined
+                ? ms(keepLastSnapshotsFor)
+                : undefined,
+            deleteEvicted:
+              deleteEvictedSnapshots !== undefined
+                ? deleteEvictedSnapshots === "true"
+                : undefined,
+          },
+        });
+      }
+      spinner.stop();
+
+      process.stderr.write(
+        "✅ Configuration updated for sandbox " + chalk.cyan(name) + "\n",
+      );
+
+      if (clear) {
+        process.stderr.write(
+          chalk.dim("   ╰ ") +
+            "keep-last-snapshots: " +
+            chalk.cyan("cleared") +
+            "\n",
+        );
+      } else {
+        const parts: string[] = [`count=${count}`];
+        if (keepLastSnapshotsFor !== undefined) {
+          const displayExp =
+            ms(keepLastSnapshotsFor) === 0 ? "none" : keepLastSnapshotsFor;
+          parts.push(`for=${displayExp}`);
+        }
+        if (deleteEvictedSnapshots === "false") {
+          parts.push("delete-evicted-snapshots=false");
+        }
+        process.stderr.write(
+          chalk.dim("   ╰ ") +
+            "keep-last-snapshots: " +
+            chalk.cyan(parts.join(", ")) +
+            "\n",
+        );
+      }
+    } catch (error) {
+      spinner.stop();
+      throw error;
+    }
+  },
+});
+
 const currentSnapshotCommand = cmd.command({
   name: "current-snapshot",
   description: "Update the current snapshot of a sandbox",
@@ -291,6 +429,7 @@ const listCommand = cmd.command({
       { field: "Persistent", value: String(sandbox.persistent) },
       { field: "Network policy", value: String(networkPolicy) },
       { field: "Snapshot expiration", value: sandbox.snapshotExpiration != null && sandbox.snapshotExpiration > 0 ? ms(sandbox.snapshotExpiration, { long: true }) : sandbox.snapshotExpiration === 0 ? "none" : "-" },
+      { field: "Keep last snapshots", value: formatKeepLastSnapshots(sandbox.keepLastSnapshots) },
       { field: "Current snapshot", value: sandbox.currentSnapshotId ?? "-" },
       { field: "Tags", value: tagsDisplay },
     ];
@@ -432,6 +571,28 @@ const tagsCommand = cmd.command({
   },
 });
 
+function formatKeepLastSnapshots(
+  keepLastSnapshots:
+    | { count: number; expiration?: number; deleteEvicted: boolean }
+    | undefined,
+): string {
+  if (!keepLastSnapshots) {
+    return "-";
+  }
+
+  const parts = [`count=${keepLastSnapshots.count}`];
+  if (keepLastSnapshots.expiration !== undefined) {
+    parts.push(
+      `for=${keepLastSnapshots.expiration === 0 ? "none" : ms(keepLastSnapshots.expiration, { long: true })}`,
+    );
+  }
+  parts.push(
+    `delete-evicted-snapshots=${keepLastSnapshots.deleteEvicted ?? true}`,
+  );
+
+  return parts.join(", ");
+}
+
 export const config = cmd.subcommands({
   name: "config",
   description: "View and update sandbox configuration",
@@ -442,6 +603,7 @@ export const config = cmd.subcommands({
     persistent: persistentCommand,
     "network-policy": networkPolicyCommand,
     "snapshot-expiration": snapshotExpirationCommand,
+    "keep-last-snapshots": keepLastSnapshotsCommand,
     "current-snapshot": currentSnapshotCommand,
     tags: tagsCommand,
   },

--- a/packages/sandbox/src/commands/config.ts
+++ b/packages/sandbox/src/commands/config.ts
@@ -573,7 +573,7 @@ const tagsCommand = cmd.command({
 
 function formatKeepLastSnapshots(
   keepLastSnapshots:
-    | { count: number; expiration?: number; deleteEvicted: boolean }
+    | { count: number; expiration?: number; deleteEvicted?: boolean }
     | undefined,
 ): string {
   if (!keepLastSnapshots) {
@@ -586,9 +586,9 @@ function formatKeepLastSnapshots(
       `for=${keepLastSnapshots.expiration === 0 ? "none" : ms(keepLastSnapshots.expiration, { long: true })}`,
     );
   }
-  parts.push(
-    `delete-evicted-snapshots=${keepLastSnapshots.deleteEvicted ?? true}`,
-  );
+  if (keepLastSnapshots.deleteEvicted !== undefined) {
+    parts.push(`delete-evicted-snapshots=${keepLastSnapshots.deleteEvicted}`);
+  }
 
   return parts.join(", ");
 }

--- a/packages/sandbox/src/commands/config.ts
+++ b/packages/sandbox/src/commands/config.ts
@@ -205,9 +205,9 @@ const snapshotExpirationCommand = cmd.command({
 const keepLastCountType = cmd.extendType(cmd.number, {
   displayName: "COUNT",
   async from(n) {
-    if (!Number.isInteger(n) || n < 1 || n > 10) {
+    if (!Number.isInteger(n) || n < 0 || n > 10) {
       throw new Error(
-        `Invalid count: ${n}. Must be an integer between 1 and 10.`,
+        `Invalid count: ${n}. Must be an integer between 0 and 10 (0 removes the policy).`,
       );
     }
     return n;
@@ -224,29 +224,9 @@ const keepLastSnapshotsCommand = cmd.command({
       description: "Sandbox name to update",
     }),
     count: cmd.positional({
-      type: cmd.optional(keepLastCountType),
+      type: keepLastCountType,
       description:
-        "Number of most recent snapshots to keep (1-10). Omit with --clear to remove the policy.",
-    }),
-    keepLastSnapshotsFor: cmd.option({
-      long: "keep-last-snapshots-for",
-      type: cmd.optional(SnapshotExpiration),
-      description:
-        'Expiration for kept snapshots. Use "none" or 0 for no expiration. Example: 7d, 30d',
-    }),
-    deleteEvictedSnapshots: cmd.option({
-      long: "delete-evicted-snapshots",
-      type: cmd.optional({
-        ...cmd.oneOf(["true", "false"]),
-        displayName: "true|false",
-      }),
-      description:
-        'When "true" (the default), evicted snapshots are deleted immediately; when "false", they keep the default expiration.',
-    }),
-    clear: cmd.flag({
-      long: "clear",
-      description:
-        "Remove the snapshot retention policy from this sandbox.",
+        "Number of most recent snapshots to keep (1-10). Pass 0 to remove the policy.",
     }),
     scope,
   },
@@ -254,29 +234,7 @@ const keepLastSnapshotsCommand = cmd.command({
     scope: { token, team, project },
     sandbox: name,
     count,
-    keepLastSnapshotsFor,
-    deleteEvictedSnapshots,
-    clear,
   }) {
-    if (
-      clear &&
-      (count !== undefined ||
-        keepLastSnapshotsFor !== undefined ||
-        deleteEvictedSnapshots !== undefined)
-    ) {
-      throw new Error(
-        "--clear cannot be combined with <count>, --keep-last-snapshots-for, or --delete-evicted-snapshots.",
-      );
-    }
-    if (!clear && count === undefined) {
-      throw new Error(
-        [
-          "Missing <count> argument.",
-          `${chalk.bold("hint:")} Pass a count between 1 and 10, or --clear to remove the policy.`,
-        ].join("\n"),
-      );
-    }
-
     const sandbox = await sandboxClient.get({
       name,
       projectId: project,
@@ -286,20 +244,15 @@ const keepLastSnapshotsCommand = cmd.command({
 
     const spinner = ora("Updating sandbox configuration...").start();
     try {
-      if (clear) {
+      if (count === 0) {
         await sandbox.update({ keepLastSnapshots: null });
       } else {
+        const current = sandbox.keepLastSnapshots;
         await sandbox.update({
           keepLastSnapshots: {
-            count: count!,
-            expiration:
-              keepLastSnapshotsFor !== undefined
-                ? ms(keepLastSnapshotsFor)
-                : undefined,
-            deleteEvicted:
-              deleteEvictedSnapshots !== undefined
-                ? deleteEvictedSnapshots === "true"
-                : undefined,
+            count,
+            expiration: current?.expiration,
+            deleteEvicted: current?.deleteEvicted,
           },
         });
       }
@@ -308,31 +261,143 @@ const keepLastSnapshotsCommand = cmd.command({
       process.stderr.write(
         "✅ Configuration updated for sandbox " + chalk.cyan(name) + "\n",
       );
+      process.stderr.write(
+        chalk.dim("   ╰ ") +
+          "keep-last-snapshots: " +
+          chalk.cyan(count === 0 ? "cleared" : `count=${count}`) +
+          "\n",
+      );
+    } catch (error) {
+      spinner.stop();
+      throw error;
+    }
+  },
+});
 
-      if (clear) {
-        process.stderr.write(
-          chalk.dim("   ╰ ") +
-            "keep-last-snapshots: " +
-            chalk.cyan("cleared") +
-            "\n",
-        );
-      } else {
-        const parts: string[] = [`count=${count}`];
-        if (keepLastSnapshotsFor !== undefined) {
-          const displayExp =
-            ms(keepLastSnapshotsFor) === 0 ? "none" : keepLastSnapshotsFor;
-          parts.push(`for=${displayExp}`);
-        }
-        if (deleteEvictedSnapshots === "false") {
-          parts.push("delete-evicted-snapshots=false");
-        }
-        process.stderr.write(
-          chalk.dim("   ╰ ") +
-            "keep-last-snapshots: " +
-            chalk.cyan(parts.join(", ")) +
-            "\n",
-        );
-      }
+const keepLastSnapshotsForCommand = cmd.command({
+  name: "keep-last-snapshots-for",
+  description:
+    "Update the expiration applied to snapshots kept by the retention policy",
+  args: {
+    sandbox: cmd.positional({
+      type: sandboxName,
+      description: "Sandbox name to update",
+    }),
+    duration: cmd.positional({
+      type: SnapshotExpiration,
+      description:
+        'Expiration for kept snapshots. Use "none" or 0 for no expiration. Example: 7d, 30d',
+    }),
+    scope,
+  },
+  async handler({
+    scope: { token, team, project },
+    sandbox: name,
+    duration,
+  }) {
+    const sandbox = await sandboxClient.get({
+      name,
+      projectId: project,
+      teamId: team,
+      token,
+    });
+
+    const current = sandbox.keepLastSnapshots;
+    if (!current) {
+      throw new Error(
+        [
+          "No keep-last-snapshots policy is set on this sandbox.",
+          `${chalk.bold("hint:")} Set a count first with: sandbox config keep-last-snapshots ${name} <count>`,
+        ].join("\n"),
+      );
+    }
+
+    const spinner = ora("Updating sandbox configuration...").start();
+    try {
+      await sandbox.update({
+        keepLastSnapshots: {
+          count: current.count,
+          expiration: ms(duration),
+          deleteEvicted: current.deleteEvicted,
+        },
+      });
+      spinner.stop();
+
+      const display = ms(duration) === 0 ? "none" : duration;
+      process.stderr.write(
+        "✅ Configuration updated for sandbox " + chalk.cyan(name) + "\n",
+      );
+      process.stderr.write(
+        chalk.dim("   ╰ ") +
+          "keep-last-snapshots-for: " +
+          chalk.cyan(display) +
+          "\n",
+      );
+    } catch (error) {
+      spinner.stop();
+      throw error;
+    }
+  },
+});
+
+const deleteEvictedSnapshotsCommand = cmd.command({
+  name: "delete-evicted-snapshots",
+  description:
+    'When "true" (the default), snapshots evicted by the keep-last-snapshots policy are deleted immediately; when "false", they keep the default expiration.',
+  args: {
+    sandbox: cmd.positional({
+      type: sandboxName,
+      description: "Sandbox name to update",
+    }),
+    value: cmd.positional({
+      type: { ...cmd.oneOf(["true", "false"]), displayName: "true|false" },
+      description:
+        'Whether to delete evicted snapshots immediately ("true") or let them keep the default expiration ("false").',
+    }),
+    scope,
+  },
+  async handler({
+    scope: { token, team, project },
+    sandbox: name,
+    value,
+  }) {
+    const sandbox = await sandboxClient.get({
+      name,
+      projectId: project,
+      teamId: team,
+      token,
+    });
+
+    const current = sandbox.keepLastSnapshots;
+    if (!current) {
+      throw new Error(
+        [
+          "No keep-last-snapshots policy is set on this sandbox.",
+          `${chalk.bold("hint:")} Set a count first with: sandbox config keep-last-snapshots ${name} <count>`,
+        ].join("\n"),
+      );
+    }
+
+    const spinner = ora("Updating sandbox configuration...").start();
+    try {
+      await sandbox.update({
+        keepLastSnapshots: {
+          count: current.count,
+          expiration: current.expiration,
+          deleteEvicted: value === "true",
+        },
+      });
+      spinner.stop();
+
+      process.stderr.write(
+        "✅ Configuration updated for sandbox " + chalk.cyan(name) + "\n",
+      );
+      process.stderr.write(
+        chalk.dim("   ╰ ") +
+          "delete-evicted-snapshots: " +
+          chalk.cyan(value) +
+          "\n",
+      );
     } catch (error) {
       spinner.stop();
       throw error;
@@ -604,6 +669,8 @@ export const config = cmd.subcommands({
     "network-policy": networkPolicyCommand,
     "snapshot-expiration": snapshotExpirationCommand,
     "keep-last-snapshots": keepLastSnapshotsCommand,
+    "keep-last-snapshots-for": keepLastSnapshotsForCommand,
+    "delete-evicted-snapshots": deleteEvictedSnapshotsCommand,
     "current-snapshot": currentSnapshotCommand,
     tags: tagsCommand,
   },

--- a/packages/sandbox/src/commands/create.ts
+++ b/packages/sandbox/src/commands/create.ts
@@ -88,6 +88,39 @@ export const args = {
     type: cmd.optional(SnapshotExpiration),
     description: 'Default snapshot expiration. Use "none" or 0 for no expiration. Example: 7d, 30d',
   }),
+  keepLastSnapshots: cmd.option({
+    long: "keep-last-snapshots",
+    type: cmd.optional(
+      cmd.extendType(cmd.number, {
+        displayName: "COUNT",
+        async from(n) {
+          if (!Number.isInteger(n) || n < 1 || n > 10) {
+            throw new Error(
+              `Invalid --keep-last-snapshots value: ${n}. Must be an integer between 1 and 10.`,
+            );
+          }
+          return n;
+        },
+      }),
+    ),
+    description:
+      "Keep only the N most recent snapshots of this sandbox (1-10).",
+  }),
+  keepLastSnapshotsFor: cmd.option({
+    long: "keep-last-snapshots-for",
+    type: cmd.optional(SnapshotExpiration),
+    description:
+      'Expiration applied to kept snapshots. Use "none" or 0 for no expiration. Example: 7d, 30d',
+  }),
+  deleteEvictedSnapshots: cmd.option({
+    long: "delete-evicted-snapshots",
+    type: cmd.optional({
+      ...cmd.oneOf(["true", "false"]),
+      displayName: "true|false",
+    }),
+    description:
+      'When "true" (the default), evicted snapshots are deleted immediately; when "false", they keep the default expiration.',
+  }),
   ...networkPolicyArgs,
   scope,
 } as const;
@@ -117,6 +150,9 @@ export const create = cmd.command({
     envVars,
     tags,
     snapshotExpiration,
+    keepLastSnapshots,
+    keepLastSnapshotsFor,
+    deleteEvictedSnapshots,
     networkPolicy: networkPolicyMode,
     allowedDomains,
     allowedCIDRs,
@@ -137,6 +173,34 @@ export const create = cmd.command({
       allowedCIDRs,
       deniedCIDRs,
     });
+
+    if (
+      keepLastSnapshots === undefined &&
+      (keepLastSnapshotsFor !== undefined ||
+        deleteEvictedSnapshots !== undefined)
+    ) {
+      throw new Error(
+        [
+          "--keep-last-snapshots-for and --delete-evicted-snapshots require --keep-last-snapshots.",
+          `${chalk.bold("hint:")} Pass --keep-last-snapshots <count> to enable the retention policy.`,
+        ].join("\n"),
+      );
+    }
+
+    const keepLastSnapshotsPayload =
+      keepLastSnapshots !== undefined
+        ? {
+            count: keepLastSnapshots,
+            expiration:
+              keepLastSnapshotsFor !== undefined
+                ? ms(keepLastSnapshotsFor)
+                : undefined,
+            deleteEvicted:
+              deleteEvictedSnapshots !== undefined
+                ? deleteEvictedSnapshots === "true"
+                : undefined,
+          }
+        : undefined;
 
     const persistent = !nonPersistent
     const resources = vcpus ? { vcpus } : undefined;
@@ -166,6 +230,7 @@ export const create = cmd.command({
           tags: tagsObj,
           persistent,
           snapshotExpiration: snapshotExpiration ? ms(snapshotExpiration) : undefined,
+          keepLastSnapshots: keepLastSnapshotsPayload,
           __interactive: true,
         })
       : await sandboxClient.create({
@@ -182,6 +247,7 @@ export const create = cmd.command({
           tags: tagsObj,
           persistent,
           snapshotExpiration: snapshotExpiration ? ms(snapshotExpiration) : undefined,
+          keepLastSnapshots: keepLastSnapshotsPayload,
           __interactive: true,
         });
     spinner?.stop();

--- a/packages/vercel-sandbox/src/api-client/api-client.test.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.test.ts
@@ -846,6 +846,7 @@ describe("APIClient", () => {
         timeout: 600000,
         ports: [3000, 4000],
         snapshotExpiration: 604800000,
+        keepLastSnapshots: { count: 5, expiration: 0, deleteEvicted: false },
         currentSnapshotId: "snap_abc123",
       });
 
@@ -861,7 +862,34 @@ describe("APIClient", () => {
       expect(parsedBody.timeout).toBe(600000);
       expect(parsedBody.ports).toEqual([3000, 4000]);
       expect(parsedBody.snapshotExpiration).toBe(604800000);
+      expect(parsedBody.keepLastSnapshots).toEqual({
+        count: 5,
+        expiration: 0,
+        deleteEvicted: false,
+      });
       expect(parsedBody.currentSnapshotId).toBe("snap_abc123");
+    });
+
+    it("sends null to clear keepLastSnapshots", async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ sandbox: makeSandboxMetadata() }), {
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await client.updateSandbox({
+        name: "my-sandbox",
+        projectId: "proj_123",
+        keepLastSnapshots: null,
+      });
+
+      const [, opts] = mockFetch.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      // Presence of the key with null — not undefined/missing — is the signal.
+      expect(Object.prototype.hasOwnProperty.call(body, "keepLastSnapshots")).toBe(
+        true,
+      );
+      expect(body.keepLastSnapshots).toBeNull();
     });
   });
 
@@ -968,4 +996,89 @@ describe("APIClient", () => {
       );
     });
   });
+
+  describe("createSandbox", () => {
+    let client: APIClient;
+    let mockFetch: ReturnType<typeof vi.fn>;
+
+    const sandboxResponse = () =>
+      new Response(
+        JSON.stringify({
+          sandbox: {
+            name: "my-sandbox",
+            persistent: true,
+            region: "iad1",
+            vcpus: 1,
+            memory: 2048,
+            runtime: "node24",
+            timeout: 300000,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+            status: "running",
+            currentSessionId: "sbx_123",
+            keepLastSnapshots: {
+              count: 3,
+              expiration: 604800000,
+              deleteEvicted: true,
+            },
+          },
+          session: {
+            id: "sbx_123",
+            memory: 2048,
+            vcpus: 1,
+            region: "iad1",
+            runtime: "node24",
+            timeout: 300000,
+            status: "running",
+            requestedAt: Date.now(),
+            createdAt: Date.now(),
+            cwd: "/",
+            updatedAt: Date.now(),
+          },
+          routes: [],
+        }),
+        { headers: { "content-type": "application/json" } },
+      );
+
+    beforeEach(() => {
+      mockFetch = vi.fn();
+      client = new APIClient({
+        teamId: "team_123",
+        token: "1234",
+        fetch: mockFetch,
+      });
+    });
+
+    it("forwards keepLastSnapshots in the request body", async () => {
+      mockFetch.mockResolvedValue(sandboxResponse());
+
+      await client.createSandbox({
+        projectId: "proj_123",
+        keepLastSnapshots: {
+          count: 3,
+          expiration: 604800000,
+          deleteEvicted: true,
+        },
+      });
+
+      const [, opts] = mockFetch.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body.keepLastSnapshots).toEqual({
+        count: 3,
+        expiration: 604800000,
+        deleteEvicted: true,
+      });
+    });
+
+    it("omits keepLastSnapshots when not provided", async () => {
+      mockFetch.mockResolvedValue(sandboxResponse());
+
+      await client.createSandbox({ projectId: "proj_123" });
+
+      const [, opts] = mockFetch.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body).not.toHaveProperty("keepLastSnapshots");
+    });
+  });
+
 });

--- a/packages/vercel-sandbox/src/api-client/api-client.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.ts
@@ -176,6 +176,11 @@ export class APIClient extends BaseClient {
       env?: Record<string, string>;
       tags?: Record<string, string>;
       snapshotExpiration?: number;
+      keepLastSnapshots?: {
+        count: number;
+        expiration?: number;
+        deleteEvicted?: boolean;
+      };
       signal?: AbortSignal;
     }>,
   ) {
@@ -199,6 +204,7 @@ export class APIClient extends BaseClient {
           env: params.env,
           tags: params.tags,
           snapshotExpiration: params.snapshotExpiration,
+          keepLastSnapshots: params.keepLastSnapshots,
           ...privateParams,
         }),
         signal: params.signal,
@@ -772,6 +778,11 @@ export class APIClient extends BaseClient {
     tags?: Record<string, string>;
     ports?: number[];
     snapshotExpiration?: number;
+    keepLastSnapshots?: {
+      count: number;
+      expiration?: number;
+      deleteEvicted?: boolean;
+    } | null;
     currentSnapshotId?: string;
     signal?: AbortSignal;
   }) {
@@ -793,6 +804,7 @@ export class APIClient extends BaseClient {
           tags: params.tags,
           ports: params.ports,
           snapshotExpiration: params.snapshotExpiration,
+          keepLastSnapshots: params.keepLastSnapshots,
           currentSnapshotId: params.currentSnapshotId,
         }),
         signal: params.signal,

--- a/packages/vercel-sandbox/src/api-client/validators.ts
+++ b/packages/vercel-sandbox/src/api-client/validators.ts
@@ -247,6 +247,13 @@ export const Sandbox = z.object({
   cwd: z.string().optional(),
   tags: z.record(z.string()).optional(),
   snapshotExpiration: z.number().optional(),
+  keepLastSnapshots: z
+    .object({
+      count: z.number(),
+      expiration: z.number().optional(),
+      deleteEvicted: z.boolean(),
+    })
+    .optional(),
 });
 
 export type SandboxMetaData = z.infer<typeof Sandbox>;

--- a/packages/vercel-sandbox/src/api-client/validators.ts
+++ b/packages/vercel-sandbox/src/api-client/validators.ts
@@ -251,7 +251,7 @@ export const Sandbox = z.object({
     .object({
       count: z.number(),
       expiration: z.number().optional(),
-      deleteEvicted: z.boolean(),
+      deleteEvicted: z.boolean().optional(),
     })
     .optional(),
 });

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -578,10 +578,15 @@ for (const port of ports) {
       timeout: 60_000,
       persistent: true,
       snapshotExpiration: 7 * 86400000,
+      keepLastSnapshots: { count: 3 },
     });
 
     try {
       expect(sbx.snapshotExpiration).toBe(7 * 86400000);
+      expect(sbx.keepLastSnapshots).toMatchObject({
+        count: 3,
+        deleteEvicted: true,
+      });
       await sbx.stop();
 
       const { snapshotId } = await sbx.snapshot();
@@ -591,6 +596,11 @@ for (const port of ports) {
         timeout: 30_000,
         persistent: false,
         snapshotExpiration: 2 * 86400000,
+        keepLastSnapshots: {
+          count: 5,
+          expiration: 3 * 86400000,
+          deleteEvicted: false,
+        },
         currentSnapshotId: snapshotId,
       });
 
@@ -603,10 +613,35 @@ for (const port of ports) {
       expect(updated.timeout).toBe(30_000);
       expect(updated.persistent).toBe(false);
       expect(updated.snapshotExpiration).toBe(2 * 86400000);
+      expect(updated.keepLastSnapshots).toEqual({
+        count: 5,
+        expiration: 3 * 86400000,
+        deleteEvicted: false,
+      });
       expect(updated.currentSnapshotId).toBe(snapshotId);
     } finally {
       await sbx.delete();
     }
+  });
+
+  it("clears keepLastSnapshots when updated with null", async () => {
+    const sandbox = await Sandbox.create({
+      persistent: true,
+      keepLastSnapshots: {
+        count: 2,
+        expiration: 7 * 86400000,
+        deleteEvicted: true,
+      },
+    });
+    expect(sandbox.keepLastSnapshots).toMatchObject({ count: 2 });
+
+    await sandbox.update({ keepLastSnapshots: null });
+
+    const cleared = await Sandbox.get({
+      name: sandbox.name,
+      resume: false,
+    });
+    expect(cleared.keepLastSnapshots).toBeUndefined();
   });
 
   it("appears in the sandbox list after creation", async () => {

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -625,7 +625,7 @@ for (const port of ports) {
   });
 
   it("clears keepLastSnapshots when updated with null", async () => {
-    const sandbox = await Sandbox.create({
+    const sbx = await Sandbox.create({
       persistent: true,
       keepLastSnapshots: {
         count: 2,
@@ -633,15 +633,20 @@ for (const port of ports) {
         deleteEvicted: true,
       },
     });
-    expect(sandbox.keepLastSnapshots).toMatchObject({ count: 2 });
 
-    await sandbox.update({ keepLastSnapshots: null });
+    try {
+      expect(sbx.keepLastSnapshots).toMatchObject({ count: 2 });
 
-    const cleared = await Sandbox.get({
-      name: sandbox.name,
-      resume: false,
-    });
-    expect(cleared.keepLastSnapshots).toBeUndefined();
+      await sbx.update({ keepLastSnapshots: null });
+
+      const cleared = await Sandbox.get({
+        name: sbx.name,
+        resume: false,
+      });
+      expect(cleared.keepLastSnapshots).toBeUndefined();
+    } finally {
+      await sbx.delete();
+    }
   });
 
   it("appears in the sandbox list after creation", async () => {

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -462,7 +462,7 @@ export class Sandbox {
    * on this sandbox, if any.
    */
   public get keepLastSnapshots():
-    | { count: number; expiration?: number; deleteEvicted: boolean }
+    | { count: number; expiration?: number; deleteEvicted?: boolean }
     | undefined {
     return this.sandbox.keepLastSnapshots;
   }

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -124,6 +124,26 @@ export interface BaseCreateSandboxParams {
    */
   snapshotExpiration?: number;
   /**
+   * Retention policy that keeps only the N most recent snapshots of this
+   * sandbox. Older snapshots are evicted when a new one is created.
+   */
+  keepLastSnapshots?: {
+    /**
+     * Number of snapshots to keep (1-10).
+     */
+    count: number;
+    /**
+     * Expiration in milliseconds applied to kept snapshots.
+     * Use `0` for no expiration. Falls back to `snapshotExpiration` when omitted.
+     */
+    expiration?: number;
+    /**
+     * When `true` (the default), evicted snapshots are deleted immediately;
+     * when `false`, they keep the default expiration.
+     */
+    deleteEvicted?: boolean;
+  };
+  /**
    * Called when the sandbox session is resumed (e.g., after a snapshot restore).
    * Use this to re-warm caches, restore transient state, or run other setup logic.
    */
@@ -438,6 +458,16 @@ export class Sandbox {
   }
 
   /**
+   * The snapshot retention policy (`keep-last-snapshots`) currently configured
+   * on this sandbox, if any.
+   */
+  public get keepLastSnapshots():
+    | { count: number; expiration?: number; deleteEvicted: boolean }
+    | undefined {
+    return this.sandbox.keepLastSnapshots;
+  }
+
+  /**
    * The amount of CPU used by the session. Only reported once the VM is stopped.
    */
   public get activeCpuUsageMs(): number | undefined {
@@ -573,6 +603,7 @@ export class Sandbox {
       env: params?.env,
       tags: params?.tags,
       snapshotExpiration: params?.snapshotExpiration,
+      keepLastSnapshots: params?.keepLastSnapshots,
       signal: params?.signal,
       name: params?.name,
       persistent: params?.persistent,
@@ -1171,6 +1202,11 @@ export class Sandbox {
       tags?: Record<string, string>;
       ports?: number[];
       snapshotExpiration?: number;
+      keepLastSnapshots?: {
+        count: number;
+        expiration?: number;
+        deleteEvicted?: boolean;
+      } | null;
       currentSnapshotId?: string;
     },
     opts?: { signal?: AbortSignal },
@@ -1196,6 +1232,7 @@ export class Sandbox {
       tags: params.tags,
       ports: params.ports,
       snapshotExpiration: params.snapshotExpiration,
+      keepLastSnapshots: params.keepLastSnapshots,
       currentSnapshotId: params.currentSnapshotId,
       signal: opts?.signal,
     });


### PR DESCRIPTION
Re-apply https://github.com/vercel/sandbox/pull/164, which was closed.

CLI
---

`sandbox create` accepts retention policy flags. By default, evicted snapshots are deleted immediately; pass `--delete-evicted-snapshots false` to let them fall back to the sandbox's default expiration instead.

```
> sandbox create --keep-last-snapshots 3
> sandbox create --keep-last-snapshots 3 --keep-last-snapshots-for 7d
> sandbox create --keep-last-snapshots 5 --keep-last-snapshots-for 30d --delete-evicted-snapshots false
```

The `sandbox config` command exposes one subcommand per retention field. The two modifier subcommands (`keep-last-snapshots-for`, `delete-evicted-snapshots`) require an existing policy.

```
> sandbox config keep-last-snapshots my-sandbox 3
> sandbox config keep-last-snapshots-for my-sandbox 7d
> sandbox config delete-evicted-snapshots my-sandbox false

# Pass 0 to remove the policy:
> sandbox config keep-last-snapshots my-sandbox 0
```

`sandbox config list` includes a new "Keep last snapshots" row:

```
> sandbox config list my-sandbox

FIELD                 VALUE
vCPUs                 2
Timeout               10 minutes
Persistent            true
Network policy        restricted
Snapshot expiration   7 days
Keep last snapshots   count=3, for=7 days, delete-evicted-snapshots=true
Current snapshot      -
Tags                  -
```

SDK
---

`Sandbox.create` and `Sandbox.update` accept a new optional `keepLastSnapshots` field.

```ts
const sandbox = await Sandbox.create({
  keepLastSnapshots: {
    count: 3,
    expiration: 7 * 24 * 60 * 60 * 1000,   // ms, 0 = never. Falls back to snapshotExpiration when omitted.
    deleteEvicted: true,                    // default true
  },
});
```

On `Sandbox.update`, pass `null` to remove the policy:

```ts
await sandbox.update({ keepLastSnapshots: null });
```