### PR TITLE
chore: add minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,5 @@ packages:
 catalog:
   tsdown: 0.16.6
   vitest: 3.2.1
+
+minimumReleaseAge: 2880


### PR DESCRIPTION
Enforce a 2 days minimum release age for new packages to be installed in the monorepo