### PR TITLE
fix(vercel-sandbox): reject non-octet-stream responses in readFile

### DIFF
--- a/.changeset/sandbox-cp-error-payload.md
+++ b/.changeset/sandbox-cp-error-payload.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Fix `readFile` writing the API error JSON into the destination when the file response is not an octet-stream. The SDK now rejects any non-`application/octet-stream` response (including 2xx with a JSON error body) instead of piping it verbatim to the caller's stream.

--- a/packages/vercel-sandbox/src/api-client/api-client.test.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.test.ts
@@ -1190,4 +1190,94 @@ describe("APIClient", () => {
     });
   });
 
+  describe("readFile", () => {
+    let client: APIClient;
+    let mockFetch: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockFetch = vi.fn();
+      client = new APIClient({
+        teamId: "team_123",
+        token: "1234",
+        fetch: mockFetch,
+      });
+    });
+
+    it("throws APIError when the API returns a non-2xx with an error payload", async () => {
+      const errorBody = JSON.stringify({
+        error: {
+          code: "sandbox_stopped",
+          message: "Sandbox has stopped execution and is no longer available",
+        },
+      });
+
+      mockFetch.mockResolvedValue(
+        new Response(errorBody, {
+          status: 410,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await expect(
+        client.readFile({ sessionId: "sbx_123", path: "/probe.txt" }),
+      ).rejects.toThrow(APIError);
+    });
+
+    it("throws APIError when the response is 2xx but the content-type is not octet-stream", async () => {
+      const errorBody = JSON.stringify({
+        error: {
+          code: "sandbox_stopped",
+          message: "Sandbox has stopped execution and is no longer available",
+        },
+      });
+
+      mockFetch.mockResolvedValue(
+        new Response(errorBody, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await expect(
+        client.readFile({ sessionId: "sbx_123", path: "/probe.txt" }),
+      ).rejects.toThrow(APIError);
+    });
+
+    it("returns the readable stream when the content-type is octet-stream", async () => {
+      mockFetch.mockResolvedValue(
+        new Response("hello world", {
+          status: 200,
+          headers: { "content-type": "application/octet-stream" },
+        }),
+      );
+
+      const stream = await client.readFile({
+        sessionId: "sbx_123",
+        path: "/probe.txt",
+      });
+      expect(stream).not.toBeNull();
+
+      const chunks: Buffer[] = [];
+      for await (const chunk of stream!) {
+        chunks.push(chunk as Buffer);
+      }
+      expect(Buffer.concat(chunks).toString()).toBe("hello world");
+    });
+
+    it("returns null when the API returns 404", async () => {
+      mockFetch.mockResolvedValue(
+        new Response(null, {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      const stream = await client.readFile({
+        sessionId: "sbx_123",
+        path: "/probe.txt",
+      });
+      expect(stream).toBeNull();
+    });
+  });
+
 });

--- a/packages/vercel-sandbox/src/api-client/api-client.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.ts
@@ -569,8 +569,23 @@ export class APIClient extends BaseClient {
       return null;
     }
 
-    if (!response.ok) {
-      await parseOrThrow(z.any(), response);
+    // The file endpoint must return the file as an octet-stream. Any other
+    // content type (e.g. application/json) indicates an error payload that
+    // would otherwise be piped verbatim into the destination file.
+    const contentType = response.headers.get("content-type") ?? "";
+    if (!response.ok || !contentType.includes("application/octet-stream")) {
+      const text = await response.text().catch(() => "");
+      let json: unknown;
+      try {
+        json = JSON.parse(text || "{}");
+      } catch {
+        json = undefined;
+      }
+      throw new APIError(response, {
+        message: `Unexpected response reading file: status ${response.status}, content-type ${contentType || "(none)"}`,
+        json,
+        text,
+      });
     }
 
     if (response.body === null) {


### PR DESCRIPTION
Fix `readFile` writing the API error JSON into the destination when the file response is not an octet-stream.

The SDK now rejects any non-`application/octet-stream` response (including 2xx with a JSON error body) instead of piping it verbatim to the caller's stream.