### PR TITLE
feat(cli): allow updating sandbox ports

### DIFF
--- a/.changeset/cli-ports-config.md
+++ b/.changeset/cli-ports-config.md
@@ -1,0 +1,5 @@
+---
+"sandbox": minor
+---
+
+Add `sandbox config ports` subcommand to update the sandbox's ports.

--- a/packages/sandbox/docs/index.md
+++ b/packages/sandbox/docs/index.md
@@ -363,6 +363,7 @@ Commands:
     keep-last-snapshots-for   <name> <DURATION|none>  Update the expiration applied to snapshots kept by the retention policy
     delete-evicted-snapshots  <name> <true|false>     When "true" (the default), snapshots evicted by the keep-last-snapshots policy are deleted immediately; when "false", they keep the default expiration.
     current-snapshot          <name> <snapshot_id>    Update the current snapshot of a sandbox
+    ports                     <name>                  Update the published ports of a sandbox. Replaces all existing published ports.
     tags                      <name>                  Update the tags of a sandbox. Replaces all existing tags with the provided tags.
 ```
 

--- a/packages/sandbox/src/args/ports.ts
+++ b/packages/sandbox/src/args/ports.ts
@@ -14,7 +14,7 @@ export const publishPorts = cmd.multioption({
             [
               `Invalid port: ${number}.`,
               `${chalk.bold("hint:")} Ports must be integers between 1024-65535 (privileged ports 0-1023 are reserved).`,
-              "Examples: 3000, 8080, 8443",
+              "Examples: 3000, 8443",
             ].join("\n"),
           );
         }

--- a/packages/sandbox/src/args/ports.ts
+++ b/packages/sandbox/src/args/ports.ts
@@ -1,0 +1,25 @@
+import * as cmd from "cmd-ts";
+import chalk from "chalk";
+
+export const publishPorts = cmd.multioption({
+  long: "publish-port",
+  short: "p",
+  description: "Publish sandbox port(s) to DOMAIN.vercel.run",
+  type: cmd.array(
+    cmd.extendType(cmd.number, {
+      displayName: "PORT",
+      async from(number) {
+        if (!Number.isInteger(number) || number < 1024 || number > 65535) {
+          throw new Error(
+            [
+              `Invalid port: ${number}.`,
+              `${chalk.bold("hint:")} Ports must be integers between 1024-65535 (privileged ports 0-1023 are reserved).`,
+              "Examples: 3000, 8080, 8443",
+            ].join("\n"),
+          );
+        }
+        return number;
+      },
+    }),
+  ),
+});

--- a/packages/sandbox/src/commands/config.ts
+++ b/packages/sandbox/src/commands/config.ts
@@ -492,13 +492,15 @@ const portsCommand = cmd.command({
       if (ports.length === 0) {
         process.stderr.write(chalk.dim("   ╰ ") + "all ports unpublished\n");
       } else {
+        const routes = getPublishedRoutes(sandbox);
+        process.stderr.write(chalk.dim("   │ ") + "ports:\n");
         for (let i = 0; i < ports.length; i++) {
           const port = ports[i];
+          const route = routes?.find((route) => route.port === port);
           const isLast = i === ports.length - 1;
           const prefix = isLast ? chalk.dim("   ╰ ") : chalk.dim("   │ ");
-          process.stderr.write(
-            prefix + "publish-port: " + chalk.cyan(port) + "\n",
-          );
+          const url = route ? " -> " + chalk.cyan(route.url) : "";
+          process.stderr.write(prefix + "• " + port + url + "\n");
         }
       }
     } catch (error) {
@@ -708,30 +710,29 @@ function formatKeepLastSnapshots(
 }
 
 function formatPorts(sandbox: Sandbox): string {
-  let routes: Sandbox["routes"];
-  let interactivePort: Sandbox["interactivePort"];
-  try {
-    routes = sandbox.routes;
-    interactivePort = sandbox.interactivePort;
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message === "No active session. Run a command or call resume first."
-    ) {
-      return "-";
-    }
-    throw error;
-  }
-
-  const ports = routes
-    .filter((route) => route.port !== interactivePort)
-    .map((route) => route.port);
+  const ports = getPublishedRoutes(sandbox)?.map((route) => route.port) ?? [];
 
   if (ports.length === 0) {
     return "-";
   }
 
   return ports.join(", ");
+}
+
+function getPublishedRoutes(sandbox: Sandbox): Sandbox["routes"] | undefined {
+  try {
+    return sandbox.routes.filter(
+      (route) => route.port !== sandbox.interactivePort,
+    );
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === "No active session. Run a command or call resume first."
+    ) {
+      return undefined;
+    }
+    throw error;
+  }
 }
 
 export const config = cmd.subcommands({

--- a/packages/sandbox/src/commands/config.ts
+++ b/packages/sandbox/src/commands/config.ts
@@ -13,6 +13,7 @@ import { vcpusType } from "../args/vcpus";
 import { Duration } from "../types/duration";
 import { SnapshotExpiration } from "../types/snapshot-expiration";
 import { ObjectFromKeyValue } from "../args/key-value-pair";
+import { publishPorts } from "../args/ports";
 import ora from "ora";
 import chalk from "chalk";
 import ms from "ms";
@@ -460,6 +461,53 @@ const currentSnapshotCommand = cmd.command({
   },
 });
 
+const portsCommand = cmd.command({
+  name: "ports",
+  description:
+    "Update the published ports of a sandbox. Replaces all existing published ports.",
+  args: {
+    sandbox: cmd.positional({
+      type: sandboxName,
+      description: "Sandbox name to update",
+    }),
+    ports: publishPorts,
+    scope,
+  },
+  async handler({ scope: { token, team, project }, sandbox: name, ports }) {
+    const sandbox = await sandboxClient.get({
+      name,
+      projectId: project,
+      teamId: team,
+      token,
+    });
+
+    const spinner = ora("Updating sandbox ports...").start();
+    try {
+      await sandbox.update({ ports });
+      spinner.stop();
+
+      process.stderr.write(
+        "✅ Ports updated for sandbox " + chalk.cyan(name) + "\n",
+      );
+      if (ports.length === 0) {
+        process.stderr.write(chalk.dim("   ╰ ") + "all ports unpublished\n");
+      } else {
+        for (let i = 0; i < ports.length; i++) {
+          const port = ports[i];
+          const isLast = i === ports.length - 1;
+          const prefix = isLast ? chalk.dim("   ╰ ") : chalk.dim("   │ ");
+          process.stderr.write(
+            prefix + "publish-port: " + chalk.cyan(port) + "\n",
+          );
+        }
+      }
+    } catch (error) {
+      spinner.stop();
+      throw error;
+    }
+  },
+});
+
 const listCommand = cmd.command({
   name: "list",
   description: "Display the current configuration of a sandbox",
@@ -672,6 +720,7 @@ export const config = cmd.subcommands({
     "keep-last-snapshots-for": keepLastSnapshotsForCommand,
     "delete-evicted-snapshots": deleteEvictedSnapshotsCommand,
     "current-snapshot": currentSnapshotCommand,
+    ports: portsCommand,
     tags: tagsCommand,
   },
 });

--- a/packages/sandbox/src/commands/config.ts
+++ b/packages/sandbox/src/commands/config.ts
@@ -720,19 +720,9 @@ function formatPorts(sandbox: Sandbox): string {
 }
 
 function getPublishedRoutes(sandbox: Sandbox): Sandbox["routes"] | undefined {
-  try {
-    return sandbox.routes.filter(
-      (route) => route.port !== sandbox.interactivePort,
-    );
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message === "No active session. Run a command or call resume first."
-    ) {
-      return undefined;
-    }
-    throw error;
-  }
+  return sandbox.routes.filter(
+    (route) => route.port !== sandbox.interactivePort,
+  );
 }
 
 export const config = cmd.subcommands({

--- a/packages/sandbox/src/commands/config.ts
+++ b/packages/sandbox/src/commands/config.ts
@@ -541,6 +541,7 @@ const listCommand = cmd.command({
       { field: "Timeout", value: sandbox.timeout != null ? ms(sandbox.timeout, { long: true }) : "-" },
       { field: "Persistent", value: String(sandbox.persistent) },
       { field: "Network policy", value: String(networkPolicy) },
+      { field: "Ports", value: formatPorts(sandbox) },
       { field: "Snapshot expiration", value: sandbox.snapshotExpiration != null && sandbox.snapshotExpiration > 0 ? ms(sandbox.snapshotExpiration, { long: true }) : sandbox.snapshotExpiration === 0 ? "none" : "-" },
       { field: "Keep last snapshots", value: formatKeepLastSnapshots(sandbox.keepLastSnapshots) },
       { field: "Current snapshot", value: sandbox.currentSnapshotId ?? "-" },
@@ -704,6 +705,33 @@ function formatKeepLastSnapshots(
   }
 
   return parts.join(", ");
+}
+
+function formatPorts(sandbox: Sandbox): string {
+  let routes: Sandbox["routes"];
+  let interactivePort: Sandbox["interactivePort"];
+  try {
+    routes = sandbox.routes;
+    interactivePort = sandbox.interactivePort;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === "No active session. Run a command or call resume first."
+    ) {
+      return "-";
+    }
+    throw error;
+  }
+
+  const ports = routes
+    .filter((route) => route.port !== interactivePort)
+    .map((route) => route.port);
+
+  if (ports.length === 0) {
+    return "-";
+  }
+
+  return ports.join(", ");
 }
 
 export const config = cmd.subcommands({

--- a/packages/sandbox/src/commands/create.ts
+++ b/packages/sandbox/src/commands/create.ts
@@ -14,6 +14,7 @@ import { networkPolicyArgs } from "../args/network-policy";
 import { buildNetworkPolicy } from "../util/network-policy";
 import { ObjectFromKeyValue } from "../args/key-value-pair";
 import { SnapshotExpiration } from "../types/snapshot-expiration";
+import { publishPorts } from "../args/ports";
 
 export const args = {
   name: cmd.option({
@@ -28,28 +29,7 @@ export const args = {
   runtime,
   timeout,
   vcpus,
-  ports: cmd.multioption({
-    long: "publish-port",
-    short: "p",
-    description: "Publish sandbox port(s) to DOMAIN.vercel.run",
-    type: cmd.array(
-      cmd.extendType(cmd.number, {
-        displayName: "PORT",
-        async from(number) {
-          if (number < 1024 || number > 65535) {
-            throw new Error(
-              [
-                `Invalid port: ${number}.`,
-                `${chalk.bold("hint:")} Ports must be between 1024-65535 (privileged ports 0-1023 are reserved).`,
-                "╰▶ Examples: 3000, 8080, 8443",
-              ].join("\n"),
-            );
-          }
-          return number;
-        },
-      }),
-    ),
-  }),
+  ports: publishPorts,
   silent: cmd.flag({
     long: "silent",
     description: "Don't write sandbox name to stdout",


### PR DESCRIPTION
In https://github.com/vercel/sandbox/pull/184 we added support for updating a sandbox ports at runtime. However, we missed adding this functionnality to the CLI

This PR adds a new `sandbox config ports` subcommand to update the ports dynamically:
```sh
sandbox config ports my-sandbox-name # clear all ports
sandbox config ports my-sandbox-name -p 8080 -p 1234 # replaces currently opened ports
```
<img width="560" height="126" alt="Screenshot 2026-05-22 at 08 59 01" src="https://github.com/user-attachments/assets/d82af12d-7f6d-466b-8c0a-a305cdd41ed3" />

We also surface the configured ports in `sandbox config list`:
<img width="452" height="247" alt="Screenshot 2026-05-22 at 08 53 51" src="https://github.com/user-attachments/assets/8ebe1445-cdc3-460a-891d-78899ca6b1ee" />
