### PR TITLE
fix(vercel-sandbox): add missing `updatedAt` getter to Snapshot class

### DIFF
--- a/.changeset/snapshot-updated-at.md
+++ b/.changeset/snapshot-updated-at.md
@@ -2,4 +2,4 @@
 "@vercel/sandbox": patch
 ---
 
-Add missing `updatedAt` getter to the `Snapshot` class
+Add `updatedAt` getter to the `Snapshot` class

--- a/.changeset/snapshot-updated-at.md
+++ b/.changeset/snapshot-updated-at.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Add missing `updatedAt` getter to the `Snapshot` class

--- a/packages/vercel-sandbox/src/snapshot.ts
+++ b/packages/vercel-sandbox/src/snapshot.ts
@@ -83,6 +83,13 @@ export class Snapshot {
   }
 
   /**
+   * When this snapshot was last updated.
+   */
+  public get updatedAt(): Date {
+    return new Date(this.snapshot.updatedAt);
+  }
+
+  /**
    * The expiration date of this snapshot, or undefined if it does not expire.
    */
   public get expiresAt(): Date | undefined {


### PR DESCRIPTION
The raw API response includes `updatedAt`, but the `Snapshot` class only exposes `snapshotId`, `sourceSessionId`, `status`, `sizeBytes`, `createdAt`, and `expiresAt` as public getters.

Adds the missing `updatedAt` getter to `Snapshot`, placed between `createdAt` and `expiresAt` to match the existing ordering and pattern.