### PR TITLE
fix(sandbox): retry interactive shell WebSocket open

### DIFF
--- a/.changeset/retry-interactive-shell-open.md
+++ b/.changeset/retry-interactive-shell-open.md
@@ -1,0 +1,5 @@
+---
+"sandbox": patch
+---
+
+Retry the interactive shell WebSocket open on connection failure so `sandbox connect` recovers when the sandbox-router cache is briefly stale after a named-sandbox resume.

--- a/packages/sandbox/src/interactive-shell/interactive-shell.ts
+++ b/packages/sandbox/src/interactive-shell/interactive-shell.ts
@@ -412,7 +412,7 @@ async function openWithRetry<
         throw err;
       }
     },
-    { retries: 3, minTimeout: 300, factor: 2, maxRetryTime: 12_000 },
+    { retries: 2, minTimeout: 0, factor: 0 },
   );
 }
 

--- a/packages/sandbox/src/interactive-shell/interactive-shell.ts
+++ b/packages/sandbox/src/interactive-shell/interactive-shell.ts
@@ -408,11 +408,13 @@ async function openWithRetry<
         debug("WebSocket open attempt %d failed: %o", attempt, err);
         try {
           client.close();
-        } catch {}
+        } catch (closeErr) {
+          debug("WebSocket close after failed open errored: %o", closeErr);
+        }
         throw err;
       }
     },
-    { retries: 2, minTimeout: 0, factor: 0 },
+    { retries: 2, minTimeout: 500, factor: 0 },
   );
 }
 

--- a/packages/sandbox/src/interactive-shell/interactive-shell.ts
+++ b/packages/sandbox/src/interactive-shell/interactive-shell.ts
@@ -5,6 +5,7 @@ import {
   type Listener,
 } from "@vercel/pty-tunnel";
 import createDebugger from "debug";
+import retry from "async-retry";
 import { printCommand } from "../util/print-command";
 import ora, { Ora, spinners } from "ora";
 import { PassThrough } from "node:stream";
@@ -388,33 +389,25 @@ async function connect(
   listener.stdoutStream.end();
 }
 
-async function openWithRetry<T extends { waitForOpen(): Promise<unknown>; close(): void }>(
-  create: () => T,
-): Promise<T> {
-  const maxAttempts = 5;
-  let lastError: unknown;
-  for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    if (attempt > 0) {
-      await new Promise((resolve) => setTimeout(resolve, 300 * attempt));
-    }
-    const client = create();
-    try {
-      await client.waitForOpen();
-      return client;
-    } catch (err) {
-      lastError = err;
-      debug(
-        "WebSocket open attempt %d/%d failed: %o",
-        attempt + 1,
-        maxAttempts,
-        err,
-      );
+async function openWithRetry<
+  T extends { waitForOpen(): Promise<unknown>; close(): void },
+>(create: () => T): Promise<T> {
+  return retry<T>(
+    async (_bail, attempt) => {
+      const client = create();
       try {
-        client.close();
-      } catch {}
-    }
-  }
-  throw lastError ?? new Error("Failed to open interactive shell WebSocket");
+        await client.waitForOpen();
+        return client;
+      } catch (err) {
+        debug("WebSocket open attempt %d failed: %o", attempt, err);
+        try {
+          client.close();
+        } catch {}
+        throw err;
+      }
+    },
+    { retries: 4, minTimeout: 300, factor: 2, maxRetryTime: 5_000 },
+  );
 }
 
 function getStderrStream() {

--- a/packages/sandbox/src/interactive-shell/interactive-shell.ts
+++ b/packages/sandbox/src/interactive-shell/interactive-shell.ts
@@ -389,8 +389,6 @@ async function connect(
   listener.stdoutStream.end();
 }
 
-const OPEN_ATTEMPT_TIMEOUT_MS = 2_500;
-
 async function openWithRetry<
   T extends { waitForOpen(): Promise<unknown>; close(): void },
 >(create: () => T): Promise<T> {
@@ -398,7 +396,7 @@ async function openWithRetry<
     async (_bail, attempt) => {
       const client = create();
       try {
-        await withTimeout(client.waitForOpen(), OPEN_ATTEMPT_TIMEOUT_MS);
+        await withTimeout(client.waitForOpen(), 2_500);
         return client;
       } catch (err) {
         debug("WebSocket open attempt %d failed: %o", attempt, err);

--- a/packages/sandbox/src/interactive-shell/interactive-shell.ts
+++ b/packages/sandbox/src/interactive-shell/interactive-shell.ts
@@ -398,11 +398,7 @@ async function openWithRetry<
     async (_bail, attempt) => {
       const client = create();
       try {
-        await withTimeout(
-          client.waitForOpen(),
-          OPEN_ATTEMPT_TIMEOUT_MS,
-          `WebSocket open timed out after ${OPEN_ATTEMPT_TIMEOUT_MS}ms`,
-        );
+        await withTimeout(client.waitForOpen(), OPEN_ATTEMPT_TIMEOUT_MS);
         return client;
       } catch (err) {
         debug("WebSocket open attempt %d failed: %o", attempt, err);
@@ -418,15 +414,14 @@ async function openWithRetry<
   );
 }
 
-function withTimeout<T>(
-  promise: Promise<T>,
-  ms: number,
-  message: string,
-): Promise<T> {
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   promise.catch(() => {});
   let timer: NodeJS.Timeout | undefined;
   const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error(message)), ms);
+    timer = setTimeout(
+      () => reject(new Error(`Operation timed out after ${ms}ms`)),
+      ms,
+    );
   });
   return Promise.race([promise, timeout]).finally(() => {
     if (timer) clearTimeout(timer);

--- a/packages/sandbox/src/interactive-shell/interactive-shell.ts
+++ b/packages/sandbox/src/interactive-shell/interactive-shell.ts
@@ -282,12 +282,13 @@ async function attach({
   debug("Connecting to WebSocket URL:", url);
 
   const stdoutPipe = messageReader(process.stdout);
-  const client = details.createClient(url);
-  client.addEventListener("message", async ({ data }) => {
-    stdoutPipe.next(data);
+  const client = await openWithRetry(() => {
+    const c = details.createClient(url);
+    c.addEventListener("message", async ({ data }) => {
+      stdoutPipe.next(data);
+    });
+    return c;
   });
-
-  await client.waitForOpen();
   progress.stop();
 
   using extensionController = createAbortController("stopped extensions");
@@ -385,6 +386,35 @@ async function connect(
     }
   }
   listener.stdoutStream.end();
+}
+
+async function openWithRetry<T extends { waitForOpen(): Promise<unknown>; close(): void }>(
+  create: () => T,
+): Promise<T> {
+  const maxAttempts = 5;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) => setTimeout(resolve, 300 * attempt));
+    }
+    const client = create();
+    try {
+      await client.waitForOpen();
+      return client;
+    } catch (err) {
+      lastError = err;
+      debug(
+        "WebSocket open attempt %d/%d failed: %o",
+        attempt + 1,
+        maxAttempts,
+        err,
+      );
+      try {
+        client.close();
+      } catch {}
+    }
+  }
+  throw lastError ?? new Error("Failed to open interactive shell WebSocket");
 }
 
 function getStderrStream() {

--- a/packages/sandbox/src/interactive-shell/interactive-shell.ts
+++ b/packages/sandbox/src/interactive-shell/interactive-shell.ts
@@ -389,6 +389,8 @@ async function connect(
   listener.stdoutStream.end();
 }
 
+const OPEN_ATTEMPT_TIMEOUT_MS = 2_500;
+
 async function openWithRetry<
   T extends { waitForOpen(): Promise<unknown>; close(): void },
 >(create: () => T): Promise<T> {
@@ -396,7 +398,11 @@ async function openWithRetry<
     async (_bail, attempt) => {
       const client = create();
       try {
-        await client.waitForOpen();
+        await withTimeout(
+          client.waitForOpen(),
+          OPEN_ATTEMPT_TIMEOUT_MS,
+          `WebSocket open timed out after ${OPEN_ATTEMPT_TIMEOUT_MS}ms`,
+        );
         return client;
       } catch (err) {
         debug("WebSocket open attempt %d failed: %o", attempt, err);
@@ -406,8 +412,23 @@ async function openWithRetry<
         throw err;
       }
     },
-    { retries: 4, minTimeout: 300, factor: 2, maxRetryTime: 5_000 },
+    { retries: 3, minTimeout: 300, factor: 2, maxRetryTime: 12_000 },
   );
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
+  promise.catch(() => {});
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
 }
 
 function getStderrStream() {


### PR DESCRIPTION
When trying to do a `sandbox --connect`, retry up to 2 times. We also ensure we are not blocking connections and we timeout each connection after 2.5s.

Worst case scenario: 3 attempts, with 2.5s maximum wait per connection, and 500ms delay between attempts -> 8.5 seconds.