### PR TITLE
patch(sandbox): show anchor snapshot siblings in snapshots tree

### DIFF
--- a/.changeset/snapshots-tree-anchor-siblings.md
+++ b/.changeset/snapshots-tree-anchor-siblings.md
@@ -1,0 +1,6 @@
+---
+"@vercel/sandbox": patch
+"sandbox": patch
+---
+
+Show the current snapshot's siblings in `snapshots tree`. The tree now reads the API's `anchor` node so snapshots sharing the current snapshot's parent are listed, and siblings are rendered by snapshot ID instead of source session ID.

--- a/packages/sandbox/src/commands/snapshots.ts
+++ b/packages/sandbox/src/commands/snapshots.ts
@@ -311,11 +311,14 @@ const tree = cmd.command({
         }),
       ]);
 
+      const current = ancestors.start ?? descendants.start;
+
       return {
         currentSnap,
         currentSnapshotId,
         ancestors,
         descendants,
+        current,
       };
     })();
 
@@ -330,6 +333,7 @@ const tree = cmd.command({
         currentSnapshotExpiresAt: result.currentSnap.expiresAt?.getTime(),
         ancestors: result.ancestors,
         descendants: result.descendants,
+        current: result.current,
       }),
     );
 

--- a/packages/sandbox/src/commands/snapshots.ts
+++ b/packages/sandbox/src/commands/snapshots.ts
@@ -311,7 +311,7 @@ const tree = cmd.command({
         }),
       ]);
 
-      const current = ancestors.start ?? descendants.start;
+      const current = ancestors.anchor ?? descendants.anchor;
 
       return {
         currentSnap,

--- a/packages/sandbox/src/util/snapshot-tree.test.ts
+++ b/packages/sandbox/src/util/snapshot-tree.test.ts
@@ -458,4 +458,28 @@ describe("renderSnapshotTree", () => {
     expect(idxRoot).toBeGreaterThan(idxParent);
     expect(idxRootMarker).toBeGreaterThan(idxRoot);
   });
+
+  test("uses `current` node siblings when provided", () => {
+    const current = makeSnapshot({
+      id: "snap_current",
+      sourceSessionId: "sbx_current",
+    });
+    const sibling = makeSnapshot({
+      id: "snap_sibling",
+      sourceSessionId: "sbx_anchor_sibling",
+    });
+
+    const plain = strip(
+      renderSnapshotTree({
+        currentSnapshotId: "snap_current",
+        current: makeTreeNode(current, [sibling], "2"),
+        ancestors: emptyTree(),
+        descendants: emptyTree(),
+      }),
+    );
+
+    expect(plain).toContain("snap_current");
+    expect(plain).toContain("◂ current");
+    expect(plain).toContain("sbx_anchor_sibling");
+  });
 });

--- a/packages/sandbox/src/util/snapshot-tree.test.ts
+++ b/packages/sandbox/src/util/snapshot-tree.test.ts
@@ -212,12 +212,12 @@ describe("renderSnapshotTree", () => {
       }),
     );
 
-    expect(plain).toContain("sbx_s1");
-    expect(plain).toContain("sbx_s2");
-    expect(plain).not.toContain("more sandboxes");
+    expect(plain).toContain("snap_s1");
+    expect(plain).toContain("snap_s2");
+    expect(plain).not.toContain("more snapshots");
   });
 
-  test("renders '+N more sandboxes' when siblings exceed the max-show limit", () => {
+  test("renders '+N more snapshots' when siblings exceed the max-show limit", () => {
     const parent = makeSnapshot({ id: "snap_parent" });
     // 7 siblings total (count = 8, main + 7 siblings), max shown is 5
     const siblings = Array.from({ length: 7 }, (_, i) =>
@@ -235,15 +235,15 @@ describe("renderSnapshotTree", () => {
       }),
     );
 
-    // First 5 sessions visible
+    // First 5 snapshots visible
     for (let i = 0; i < 5; i++) {
-      expect(plain).toContain(`sbx_s${i}`);
+      expect(plain).toContain(`snap_s${i}`);
     }
     // remaining = totalSiblings(7) - shown(5) = 2
-    expect(plain).toContain("+2 more sandboxes");
+    expect(plain).toContain("+2 more snapshots");
   });
 
-  test("renders '+N+ more sandboxes' when the count is truncated (e.g. '10+')", () => {
+  test("renders '+N+ more snapshots' when the count is truncated (e.g. '10+')", () => {
     const parent = makeSnapshot({ id: "snap_parent" });
     // Server returned "10+" with 9 siblings (CHILDREN_PER_NODE_LIMIT - 1)
     const siblings = Array.from({ length: 9 }, (_, i) =>
@@ -262,7 +262,7 @@ describe("renderSnapshotTree", () => {
     );
 
     // remaining = totalSiblings(9) - shown(5) = 4, with "+" suffix
-    expect(plain).toContain("+4+ more sandboxes");
+    expect(plain).toContain("+4+ more snapshots");
   });
 
   test("renders the root marker when ancestors have no parent and pagination is exhausted", () => {
@@ -480,6 +480,6 @@ describe("renderSnapshotTree", () => {
 
     expect(plain).toContain("snap_current");
     expect(plain).toContain("◂ current");
-    expect(plain).toContain("sbx_anchor_sibling");
+    expect(plain).toContain("snap_sibling");
   });
 });

--- a/packages/sandbox/src/util/snapshot-tree.ts
+++ b/packages/sandbox/src/util/snapshot-tree.ts
@@ -25,6 +25,7 @@ export type RenderSnapshotTreeParams =
       currentSnapshotExpiresAt?: number;
       ancestors: TreeResponse;
       descendants: TreeResponse;
+      current?: TreeNode;
       hideCurrent?: false;
     }
   | {
@@ -123,6 +124,7 @@ export function renderSnapshotTree(
   if (!hideCurrent) {
     const { currentSnapshotId: id, currentSnapshotExpiresAt } = params;
     const currentTreeNode =
+      params.current ??
       ancestors.snapshots.find((n) => n.snapshot.id === id) ??
       descendants.snapshots.find((n) => n.snapshot.id === id);
     const currentNode: TreeNode = currentTreeNode ?? {

--- a/packages/sandbox/src/util/snapshot-tree.ts
+++ b/packages/sandbox/src/util/snapshot-tree.ts
@@ -75,13 +75,13 @@ function renderSiblings(siblings: SnapshotData[], count: string): string[] {
   for (let i = 0; i < shown.length; i++) {
     const isLast = i === shown.length - 1 && remaining <= 0;
     const connector = isLast ? "╰──" : "├──";
-    lines.push(`│   ${connector} ${chalk.gray(shown[i].sourceSessionId)}`);
+    lines.push(`│   ${connector} ${chalk.gray(shown[i].id)}`);
   }
 
   if (remaining > 0) {
     const suffix = hasPlus ? "+" : "";
     lines.push(
-      `│   ╰── ${chalk.gray(`+${remaining}${suffix} more sandboxes`)}`,
+      `│   ╰── ${chalk.gray(`+${remaining}${suffix} more snapshots`)}`,
     );
   }
 

--- a/packages/vercel-sandbox/src/api-client/validators.ts
+++ b/packages/vercel-sandbox/src/api-client/validators.ts
@@ -229,7 +229,7 @@ export type SnapshotTreeNodeData = z.infer<typeof SnapshotTreeNode>;
 
 export const SnapshotTreeResponse = z.object({
   snapshots: z.array(SnapshotTreeNode),
-  start: SnapshotTreeNode.optional(),
+  anchor: SnapshotTreeNode.optional(),
   pagination: CursorPagination,
 });
 

--- a/packages/vercel-sandbox/src/api-client/validators.ts
+++ b/packages/vercel-sandbox/src/api-client/validators.ts
@@ -229,6 +229,7 @@ export type SnapshotTreeNodeData = z.infer<typeof SnapshotTreeNode>;
 
 export const SnapshotTreeResponse = z.object({
   snapshots: z.array(SnapshotTreeNode),
+  start: SnapshotTreeNode.optional(),
   pagination: CursorPagination,
 });
 


### PR DESCRIPTION
Fix some issues with the snapshot tree.

Changes:

- Now we return as siblings the snapshots, not the sandbox sessions.
- We use the new API, which returns the `anchor` field. We use it to show the siblings from the root snapshots, which before we could not.