### PR TITLE
feat(sandbox,vercel-sandbox): support timeout parameter when executing a command

### DIFF
--- a/.changeset/run-command-timeout.md
+++ b/.changeset/run-command-timeout.md
@@ -3,4 +3,4 @@
 "sandbox": minor
 ---
 
-Add `timeoutMs` to `runCommand` (SDK) and a `--timeout <duration>` flag to `sandbox exec` (CLI). When the duration elapses the command is killed with SIGKILL (commands typically surface as exit code 137). Cannot be combined with `detached: true` (SDK) or `--interactive` (CLI).
+Add `timeoutMs` to `runCommand` (SDK) and a `--timeout <duration>` flag to `sandbox exec` (CLI).

--- a/.changeset/run-command-timeout.md
+++ b/.changeset/run-command-timeout.md
@@ -1,0 +1,6 @@
+---
+"@vercel/sandbox": minor
+"sandbox": minor
+---
+
+Add `timeoutMs` to `runCommand` (SDK) and a `--timeout <duration>` flag to `sandbox exec` (CLI). When the duration elapses the command is killed with SIGKILL (commands typically surface as exit code 137). Cannot be combined with `detached: true` (SDK) or `--interactive` (CLI).

--- a/packages/sandbox/src/commands/create.ts
+++ b/packages/sandbox/src/commands/create.ts
@@ -175,6 +175,7 @@ export const create = cmd.command({
         interactive: true,
         tty: true,
         sandbox,
+        timeout: undefined,
       });
     }
 

--- a/packages/sandbox/src/commands/exec.ts
+++ b/packages/sandbox/src/commands/exec.ts
@@ -1,11 +1,13 @@
 import { Sandbox } from "@vercel/sandbox";
 import * as cmd from "cmd-ts";
+import ms from "ms";
 import { sandboxName } from "../args/sandbox-name";
 import { isatty } from "node:tty";
 import { startInteractiveShell } from "../interactive-shell/interactive-shell";
 import { printCommand } from "../util/print-command";
 import { ObjectFromKeyValue } from "../args/key-value-pair";
 import { scope } from "../args/scope";
+import { Duration } from "../types/duration";
 import { sandboxClient } from "../client";
 import chalk from "chalk";
 
@@ -68,6 +70,14 @@ export const args = {
     type: ObjectFromKeyValue,
     description: "Environment variables to set for the command",
   }),
+  timeout: cmd.option({
+    long: "timeout",
+    type: cmd.optional(Duration),
+    description:
+      "Maximum duration to wait for the command (e.g. 30s, 5m). " +
+      "On expiry the process is killed with SIGKILL. " +
+      "Cannot be combined with --interactive.",
+  }),
   scope,
 } as const;
 
@@ -85,7 +95,17 @@ export const exec = cmd.command({
     interactive,
     envVars,
     skipExtendingTimeout,
+    timeout,
   }) {
+    if (interactive && timeout) {
+      throw new Error(
+        [
+          "--timeout cannot be combined with --interactive.",
+          `${chalk.bold("hint:")} Remove one of the two flags. Interactive sessions do not enforce a command timeout.`,
+        ].join("\n"),
+      );
+    }
+
     const sandbox =
       typeof sandboxName !== "string"
         ? sandboxName
@@ -107,6 +127,7 @@ export const exec = cmd.command({
         sudo: asSudo,
         cwd,
         env: envVars,
+        timeoutMs: timeout ? ms(timeout) : undefined,
       });
 
       process.exitCode = result.exitCode;

--- a/packages/sandbox/src/commands/exec.ts
+++ b/packages/sandbox/src/commands/exec.ts
@@ -130,6 +130,13 @@ export const exec = cmd.command({
         timeoutMs: timeout ? ms(timeout) : undefined,
       });
 
+      // Exit code 137 (128 + SIGKILL) is how a `--timeout` kill surfaces.
+      if (timeout && result.exitCode === 137) {
+        console.error(
+          `${chalk.yellow("Command was killed (SIGKILL, exit code 137)")}.`,
+        );
+      }
+
       process.exitCode = result.exitCode;
     } else {
       await startInteractiveShell({

--- a/packages/sandbox/src/commands/fork.ts
+++ b/packages/sandbox/src/commands/fork.ts
@@ -182,6 +182,7 @@ export const fork = cmd.command({
         interactive: true,
         tty: true,
         sandbox,
+        timeout: undefined,
       });
     }
 

--- a/packages/sandbox/src/commands/run.ts
+++ b/packages/sandbox/src/commands/run.ts
@@ -8,7 +8,9 @@ import { omit } from "../util/omit";
 
 const args = {
   ...Create.args,
-  ...omit(Exec.args, "sandbox"),
+  // `timeout` is omitted because it collides with Create's `--timeout`
+  // (sandbox lifetime).
+  ...omit(Exec.args, "sandbox", "timeout"),
   removeAfterUse: cmd.flag({
     long: "rm",
     description: "Automatically remove the sandbox when the command exits.",
@@ -53,7 +55,7 @@ export const run = cmd.command({
     }
 
     try {
-      await Exec.exec.handler({ ...rest, sandbox });
+      await Exec.exec.handler({ ...rest, sandbox, timeout: undefined });
     } finally {
       if (removeAfterUse) {
         await sandbox.delete();

--- a/packages/vercel-sandbox/src/api-client/api-client.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.ts
@@ -221,6 +221,7 @@ export class APIClient extends BaseClient {
     env: Record<string, string>;
     sudo: boolean;
     wait: true;
+    timeout?: number;
     signal?: AbortSignal;
   }): Promise<{ command: CommandData; finished: Promise<CommandFinishedData> }>;
   async runCommand(params: {
@@ -241,6 +242,7 @@ export class APIClient extends BaseClient {
     env: Record<string, string>;
     sudo: boolean;
     wait?: boolean;
+    timeout?: number;
     signal?: AbortSignal;
   }) {
     if (params.wait) {
@@ -255,6 +257,7 @@ export class APIClient extends BaseClient {
             env: params.env,
             sudo: params.sudo,
             wait: true,
+            timeout: params.timeout,
           }),
           signal: params.signal,
         },

--- a/packages/vercel-sandbox/src/api-client/api-client.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.ts
@@ -232,6 +232,7 @@ export class APIClient extends BaseClient {
     env: Record<string, string>;
     sudo: boolean;
     wait?: false;
+    timeout?: number;
     signal?: AbortSignal;
   }): Promise<Parsed<z.infer<typeof CommandResponse>>>;
   async runCommand(params: {
@@ -325,6 +326,7 @@ export class APIClient extends BaseClient {
           cwd: params.cwd,
           env: params.env,
           sudo: params.sudo,
+          timeout: params.timeout,
         }),
         signal: params.signal,
       }),

--- a/packages/vercel-sandbox/src/command.test.ts
+++ b/packages/vercel-sandbox/src/command.test.ts
@@ -68,6 +68,16 @@ describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")("Command", () => {
     expect(result.exitCode).toBe(143);
   });
 
+  it("kills a command with SIGKILL when timeoutMs elapses", async () => {
+    const cmd = await sandbox.runCommand({
+      cmd: "sleep",
+      args: ["60"],
+      timeoutMs: 1_000,
+    });
+
+    expect(cmd.exitCode).toBe(137);
+  });
+
   it("can execute commands with sudo", async () => {
     const cmd = await sandbox.runCommand({
       cmd: "env",

--- a/packages/vercel-sandbox/src/command.test.ts
+++ b/packages/vercel-sandbox/src/command.test.ts
@@ -68,7 +68,7 @@ describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")("Command", () => {
     expect(result.exitCode).toBe(143);
   });
 
-  it("kills a command with SIGKILL when timeoutMs elapses", async () => {
+  it("kills a non-detached (awaited) command with SIGKILL when timeoutMs elapses", async () => {
     const cmd = await sandbox.runCommand({
       cmd: "sleep",
       args: ["60"],
@@ -76,6 +76,18 @@ describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")("Command", () => {
     });
 
     expect(cmd.exitCode).toBe(137);
+  });
+
+  it("kills a detached command with SIGKILL when timeoutMs elapses", async () => {
+    const cmd = await sandbox.runCommand({
+      cmd: "sleep",
+      args: ["60"],
+      detached: true,
+      timeoutMs: 1_000,
+    });
+
+    const result = await cmd.wait();
+    expect(result.exitCode).toBe(137);
   });
 
   it("can execute commands with sudo", async () => {

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -245,6 +245,69 @@ describe("_runCommand error handling", () => {
   });
 });
 
+describe("runCommand timeoutMs", () => {
+  const makeRunningSandbox = (runCommandMock: ReturnType<typeof vi.fn>) =>
+    new Sandbox({
+      client: { runCommand: runCommandMock } as unknown as APIClient,
+      routes: [],
+      sandbox: makeSandboxMetadata(),
+      session: {} as any,
+      projectId: "test-project",
+    });
+
+  it("forwards timeoutMs to the API client as `timeout` on the wait path", async () => {
+    const command = makeCommand();
+    const runCommandMock = vi.fn(async () => ({
+      command,
+      finished: Promise.resolve({ ...command, exitCode: 0 }),
+    }));
+    const sandbox = makeRunningSandbox(runCommandMock);
+
+    await sandbox.runCommand({
+      cmd: "sleep",
+      args: ["60"],
+      timeoutMs: 2500,
+    });
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wait: true,
+        timeout: 2500,
+      }),
+    );
+  });
+
+  it("omits `timeout` when no timeoutMs is provided", async () => {
+    const command = makeCommand();
+    const runCommandMock = vi.fn(async () => ({
+      command,
+      finished: Promise.resolve({ ...command, exitCode: 0 }),
+    }));
+    const sandbox = makeRunningSandbox(runCommandMock);
+
+    await sandbox.runCommand({ cmd: "echo", args: ["hello"] });
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({ wait: true, timeout: undefined }),
+    );
+  });
+
+  it("throws when detached and timeoutMs are combined", async () => {
+    const runCommandMock = vi.fn();
+    const sandbox = makeRunningSandbox(runCommandMock);
+
+    await expect(
+      sandbox.runCommand({
+        cmd: "sleep",
+        args: ["5"],
+        detached: true,
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow(TypeError);
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("Sandbox.getOrCreate", () => {
   const CREDENTIALS = {
     token: "test-token",

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -292,19 +292,24 @@ describe("runCommand timeoutMs", () => {
     );
   });
 
-  it("throws when detached and timeoutMs are combined", async () => {
-    const runCommandMock = vi.fn();
+  it("forwards timeoutMs as `timeout` on the detached (non-wait) path", async () => {
+    const command = makeCommand();
+    const runCommandMock = vi.fn(async () => ({ json: { command } }));
     const sandbox = makeRunningSandbox(runCommandMock);
 
-    await expect(
-      sandbox.runCommand({
-        cmd: "sleep",
-        args: ["5"],
-        detached: true,
-        timeoutMs: 1000,
-      }),
-    ).rejects.toThrow(TypeError);
-    expect(runCommandMock).not.toHaveBeenCalled();
+    await sandbox.runCommand({
+      cmd: "sleep",
+      args: ["5"],
+      detached: true,
+      timeoutMs: 1000,
+    });
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 1000 }),
+    );
+    expect(runCommandMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ wait: true }),
+    );
   });
 });
 

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -1005,12 +1005,14 @@ export class Sandbox {
    * @param args - Arguments to pass to the command.
    * @param opts - Optional parameters.
    * @param opts.signal - An AbortSignal to cancel the command execution.
+   * @param opts.timeoutMs - Maximum time in milliseconds to wait for the
+   * command to complete. On expiry the process is killed with SIGKILL.
    * @returns A {@link CommandFinished} result once execution is done.
    */
   async runCommand(
     command: string,
     args?: string[],
-    opts?: { signal?: AbortSignal },
+    opts?: { signal?: AbortSignal; timeoutMs?: number },
   ): Promise<CommandFinished>;
   /**
    * Start executing a command in detached mode.
@@ -1034,7 +1036,7 @@ export class Sandbox {
   async runCommand(
     commandOrParams: string | RunCommandParams,
     args?: string[],
-    opts?: { signal?: AbortSignal },
+    opts?: { signal?: AbortSignal; timeoutMs?: number },
   ): Promise<Command | CommandFinished> {
     "use step";
     const signal =

--- a/packages/vercel-sandbox/src/session.ts
+++ b/packages/vercel-sandbox/src/session.ts
@@ -64,6 +64,12 @@ export interface RunCommandParams {
    * An AbortSignal to cancel the command execution
    */
   signal?: AbortSignal;
+  /**
+   * Maximum time in milliseconds to wait for the command to complete.
+   * When elapsed, the process is killed with SIGKILL. Cannot be combined with
+   * `detached: true`.
+   */
+  timeoutMs?: number;
 }
 
 /**
@@ -354,12 +360,14 @@ export class Session {
    * @param args - Arguments to pass to the command.
    * @param opts - Optional parameters.
    * @param opts.signal - An AbortSignal to cancel the command execution.
+   * @param opts.timeoutMs - Maximum time in milliseconds to wait for the
+   * command to complete. On expiry the process is killed with SIGKILL.
    * @returns A {@link CommandFinished} result once execution is done.
    */
   async runCommand(
     command: string,
     args?: string[],
-    opts?: { signal?: AbortSignal },
+    opts?: { signal?: AbortSignal; timeoutMs?: number },
   ): Promise<CommandFinished>;
 
   /**
@@ -383,14 +391,26 @@ export class Session {
   async runCommand(
     commandOrParams: string | RunCommandParams,
     args?: string[],
-    opts?: { signal?: AbortSignal },
+    opts?: { signal?: AbortSignal; timeoutMs?: number },
   ): Promise<Command | CommandFinished> {
     "use step";
     const client = await this.ensureClient();
     const params: RunCommandParams =
       typeof commandOrParams === "string"
-        ? { cmd: commandOrParams, args, signal: opts?.signal }
+        ? {
+            cmd: commandOrParams,
+            args,
+            signal: opts?.signal,
+            timeoutMs: opts?.timeoutMs,
+          }
         : commandOrParams;
+
+    if (params.detached && params.timeoutMs !== undefined) {
+      throw new TypeError(
+        "`timeoutMs` cannot be used with `detached: true`; the command must be awaited for the timeout to apply.",
+      );
+    }
+
     const wait = params.detached ? false : true;
     const pipeLogs = async (command: Command): Promise<void> => {
       if (!params.stdout && !params.stderr) {
@@ -422,6 +442,7 @@ export class Session {
         env: params.env ?? {},
         sudo: params.sudo ?? false,
         wait: true,
+        timeout: params.timeoutMs,
         signal: params.signal,
       });
 

--- a/packages/vercel-sandbox/src/session.ts
+++ b/packages/vercel-sandbox/src/session.ts
@@ -65,9 +65,9 @@ export interface RunCommandParams {
    */
   signal?: AbortSignal;
   /**
-   * Maximum time in milliseconds to wait for the command to complete.
-   * When elapsed, the process is killed with SIGKILL. Cannot be combined with
-   * `detached: true`.
+   * Maximum time in milliseconds the command may run before it is killed with
+   * SIGKILL. The timeout is enforced by the sandbox at exec time, so it applies
+   * whether or not the command is awaited (including `detached: true`).
    */
   timeoutMs?: number;
 }
@@ -404,13 +404,6 @@ export class Session {
             timeoutMs: opts?.timeoutMs,
           }
         : commandOrParams;
-
-    if (params.detached && params.timeoutMs !== undefined) {
-      throw new TypeError(
-        "`timeoutMs` cannot be used with `detached: true`; the command must be awaited for the timeout to apply.",
-      );
-    }
-
     const wait = params.detached ? false : true;
     const pipeLogs = async (command: Command): Promise<void> => {
       if (!params.stdout && !params.stderr) {
@@ -471,6 +464,7 @@ export class Session {
       cwd: params.cwd,
       env: params.env ?? {},
       sudo: params.sudo ?? false,
+      timeout: params.timeoutMs,
       signal: params.signal,
     });
 


### PR DESCRIPTION
When running a command in a sandbox you currently have to wrap the call yourself with an `AbortController` + `setTimeout` to enforce a deadline. This is verbose and easy to get wrong (forgotten clear, race with `await`).

### SDK contract

`runCommand` accepts a new `timeoutMs` option. Note that it cannot be set when a command is executed with `interactive` to true.

```ts
import { Sandbox } from "@vercel/sandbox";

const sandbox = await Sandbox.get({ name: "my-sandbox" });

const result = await sandbox.runCommand({
  cmd: "python",
  args: ["train.py"],
  timeoutMs: 30_000, // kill with SIGKILL after 30s
});
```

It's also exposed on the convenience overload:

```ts
await sandbox.runCommand("sleep", ["60"], { timeoutMs: 5_000 });
```

### CLI contract

`sandbox exec` gets a `--timeout` flag that accepts a duration string (e.g. `30s`, `5m`). It cannot be combined with `--interactive`.

```sh
> sandbox exec my-sandbox --timeout 3s -- sleep 10
Command was killed (SIGKILL, exit code 137).
```