### PR TITLE
fix(sandbox): make interactive connect resilient on stopped/resumed sandboxes

### DIFF
--- a/.changeset/fix-interactive-connect-resume.md
+++ b/.changeset/fix-interactive-connect-resume.md
@@ -1,0 +1,5 @@
+---
+"sandbox": patch
+---
+
+Fix `sandbox connect` hanging or failing on a stopped/resumed sandbox. The interactive shell now surfaces `attach()` failures instead of swallowing them once the connection handshake lands, always stops the spinner on teardown (so a failure can no longer hang the process), and includes the in-sandbox server's stderr when the interactive server exits early. The in-sandbox `vc-interactive-server` also health-checks a reused server before trusting a leftover config file, so a stale `/tmp/vercel/interactive/config.json` restored from a snapshot no longer causes it to connect to a dead socket.

--- a/packages/pty-tunnel-server/modes/remote.go
+++ b/packages/pty-tunnel-server/modes/remote.go
@@ -33,10 +33,46 @@ var _ Bootstrapper = (*ExternalProcessBootstrapper)(nil)
 // GetOrCreateServer implements Bootstrapper.
 func (e *ExternalProcessBootstrapper) GetOrCreateServer() (info config.ServerInfo, err error) {
 	info, err = config.VerifyConnection(e.ConfigPath)
-	if err != nil {
-		return e.spawnServer()
+	if err == nil {
+		// A live PID is not sufficient evidence that the server is usable. Across
+		// a snapshot/resume the config file is restored from the snapshot while
+		// the original server process is gone: the recorded PID may have been
+		// reused by an unrelated process, or a memory-restored daemon may no
+		// longer be serving.
+		if healthErr := e.pingServer(info.Port); healthErr == nil {
+			return info, nil
+		} else {
+			e.Logger.Info(
+				"Existing server config is stale (failed health check), spawning a new server",
+				"port", info.Port,
+				"pid", info.PID,
+				"error", healthErr,
+			)
+		}
 	}
-	return
+	return e.spawnServer()
+}
+
+func (e *ExternalProcessBootstrapper) pingServer(port int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	url := fmt.Sprintf("http://localhost:%d/health", port)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d", res.StatusCode)
+	}
+	return nil
 }
 
 func (e *ExternalProcessBootstrapper) spawnServer() (info config.ServerInfo, err error) {
@@ -65,6 +101,11 @@ func (e *ExternalProcessBootstrapper) spawnServer() (info config.ServerInfo, err
 
 	basename := path.Join(os.TempDir(), fmt.Sprintf("pty-tunnel-server-%d", time.Now().Nanosecond()))
 	e.Logger.Debug("Creating temporary files for server stdout/stderr", "basename", basename)
+
+	// Remove any leftover config before starting the new server.
+	if rmErr := os.Remove(e.ConfigPath); rmErr != nil && !os.IsNotExist(rmErr) {
+		e.Logger.Debug("Could not remove stale server config", "path", e.ConfigPath, "error", rmErr)
+	}
 
 	e.Logger.Info("Spawning new pty-tunnel-server process", "args", cmd.Args)
 	cmd.SysProcAttr = &syscall.SysProcAttr{

--- a/packages/sandbox/src/commands/exec.ts
+++ b/packages/sandbox/src/commands/exec.ts
@@ -114,6 +114,9 @@ export const exec = cmd.command({
             projectId: project,
             teamId: team,
             token,
+            // Resume up front so the sandbox is already running by the time the
+            // interactive-shell setup runs its parallel steps.
+            resume: true,
             __includeSystemRoutes: true,
           });
 

--- a/packages/sandbox/src/interactive-shell/interactive-shell.ts
+++ b/packages/sandbox/src/interactive-shell/interactive-shell.ts
@@ -193,7 +193,7 @@ export async function startInteractiveShell(options: {
 
   using progress = acquireRelease(
     () => ora({ discardStdin: false }).start(),
-    (s) => s.clear(),
+    (s) => s.stop(),
   );
 
   progress.text = "Setting up sandbox environment";
@@ -226,7 +226,12 @@ export async function startInteractiveShell(options: {
   });
 
   await Promise.all([
-    throwIfCommandPrematurelyExited(command, waitForProcess.signal),
+    // `throwIfCommandPrematurelyExited` rejects with an abort error once the
+    // connection is established; swallow only that interruption (a genuine
+    // premature exit is thrown before the abort and still propagates).
+    throwIfCommandPrematurelyExited(command, waitForProcess.signal).catch(
+      waitForProcess.ignoreInterruptions,
+    ),
     attach({
       sandbox: options.sandbox,
       progress,
@@ -237,28 +242,40 @@ export async function startInteractiveShell(options: {
           printCommand(options.execution[0], options.execution.slice(1)),
         ),
     }),
-  ]).catch(waitForProcess.ignoreInterruptions);
+  ]);
 }
 
 async function throwIfCommandPrematurelyExited(
   command: Command,
   signal: AbortSignal,
 ) {
+  let exitCode: number;
   try {
-    const { exitCode } = await command.wait({ signal });
-    throw new Error(
-      [
-        `Interactive shell failed to start (exit code: ${exitCode}).`,
-        `${chalk.bold("hint:")} The sandbox may have timed out or encountered an error.`,
-        "╰▶ Check sandbox status with `sandbox list` or view logs for details.",
-      ].join("\n"),
-    );
+    ({ exitCode } = await command.wait({ signal }));
   } catch (err) {
     if (signal.aborted) {
       return;
     }
     throw err;
   }
+
+  // The interactive server process exited before a connection was established.
+  // Surface its stderr.
+  let serverError = "";
+  try {
+    serverError = (await command.stderr({ signal })).trim();
+  } catch {
+    // Best-effort: never let reading the failure output mask the real error.
+  }
+
+  throw new Error(
+    [
+      `Interactive shell failed to start (exit code: ${exitCode}).`,
+      `${chalk.bold("hint:")} The sandbox may have timed out or encountered an error.`,
+      ...(serverError ? [chalk.dim(serverError)] : []),
+      "╰▶ Check sandbox status with `sandbox list` or view logs for details.",
+    ].join("\n"),
+  );
 }
 
 async function attach({

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -938,6 +938,10 @@ export class Sandbox {
       resume: true,
       signal,
     });
+    // Do not update the session if it was not resumed.
+    if (!response.json.resumed && this.session) {
+      return;
+    }
     this.session = new Session({
       client,
       routes: response.json.routes,

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -938,10 +938,6 @@ export class Sandbox {
       resume: true,
       signal,
     });
-    // Do not update the session if it was not resumed.
-    if (!response.json.resumed && this.session) {
-      return;
-    }
     this.session = new Session({
       client,
       routes: response.json.routes,


### PR DESCRIPTION
## Problem

`sandbox connect` (and interactive `sandbox exec`) could hang indefinitely on `Waiting for connection...`, or fail in a confusing way, when run against a stopped sandbox that has to be resumed. It worked reliably against an already-running sandbox, which is why it only showed up intermittently after a stop/resume.

Several independent issues combined to produce this:

1. **Real connection errors were swallowed.** Once the connection handshake landed, the abort signal that stops the "did the command exit early?" check was *also* used to filter errors from `attach()`. So any failure that happened after the handshake (for example, the resumed session not yet exposing a route for the interactive port) was silently discarded instead of surfaced.

2. **The spinner kept the process alive.** The progress spinner's teardown called `ora.clear()`, which only erases the current frame but leaves its render interval running. That timer keeps Node's event loop alive, so on any early teardown the CLI would sit forever on the spinner instead of exiting.

3. **Early server exits were opaque.** When the in-sandbox interactive server exited before connecting, the CLI showed a generic "may have timed out" hint with no detail.

4. **The in-sandbox server trusted a stale config.** `pty-tunnel-server` decided whether a server was already running purely from a leftover config file and a liveness check on its recorded PID. Across a snapshot/resume that config is restored from the snapshot while the original process is gone, so a coincidentally-reused PID made it connect to a dead socket and exit.

## Solution

- Stop funneling `attach()` through the connection-established abort filter, so genuine connection failures propagate instead of being swallowed.
- Always `stop()` the spinner on teardown (not just `clear()`), so a failure before the connection is established can no longer hang the process.
- Include the in-sandbox server's stderr in the error when it exits before connecting, so the real cause is visible.
- Have `pty-tunnel-server` health-check a server before reusing it, and remove any leftover config before spawning a new one, so a stale config restored from a snapshot can no longer cause a connection to a dead socket.

Together these turn the previous silent hang into either a working connection or a fast, legible error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)