### PR TITLE
Upgrade @vercel/sandbox to Zod 4

### DIFF
--- a/.changeset/nervous-socks-breathe.md
+++ b/.changeset/nervous-socks-breathe.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Upgrade Zod to v4 and update validators for Zod 4 compatibility.

--- a/packages/vercel-sandbox/package.json
+++ b/packages/vercel-sandbox/package.json
@@ -63,7 +63,7 @@
     "tar-stream": "3.1.7",
     "undici": "^7.16.0",
     "xdg-app-paths": "5.1.0",
-    "zod": "3.24.4"
+    "zod": "^4.1.1"
   },
   "devDependencies": {
     "@types/async-retry": "1.4.9",

--- a/packages/vercel-sandbox/src/api-client/validators.ts
+++ b/packages/vercel-sandbox/src/api-client/validators.ts
@@ -23,7 +23,7 @@ const RuleMatchValidator = z.object({
 export const InjectionRuleValidator = z.object({
   domain: z.string(),
   // headers are only sent in requests
-  headers: z.record(z.string()).optional(),
+  headers: z.record(z.string(), z.string()).optional(),
   // headerNames are returned in responses
   headerNames: z.array(z.string()).optional(),
   match: RuleMatchValidator.optional(),
@@ -36,7 +36,7 @@ export const ForwardRuleValidator = z.object({
 });
 
 export const NetworkPolicyTransformValidator = z.object({
-  headers: z.record(z.string()).optional(),
+  headers: z.record(z.string(), z.string()).optional(),
 });
 
 export const NetworkPolicyRuleValidator = z.object({
@@ -49,7 +49,7 @@ export const V2NetworkPolicyObjectValidator = z.object({
   allow: z
     .union([
       z.array(z.string()),
-      z.record(z.array(NetworkPolicyRuleValidator)),
+      z.record(z.string(), z.array(NetworkPolicyRuleValidator)),
     ])
     .optional(),
   subnets: z
@@ -262,7 +262,7 @@ export const Sandbox = z.object({
   status: Session.shape.status,
   statusUpdatedAt: z.number().optional(),
   cwd: z.string().optional(),
-  tags: z.record(z.string()).optional(),
+  tags: z.record(z.string(), z.string()).optional(),
   snapshotExpiration: z.number().optional(),
   keepLastSnapshots: z
     .object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,8 +418,8 @@ importers:
         specifier: 5.1.0
         version: 5.1.0
       zod:
-        specifier: 3.24.4
-        version: 3.24.4
+        specifier: ^4.1.1
+        version: 4.3.6
     devDependencies:
       '@types/async-retry':
         specifier: 1.4.9
@@ -6086,9 +6086,6 @@ packages:
     resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
     peerDependencies:
       zod: ^3.24.1
-
-  zod@3.24.4:
-    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
 
   zod@3.25.67:
     resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
@@ -12334,8 +12331,6 @@ snapshots:
   zod-to-json-schema@3.24.6(zod@4.3.6):
     dependencies:
       zod: 4.3.6
-
-  zod@3.24.4: {}
 
   zod@3.25.67: {}
 


### PR DESCRIPTION
## Summary

Upgrade `@vercel/sandbox` from Zod 3 to Zod 4 and update record validators for the Zod 4 API.

Zod 3 allowed single-argument `z.record(valueSchema)`. Zod 4 requires both key and value schemas, so the existing validators now use `z.record(z.string(), ...)` to preserve behavior.

## Why

Zod 4 is stable and Zod 3 is functionally end-of-life. Keeping the SDK on Zod 3 can cause friction for projects already standardized on Zod 4, especially through generated TypeScript declarations and duplicated Zod major versions.

This came up while fixing Zod 3/4 compatibility friction in https://github.com/vercel/omniagent/pull/742.

## Compatibility

This should be behavior-preserving for runtime validation. `z.record(z.string())` in Zod 3 validated string values with default string keys, so the Zod 4 equivalent is `z.record(z.string(), z.string())`.

`zod` remains a direct dependency because the SDK uses it internally rather than accepting user-provided Zod schemas.

## Testing

- `pnpm --filter @vercel/sandbox typecheck`
- `pnpm --filter @vercel/sandbox test`
- `pnpm --filter @vercel/sandbox build`