### PR TITLE
patch(vercel-sandbox,sandbox): improve CLI auth error messages and do not fail when a team is invalid

### DIFF
--- a/.changeset/mask-scope-inference-errors.md
+++ b/.changeset/mask-scope-inference-errors.md
@@ -1,0 +1,6 @@
+---
+"@vercel/sandbox": patch
+"sandbox": patch
+---
+
+Fix scope inference failing with a raw Zod validation error. Teams missing `updatedAt` are now kept and malformed team entries are skipped. The CLI also no longer leaks raw validation details when scope can't be determined, showing a friendly hint instead. OAuth response parse failures are masked the same way.

--- a/packages/sandbox/src/args/scope.ts
+++ b/packages/sandbox/src/args/scope.ts
@@ -118,7 +118,8 @@ export const scope: ArgParser<{
         teamSlug = scope.ownerSlug;
       } catch (err) {
         debug("scope inference failed: %O", err);
-        const detail = err instanceof NotOk ? ` ${err.message}` : "";
+        const detail =
+          err instanceof NotOk ? ` ${err.response.responseText}` : "";
         return {
           _tag: "error",
           error: {

--- a/packages/sandbox/src/args/scope.ts
+++ b/packages/sandbox/src/args/scope.ts
@@ -4,7 +4,11 @@ import type { ArgParser } from "cmd-ts/dist/esm/argparser";
 import { inferScope } from "../util/infer-scope";
 import { withFreshAuthRetry } from "../util/fresh-auth-retry";
 import type { ProvidesHelp } from "cmd-ts/dist/esm/helpdoc";
+import { NotOk } from "@vercel/sandbox/dist/auth/index.js";
 import chalk from "chalk";
+import createDebugger from "debug";
+
+const debug = createDebugger("sandbox:scope");
 
 const project = cmd.option({
   long: "project",
@@ -113,6 +117,8 @@ export const scope: ArgParser<{
         projectSlug = scope.projectSlug;
         teamSlug = scope.ownerSlug;
       } catch (err) {
+        debug("scope inference failed: %O", err);
+        const detail = err instanceof NotOk ? ` ${err.message}` : "";
         return {
           _tag: "error",
           error: {
@@ -120,7 +126,7 @@ export const scope: ArgParser<{
               {
                 nodes,
                 message: [
-                  `Could not determine team/project scope: ${(err as Error).message}.`,
+                  `Could not determine team/project scope.${detail}`,
                   `${chalk.bold("hint:")} Specify explicitly with --scope TEAM_SLUG --project PROJECT_NAME, or set VERCEL_OIDC_TOKEN.`,
                   "╰▶ Docs: https://vercel.com/docs/sandbox",
                 ].join("\n"),

--- a/packages/vercel-sandbox/src/auth/infer-scope.test.ts
+++ b/packages/vercel-sandbox/src/auth/infer-scope.test.ts
@@ -400,7 +400,7 @@ describe("inferScope", () => {
       });
 
       await expect(inferScope({ token: "token" })).rejects.toThrowError(
-        /Authenticated as "my-user" but none of the available teams allow sandbox creation\. Specify a team explicitly with --scope/,
+        /Authenticated as "my-user" but none of the available teams allow sandbox creation\./,
       );
     });
 

--- a/packages/vercel-sandbox/src/auth/infer-scope.test.ts
+++ b/packages/vercel-sandbox/src/auth/infer-scope.test.ts
@@ -144,6 +144,56 @@ describe("team selection from paginated results", () => {
     expect(scope.teamId).toBe("team_good");
   });
 
+  test("keeps a team that is missing updatedAt (limited-access DTO)", async () => {
+    fetchApiMock.mockImplementation(
+      mockUserAndTeams({
+        defaultTeamId: null,
+        username: "my-user",
+        // The limited-access team DTO omits `updatedAt`. The team must still be
+        // selectable rather than failing the whole page.
+        teams: [
+          {
+            id: "team_personal",
+            slug: "my-user",
+            membership: { role: "OWNER" },
+            billing: { plan: "hobby" },
+          } as never,
+        ],
+      }),
+    );
+
+    const scope = await inferScope({ token: "token" });
+    expect(scope.teamId).toBe("team_personal");
+  });
+
+  test("skips malformed team entries instead of throwing", async () => {
+    fetchApiMock.mockImplementation(async ({ endpoint }) => {
+      if (endpoint === "/v2/user") {
+        return { user: { defaultTeamId: null, username: "my-user" } };
+      }
+      if (endpoint.startsWith("/v2/teams")) {
+        return {
+          teams: [
+            // Fully malformed entry (missing membership/billing) — must be dropped.
+            { id: "team_broken", slug: "broken" },
+            {
+              id: "team_good",
+              slug: "good-team",
+              updatedAt: 100,
+              membership: { role: "OWNER" },
+              billing: { plan: "hobby" },
+            },
+          ],
+          pagination: { count: 2, next: null },
+        };
+      }
+      return {};
+    });
+
+    const scope = await inferScope({ token: "token" });
+    expect(scope.teamId).toBe("team_good");
+  });
+
   test("falls back to username when no hobby owner teams found", async () => {
     fetchApiMock.mockImplementation(
       mockUserAndTeams({

--- a/packages/vercel-sandbox/src/auth/oauth.ts
+++ b/packages/vercel-sandbox/src/auth/oauth.ts
@@ -290,8 +290,9 @@ class OAuthError extends Error {
     super(message);
     const error = processOAuthErrorResponse(response);
     if (error instanceof TypeError) {
-      const message = `Unexpected server response: ${JSON.stringify(response)}`;
-      this.cause = new Error(message, { cause: error });
+      this.cause = new Error(
+        "Unexpected response from the Vercel authorization server.",
+      );
       this.code = "server_error";
       return;
     }

--- a/packages/vercel-sandbox/src/auth/oauth.ts
+++ b/packages/vercel-sandbox/src/auth/oauth.ts
@@ -84,7 +84,7 @@ export async function OAuth() {
 
       if (!parsed.success) {
         throw new OAuthError(
-          `Failed to parse device authorization response: ${parsed.error.message}`,
+          "Failed to parse device authorization response from the Vercel authorization server.",
           json,
         );
       }
@@ -146,7 +146,7 @@ export async function OAuth() {
       if (!processed.success) {
         return [
           new OAuthError(
-            `Failed to parse token response: ${processed.error.message}`,
+            "Failed to parse token response from the Vercel authorization server.",
             json,
           ),
         ];
@@ -219,7 +219,7 @@ export async function OAuth() {
       const processed = IntrospectionResponse.safeParse(json);
       if (!processed.success) {
         throw new OAuthError(
-          `Failed to parse introspection response: ${processed.error.message}`,
+          "Failed to parse introspection response from the Vercel authorization server.",
           json,
         );
       }

--- a/packages/vercel-sandbox/src/auth/project.ts
+++ b/packages/vercel-sandbox/src/auth/project.ts
@@ -164,7 +164,7 @@ export async function inferScope(opts: {
 
   throw new NotOk({
     statusCode: 403,
-    responseText: `Authenticated as "${username}" but none of the available teams allow sandbox creation. Specify a team explicitly with --scope <team-id-or-slug>.`,
+    responseText: `Authenticated as "${username}" but none of the available teams allow sandbox creation.`,
   });
 }
 

--- a/packages/vercel-sandbox/src/auth/project.ts
+++ b/packages/vercel-sandbox/src/auth/project.ts
@@ -13,7 +13,7 @@ const UserSchema = z.object({
 const TeamSchema = z.object({
   id: z.string(),
   slug: z.string(),
-  updatedAt: z.number(),
+  updatedAt: z.number().optional(),
   membership: z.object({
     role: z.string(),
   }),
@@ -23,7 +23,15 @@ const TeamSchema = z.object({
 });
 
 const TeamsSchema = z.object({
-  teams: z.array(TeamSchema),
+  // Parse each team independently and drop any that don't validate, so a single
+  // malformed/limited team entry can never break candidate selection for the
+  // whole page.
+  teams: z.array(z.unknown()).transform((entries) =>
+    entries.flatMap((entry) => {
+      const parsed = TeamSchema.safeParse(entry);
+      return parsed.success ? [parsed.data] : [];
+    }),
+  ),
   pagination: z.object({
     count: z.number(),
     next: z.number().nullable(),
@@ -134,7 +142,7 @@ export async function inferScope(opts: {
 
     const bestHobbyTeam =
       hobbyOwnerTeams.find((t) => t.slug === username) ??
-      hobbyOwnerTeams.sort((a, b) => b.updatedAt - a.updatedAt)[0];
+      hobbyOwnerTeams.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))[0];
 
     if (bestHobbyTeam && bestHobbyTeam.id !== defaultTeamId) {
       try {


### PR DESCRIPTION
Small improvements:
- Do not fail when a team is not valid and does not pass the Zod validations. Continue processing the other teams.
- Do not fail when a team has no `updatedAt`. When customer has limited privileges over a team, they do not get this field. Now it is marked as optional.
- Mask the internal error when authenticating.