### PR TITLE
Improve cli errors

### DIFF
--- a/.changeset/pretty-timeout-and-api-errors.md
+++ b/.changeset/pretty-timeout-and-api-errors.md
@@ -2,4 +2,4 @@
 "sandbox": patch
 ---
 
-Prettify timeout and API errors. The CLI now renders any API error (400/4xx/5xx) from any command, plus request timeouts, aborts and stream interruptions, with the consistent styled layout instead of dumping a raw stack trace. Unknown errors print a single line; set `DEBUG=sandbox:errors` to see the full stack.
+Prettify timeout and API errors. Unknown errors print a single line; set `DEBUG=sandbox:errors` to see the full stack.

--- a/.changeset/pretty-timeout-and-api-errors.md
+++ b/.changeset/pretty-timeout-and-api-errors.md
@@ -1,0 +1,5 @@
+---
+"sandbox": patch
+---
+
+Prettify timeout and API errors. The CLI now renders any API error (400/4xx/5xx) from any command, plus request timeouts, aborts and stream interruptions, with the consistent styled layout instead of dumping a raw stack trace. Unknown errors print a single line; set `DEBUG=sandbox:errors` to see the full stack.

--- a/packages/sandbox/src/client.ts
+++ b/packages/sandbox/src/client.ts
@@ -1,12 +1,7 @@
 import { Sandbox, APIError, Snapshot } from "@vercel/sandbox";
 import { version } from "./pkg";
-import chalk from "chalk";
-import { tmpdir } from "node:os";
-import Path from "node:path";
-import { writeFile } from "node:fs/promises";
-import { StyledError } from "./error";
 import { withFreshAuthRetry } from "./util/fresh-auth-retry";
-import { z } from "zod";
+import { formatApiError } from "./util/format-error";
 
 /**
  * A {@link Sandbox} wrapper that adds user-agent headers and error handling.
@@ -70,63 +65,8 @@ async function withErrorHandling<T>(factory: () => Promise<T>): Promise<T> {
     return await withFreshAuthRetry(factory);
   } catch (error) {
     if (error instanceof APIError) {
-      return await handleApiError(error);
+      throw await formatApiError(error);
     }
     throw error;
   }
-}
-
-async function handleApiError(error: APIError<unknown>): Promise<never> {
-  const tmpPath = await writeResponseToTemp(error);
-  const status = error.response.status;
-  const parsedError = ApiErrorResponse.safeParse(error.json);
-  const message = parsedError.data?.error.message ?? getErrorMessage(status);
-  const lines = [
-    message,
-    `├▶ requested url: ${error.response.url}`,
-    `├▶ status code: ${status} ${error.response.statusText}`,
-    `╰▶ ${chalk.bold("hint:")} the full response buffer is stored in ${chalk.italic(tmpPath)}`,
-  ];
-  throw new StyledError(lines.join("\n"), error);
-}
-
-const ApiErrorResponse = z.object({
-  error: z.object({
-    message: z.string(),
-  }),
-});
-
-function getErrorMessage(status: number): string {
-  if (status === 401 || status === 403) {
-    return "Sandbox API request failed due to authentication. Check your token or run `sandbox login`.";
-  }
-  if (status === 404) {
-    return "Sandbox API request failed: resource not found.";
-  }
-  if (status >= 500) {
-    return "Sandbox API responded with a server error. Please try again.";
-  }
-  return "Sandbox API request failed.";
-}
-
-async function writeResponseToTemp({
-  response,
-  text,
-}: APIError<unknown>): Promise<string> {
-  const unique = [process.pid, process.hrtime.bigint()]
-    .map((x) => x.toString(36))
-    .join("");
-  const tmpPath = Path.join(tmpdir(), `sandbox-cli-response-${unique}.http`);
-  const buffers = [] as Buffer[];
-  buffers.push(Buffer.from(`${response.url}\r\n`));
-  buffers.push(Buffer.from(`${response.status} ${response.statusText}\r\n`));
-  for (const [key, value] of response.headers) {
-    buffers.push(Buffer.from(`${key}: ${value}\r\n`));
-  }
-  buffers.push(Buffer.from(`\r\n`));
-  if (text) {
-    buffers.push(Buffer.from(text));
-  }
-  await writeFile(tmpPath, Buffer.concat(buffers));
-  return tmpPath;
 }

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1,7 +1,7 @@
 import { run, setDefaultHelpFormatter } from "cmd-ts";
 import { app } from "./app";
 import dotenv from "dotenv-flow";
-import { StyledError } from "./error";
+import { printTopLevelError } from "./util/format-error";
 import { vercelFormatter } from "cmd-ts/batteries/vercel-formatter";
 
 dotenv.config({
@@ -25,13 +25,7 @@ async function main() {
 
     await run(app(), args);
   } catch (e) {
-    if (e instanceof StyledError) {
-      console.error();
-      console.error(e.message);
-      process.exit(1);
-    }
-
-    console.error(e);
+    await printTopLevelError(e);
     process.exit(1);
   }
 }

--- a/packages/sandbox/src/util/format-error.test.ts
+++ b/packages/sandbox/src/util/format-error.test.ts
@@ -1,0 +1,134 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from "vitest";
+import { APIError, StreamError } from "@vercel/sandbox";
+import {
+  isApiTimeoutError,
+  formatApiError,
+  formatApiTimeoutError,
+  formatStreamError,
+  printTopLevelError,
+} from "./format-error";
+import { StyledError } from "../error";
+
+function makeApiError(status: number, json?: unknown): APIError<unknown> {
+  return new APIError(
+    new Response("", { status, statusText: status === 400 ? "Bad Request" : "Error" }),
+    { json },
+  );
+}
+
+describe("isApiTimeoutError", () => {
+  it("detects DOMException-style TimeoutError / AbortError", () => {
+    expect(isApiTimeoutError({ name: "TimeoutError" })).toBe(true);
+    expect(isApiTimeoutError({ name: "AbortError" })).toBe(true);
+  });
+
+  it("detects node ETIMEDOUT", () => {
+    expect(isApiTimeoutError({ code: "ETIMEDOUT" })).toBe(true);
+  });
+
+  it("detects undici connect/headers timeouts via cause.code", () => {
+    expect(isApiTimeoutError({ cause: { code: "UND_ERR_CONNECT_TIMEOUT" } })).toBe(
+      true,
+    );
+    expect(isApiTimeoutError({ cause: { code: "UND_ERR_HEADERS_TIMEOUT" } })).toBe(
+      true,
+    );
+  });
+
+  it("detects the `fetch failed` TypeError wrapper", () => {
+    const err = new TypeError("fetch failed");
+    (err as { cause?: unknown }).cause = { code: "UND_ERR_CONNECT_TIMEOUT" };
+    expect(isApiTimeoutError(err)).toBe(true);
+  });
+
+  it("returns false for unrelated errors and non-objects", () => {
+    expect(isApiTimeoutError(new Error("boom"))).toBe(false);
+    expect(isApiTimeoutError({ name: "TypeError", message: "fetch failed" })).toBe(
+      false,
+    );
+    expect(isApiTimeoutError(undefined)).toBe(false);
+    expect(isApiTimeoutError("nope")).toBe(false);
+  });
+});
+
+describe("formatApiError", () => {
+  it("uses the server-provided message when present", async () => {
+    const styled = await formatApiError(
+      makeApiError(400, { error: { message: "name already in use" } }),
+    );
+    expect(styled).toBeInstanceOf(StyledError);
+    expect(styled.message).toContain("name already in use");
+    expect(styled.message).toContain("status code: 400");
+    expect(styled.message).toContain("hint:");
+  });
+
+  it("falls back to a 400 message and keeps the APIError as cause", async () => {
+    const apiError = makeApiError(400);
+    const styled = await formatApiError(apiError);
+    expect(styled.message).toContain("the request was invalid (400)");
+    expect(styled.cause).toBe(apiError);
+  });
+});
+
+describe("formatApiTimeoutError / formatStreamError", () => {
+  it("formats a timeout", () => {
+    const styled = formatApiTimeoutError({ name: "TimeoutError" });
+    expect(styled).toBeInstanceOf(StyledError);
+    expect(styled.message).toContain("timed out");
+  });
+
+  it("formats a stream error with code and session", () => {
+    const styled = formatStreamError(
+      new StreamError("sandbox_stopped", "stream ended", "sess_123"),
+    );
+    expect(styled.message).toContain("sandbox_stopped");
+    expect(styled.message).toContain("sess_123");
+  });
+});
+
+describe("printTopLevelError", () => {
+  let errorSpy: MockInstance;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  function output(): string {
+    return errorSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n");
+  }
+
+  it("prints a StyledError message verbatim", async () => {
+    await printTopLevelError(new StyledError("already pretty"));
+    expect(output()).toContain("already pretty");
+  });
+
+  it("routes an APIError through the pretty formatter", async () => {
+    await printTopLevelError(makeApiError(400));
+    expect(output()).toContain("the request was invalid (400)");
+  });
+
+  it("routes a timeout through the timeout formatter", async () => {
+    await printTopLevelError({ name: "TimeoutError" });
+    expect(output()).toContain("timed out");
+  });
+
+  it("prints a single line for unknown errors without the raw object", async () => {
+    await printTopLevelError(new Error("boom"));
+    const printed = output();
+    expect(printed).toContain("boom");
+    // The raw Error object is not printed unless DEBUG=sandbox:errors.
+    expect(errorSpy.mock.calls.some((c) => c[0] instanceof Error)).toBe(false);
+  });
+});

--- a/packages/sandbox/src/util/format-error.ts
+++ b/packages/sandbox/src/util/format-error.ts
@@ -1,0 +1,171 @@
+import { APIError, StreamError } from "@vercel/sandbox";
+import chalk from "chalk";
+import createDebugger from "debug";
+import { tmpdir } from "node:os";
+import Path from "node:path";
+import { writeFile } from "node:fs/promises";
+import { z } from "zod";
+import { StyledError } from "../error";
+
+const debug = createDebugger("sandbox:errors");
+
+const ApiErrorResponse = z.object({
+  error: z.object({
+    message: z.string(),
+  }),
+});
+
+/**
+ * Formats an {@link APIError} into a {@link StyledError} with the pretty
+ * multi-line layout used across the CLI.
+ */
+export async function formatApiError(
+  error: APIError<unknown>,
+): Promise<StyledError> {
+  const tmpPath = await writeResponseToTemp(error);
+  const status = error.response.status;
+  const parsedError = ApiErrorResponse.safeParse(error.json);
+  const message = parsedError.data?.error.message ?? getErrorMessage(status);
+  const lines = [
+    message,
+    `├▶ requested url: ${error.response.url}`,
+    `├▶ status code: ${status} ${error.response.statusText}`,
+    `╰▶ ${chalk.bold("hint:")} the full response buffer is stored in ${chalk.italic(tmpPath)}`,
+  ];
+  return new StyledError(lines.join("\n"), error);
+}
+
+function getErrorMessage(status: number): string {
+  if (status === 400) {
+    return "Sandbox API request failed: the request was invalid (400). Check the command arguments and try again.";
+  }
+  if (status === 401 || status === 403) {
+    return "Sandbox API request failed due to authentication. Check your token or run `sandbox login`.";
+  }
+  if (status === 404) {
+    return "Sandbox API request failed: resource not found.";
+  }
+  if (status === 429) {
+    return "Sandbox API rate limit exceeded (429). Please wait and try again.";
+  }
+  if (status >= 500) {
+    return "Sandbox API responded with a server error. Please try again.";
+  }
+  return "Sandbox API request failed.";
+}
+
+async function writeResponseToTemp({
+  response,
+  text,
+}: APIError<unknown>): Promise<string> {
+  const unique = [process.pid, process.hrtime.bigint()]
+    .map((x) => x.toString(12))
+    .join("");
+  const tmpPath = Path.join(tmpdir(), `sandbox-cli-response-${unique}.http`);
+
+  const buffers = [] as Buffer[];
+  buffers.push(Buffer.from(`${response.url}\r\n`));
+  buffers.push(Buffer.from(`${response.status} ${response.statusText}\r\n`));
+  for (const [key, value] of response.headers) {
+    buffers.push(Buffer.from(`${key}: ${value}\r\n`));
+  }
+  buffers.push(Buffer.from(`\r\n`));
+  if (text) {
+    buffers.push(Buffer.from(text));
+  }
+
+  await writeFile(tmpPath, Buffer.concat(buffers));
+  return tmpPath;
+}
+
+/**
+ * Detects network-level timeouts when talking to the Sandbox API.
+ */
+export function isApiTimeoutError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const e = error as {
+    name?: string;
+    code?: string;
+    message?: string;
+    cause?: unknown;
+  };
+  if (e.name === "TimeoutError" || e.name === "AbortError") {
+    return true;
+  }
+  if (e.code === "ETIMEDOUT") {
+    return true;
+  }
+
+  const causeCode = (e.cause as { code?: string } | undefined)?.code;
+  if (
+    causeCode === "UND_ERR_CONNECT_TIMEOUT" ||
+    causeCode === "UND_ERR_HEADERS_TIMEOUT"
+  ) {
+    return true;
+  }
+
+  // undici wraps the underlying error: `TypeError: fetch failed` -> cause.
+  if (e.name === "TypeError" && e.message === "fetch failed") {
+    return isApiTimeoutError(e.cause);
+  }
+  return false;
+}
+
+export function formatApiTimeoutError(error: unknown): StyledError {
+  return new StyledError(
+    [
+      "The request to the Sandbox API timed out.",
+      `╰▶ ${chalk.bold("hint:")} check your network connection and try again.`,
+    ].join("\n"),
+    error,
+  );
+}
+
+export function formatStreamError(error: StreamError): StyledError {
+  return new StyledError(
+    [
+      "The sandbox stream was interrupted.",
+      `├▶ code: ${error.code}`,
+      `├▶ session: ${error.sessionId}`,
+      `╰▶ ${chalk.bold("hint:")} the sandbox may have stopped. Resume or recreate it and try again.`,
+    ].join("\n"),
+    error,
+  );
+}
+
+/**
+ * Single funnel for every error that reaches the CLI's top-level catch.
+ */
+export async function printTopLevelError(e: unknown): Promise<void> {
+  const styled = await toStyledError(e);
+
+  console.error();
+  if (styled) {
+    console.error(styled.message);
+  } else {
+    console.error(chalk.red(e instanceof Error ? e.message : String(e)));
+    // Surface the raw error (object + stack) only when explicitly debugging.
+    if (debug.enabled) {
+      console.error(e);
+    }
+  }
+}
+
+async function toStyledError(e: unknown): Promise<StyledError | null> {
+  if (e instanceof StyledError) {
+    return e;
+  }
+  if (e instanceof APIError) {
+    return formatApiError(e);
+  }
+  if (e instanceof StreamError) {
+    return formatStreamError(e);
+  }
+  if (isApiTimeoutError(e)) {
+    return formatApiTimeoutError(e);
+  }
+  return null;
+}

--- a/packages/sandbox/src/util/format-error.ts
+++ b/packages/sandbox/src/util/format-error.ts
@@ -59,7 +59,7 @@ async function writeResponseToTemp({
   text,
 }: APIError<unknown>): Promise<string> {
   const unique = [process.pid, process.hrtime.bigint()]
-    .map((x) => x.toString(12))
+    .map((x) => x.toString(36))
     .join("");
   const tmpPath = Path.join(tmpdir(), `sandbox-cli-response-${unique}.http`);
 


### PR DESCRIPTION
Improve the CLI errors by:

- Adding a top handler, so that when the CLI errors at the top-level, we still try to stylize the error and even when we can't, we try to show a friendly error.
- Support more error codes during API requests (e.g. 400, 429, etc.)
- Now we detect API timeouts.