### PR TITLE
docs(timeout): increase pro/hobby duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ const sandbox = await Sandbox.create({
     type: "git",
   },
   resources: { vcpus: 4 },
-  // Defaults to 5 minutes. The maximum is 5 hours for Pro/Enterprise, and 45 minutes for Hobby.
+  // Defaults to 5 minutes. The maximum is 24 hours for Pro/Enterprise, and 45 minutes for Hobby.
   timeout: ms("5m"),
   ports: [3000],
   runtime: "node24",
@@ -159,7 +159,7 @@ recreate an API client using OIDC or environment credentials when needed.
 ## Limitations
 
 - Max resources: 8 vCPUs on Hobby/Pro, 32 vCPUs on Enterprise. You will get 2048 MB of memory per vCPU.
-- Sandboxes have a maximum runtime duration of 5 hours for Pro/Enterprise and 45 minutes for Hobby,
+- Sandboxes have a maximum runtime duration of 24 hours for Pro/Enterprise and 45 minutes for Hobby,
   with a default of 5 minutes. This can be configured using the `timeout` option of `Sandbox.create()`.
 
 ## System

--- a/packages/vercel-sandbox/README.md
+++ b/packages/vercel-sandbox/README.md
@@ -174,7 +174,7 @@ const sandbox = await Sandbox.create({
     type: "git",
   },
   resources: { vcpus: 4 },
-  // Defaults to 5 minutes. The maximum is 5 hours for Pro/Enterprise, and 45 minutes for Hobby.
+  // Defaults to 5 minutes. The maximum is 24 hours for Pro/Enterprise, and 45 minutes for Hobby.
   timeout: ms("5m"),
   ports: [3000],
   runtime: "node24",
@@ -192,7 +192,7 @@ recreate an API client using OIDC or environment credentials when needed.
 ## Limitations
 
 - Max resources: 8 vCPUs. You will get 2048 MB of memory per vCPU.
-- Sandboxes have a maximum runtime duration of 5 hours for Pro/Enterprise and 45 minutes for Hobby,
+- Sandboxes have a maximum runtime duration of 24 hours for Pro/Enterprise and 45 minutes for Hobby,
   with a default of 5 minutes. This can be configured using the `timeout` option of `Sandbox.create()`.
 
 ## System

--- a/skills/sandbox/SKILL.md
+++ b/skills/sandbox/SKILL.md
@@ -791,7 +791,7 @@ const result = await sandbox.runCommand({
 | Max vCPUs       | 4 vCPUs on Hobby, 8 vCPUs on Pro, 32 vCPUs on Enterprise (2048 MB RAM per vCPU) |
 | Max ports       | 15 exposed ports                                                                |
 | Max tags        | 5 key-value tags per sandbox                                                    |
-| Max timeout     | 5 hours (Pro/Enterprise), 45 minutes (Hobby)                                    |
+| Max timeout     | 24 hours (Pro/Enterprise), 45 minutes (Hobby)                                   |
 | Default timeout | 5 minutes                                                                       |
 | Base system     | Amazon Linux 2023                                                               |
 | User context    | `vercel-sandbox` user                                                           |


### PR DESCRIPTION
We're increasing the max timeout for pro/ent sandboxes from 5h to 24h.