### PR TITLE
feat(sandbox,vercel/sandbox): support new image parameter

### DIFF
--- a/.changeset/sandbox-custom-image.md
+++ b/.changeset/sandbox-custom-image.md
@@ -1,0 +1,6 @@
+---
+"@vercel/sandbox": minor
+"sandbox": minor
+---
+
+Support creating a sandbox from a custom image via the new `image` option on `Sandbox.create` and the `--image` flag on `sandbox create` / `sandbox run`.

--- a/packages/sandbox/src/args/runtime.ts
+++ b/packages/sandbox/src/args/runtime.ts
@@ -7,7 +7,5 @@ export const runtimeType = {
 
 export const runtime = cmd.option({
   long: "runtime",
-  type: runtimeType,
-  defaultValue: () => "node24" as const,
-  defaultValueIsSerializable: true,
+  type: cmd.optional(runtimeType),
 });

--- a/packages/sandbox/src/commands/create.ts
+++ b/packages/sandbox/src/commands/create.ts
@@ -143,8 +143,9 @@ export const create = cmd.command({
           projectId: scope.project,
           token: scope.token,
           ports,
-          runtime,
-          image,
+          // `runtime` always carries its `node24` default, so only forward it
+          // when no image is given.
+          ...(image ? { image } : { runtime }),
           timeout: ms(timeout),
           resources,
           networkPolicy,

--- a/packages/sandbox/src/commands/create.ts
+++ b/packages/sandbox/src/commands/create.ts
@@ -102,6 +102,10 @@ export const create = cmd.command({
     allowedCIDRs,
     deniedCIDRs,
   }) {
+    if (image && runtime) {
+      throw new Error("--image and --runtime cannot be used together.");
+    }
+
     const networkPolicy = buildNetworkPolicy({
       networkPolicy: networkPolicyMode,
       allowedDomains,
@@ -143,9 +147,9 @@ export const create = cmd.command({
           projectId: scope.project,
           token: scope.token,
           ports,
-          // `runtime` always carries its `node24` default, so only forward it
-          // when no image is given.
-          ...(image ? { image } : { runtime }),
+          // Start from either a custom image or a runtime, never both. When
+          // neither is given, default to the `node24` runtime.
+          ...(image ? { image } : { runtime: runtime ?? "node24" }),
           timeout: ms(timeout),
           resources,
           networkPolicy,

--- a/packages/sandbox/src/commands/create.ts
+++ b/packages/sandbox/src/commands/create.ts
@@ -102,8 +102,6 @@ export const create = cmd.command({
     allowedCIDRs,
     deniedCIDRs,
   }) {
-
-
     const networkPolicy = buildNetworkPolicy({
       networkPolicy: networkPolicyMode,
       allowedDomains,

--- a/packages/sandbox/src/commands/create.ts
+++ b/packages/sandbox/src/commands/create.ts
@@ -31,7 +31,7 @@ export const args = {
   image: cmd.option({
     long: "image",
     description:
-      "A Vercel Container Registry (VCR) image to start the sandbox from (e.g. my-repo, my-repo:v1).",
+      "A Vercel Container Registry (VCR) image name and optional tag or sha to start the sandbox from (e.g. my-repo, my-repo:v1).",
     type: cmd.optional(cmd.string),
   }),
   timeout,

--- a/packages/sandbox/src/commands/create.ts
+++ b/packages/sandbox/src/commands/create.ts
@@ -28,6 +28,12 @@ export const args = {
     description: "Disable automatic restore of the filesystem between sessions.",
   }),
   runtime,
+  image: cmd.option({
+    long: "image",
+    description:
+      "A Vercel Container Registry (VCR) image to start the sandbox from (e.g. my-repo, my-repo:v1).",
+    type: cmd.optional(cmd.string),
+  }),
   timeout,
   vcpus,
   ports: publishPorts,
@@ -79,6 +85,7 @@ export const create = cmd.command({
     ports,
     scope,
     runtime,
+    image,
     timeout,
     vcpus,
     silent,
@@ -95,6 +102,8 @@ export const create = cmd.command({
     allowedCIDRs,
     deniedCIDRs,
   }) {
+
+
     const networkPolicy = buildNetworkPolicy({
       networkPolicy: networkPolicyMode,
       allowedDomains,
@@ -137,6 +146,7 @@ export const create = cmd.command({
           token: scope.token,
           ports,
           runtime,
+          image,
           timeout: ms(timeout),
           resources,
           networkPolicy,

--- a/packages/vercel-sandbox/README.md
+++ b/packages/vercel-sandbox/README.md
@@ -226,6 +226,19 @@ zstd
 - User code is executed as the `vercel-sandbox` user.
 - `/vercel/sandbox` is writable.
 
+## Custom images
+
+Instead of a stock runtime, you can start a sandbox from a Vercel Container
+Registry (VCR) image with the `image` option:
+
+```typescript
+import { Sandbox } from "@vercel/sandbox";
+
+const sandbox = await Sandbox.create({
+  image: "my-repo:v1",
+});
+```
+
 ## Sudo access
 
 The `nodeX` and `python3.13` images allow users to run commands as root. This

--- a/packages/vercel-sandbox/README.md
+++ b/packages/vercel-sandbox/README.md
@@ -239,6 +239,19 @@ const sandbox = await Sandbox.create({
 });
 ```
 
+The `image` option accepts a repository in the sandbox's project, with an
+optional tag or digest. A bare repository name resolves to the `latest` tag.
+You can also pass a fully-qualified VCR URL:
+
+```typescript
+await Sandbox.create({ image: "my-repo" }); // latest tag
+await Sandbox.create({ image: "my-repo:v1" }); // specific tag
+await Sandbox.create({ image: "my-repo@sha256:..." }); // specific digest
+await Sandbox.create({
+  image: "vcr.vercel.com/my-team/my-project/my-repo:v1", // fully-qualified
+});
+```
+
 ## Sudo access
 
 The `nodeX` and `python3.13` images allow users to run commands as root. This

--- a/packages/vercel-sandbox/src/api-client/api-client.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.ts
@@ -170,6 +170,7 @@ export class APIClient extends BaseClient {
       resources?: { vcpus: number };
       persistent?: boolean;
       runtime?: RUNTIMES | (string & {});
+      image?: string;
       networkPolicy?: NetworkPolicy;
       env?: Record<string, string>;
       tags?: Record<string, string>;
@@ -194,6 +195,7 @@ export class APIClient extends BaseClient {
           timeout: params.timeout,
           resources: params.resources,
           runtime: params.runtime,
+          image: params.image,
           name: params.name,
           persistent: params.persistent,
           networkPolicy: params.networkPolicy

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -521,7 +521,6 @@ describe("Sandbox.create image", () => {
     // Runtime must not be sent when only image is provided.
     expect(body.runtime).toBeUndefined();
   });
-
 });
 
 describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")("Sandbox", () => {

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -522,22 +522,6 @@ describe("Sandbox.create image", () => {
     expect(body.runtime).toBeUndefined();
   });
 
-  it("throws when image and runtime are both provided, without calling fetch", async () => {
-    const mockFetch = vi.fn<typeof fetch>(async () =>
-      jsonResponse(200, {}),
-    );
-
-    await expect(
-      Sandbox.create({
-        ...CREDENTIALS,
-        image: "my-repo:latest",
-        runtime: "node24",
-        fetch: mockFetch as unknown as typeof fetch,
-      }),
-    ).rejects.toThrow("`image` and `runtime` are mutually exclusive.");
-
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
 });
 
 describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")("Sandbox", () => {

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -485,6 +485,61 @@ describe("Sandbox.getOrCreate", () => {
   });
 });
 
+describe("Sandbox.create image", () => {
+  const CREDENTIALS = {
+    token: "test-token",
+    teamId: "team_123",
+    projectId: "proj_123",
+  };
+
+  const jsonResponse = (status: number, body: unknown) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+
+  it("sends image in the create request body", async () => {
+    // Return a 400 so create rejects predictably; we only assert the body.
+    const mockFetch = vi.fn<typeof fetch>(async () =>
+      jsonResponse(400, { error: { code: "bad_request", message: "stop" } }),
+    );
+
+    await expect(
+      Sandbox.create({
+        ...CREDENTIALS,
+        image: "my-repo:latest",
+        fetch: mockFetch as unknown as typeof fetch,
+      }),
+    ).rejects.toBeInstanceOf(APIError);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).toContain("/v2/sandboxes");
+    expect(init?.method).toBe("POST");
+    const body = JSON.parse(String(init?.body));
+    expect(body.image).toBe("my-repo:latest");
+    // Runtime must not be sent when only image is provided.
+    expect(body.runtime).toBeUndefined();
+  });
+
+  it("throws when image and runtime are both provided, without calling fetch", async () => {
+    const mockFetch = vi.fn<typeof fetch>(async () =>
+      jsonResponse(200, {}),
+    );
+
+    await expect(
+      Sandbox.create({
+        ...CREDENTIALS,
+        image: "my-repo:latest",
+        runtime: "node24",
+        fetch: mockFetch as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow("`image` and `runtime` are mutually exclusive.");
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
 describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")("Sandbox", () => {
   const PORTS = [3000, 4000];
   const SNAPSHOT_EXPIRATION = ms("1d");

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -81,15 +81,6 @@ export interface BaseCreateSandboxParams {
    */
   resources?: { vcpus: number };
   /**
-   * The runtime of the sandbox, currently only `node24`, `node22`, `node26` and `python3.13` are supported.
-   * If not specified, the default runtime `node24` will be used.
-   */
-  runtime?: RUNTIMES | (string & {});
-  /**
-   * A Vercel Container Registry (VCR) image to start the sandbox from.
-   */
-  image?: string;
-  /**
    * Network policy to define network restrictions for the sandbox.
    * Defaults to full internet access if not specified.
    */
@@ -154,10 +145,37 @@ export interface BaseCreateSandboxParams {
   onResume?: (sandbox: Sandbox) => Promise<void>;
 }
 
+/**
+ * `runtime` and `image` are mutually exclusive: a sandbox starts from either a
+ * stock runtime or a custom VCR image, never both. The `never` counterpart in
+ * each branch makes passing both a compile-time error.
+ * @inline
+ */
+export type RuntimeOrImage =
+  | {
+      /**
+       * The runtime of the sandbox, currently only `node24`, `node22`, `node26`
+       * and `python3.13` are supported.
+       * If not specified, the default runtime `node24` will be used.
+       */
+      runtime?: RUNTIMES | (string & {});
+      image?: never;
+    }
+  | {
+      /**
+       * A Vercel Container Registry (VCR) image to start the sandbox from.
+       */
+      image?: string;
+      runtime?: never;
+    };
+
 export type CreateSandboxParams =
-  | BaseCreateSandboxParams
-  | (Omit<BaseCreateSandboxParams, "runtime" | "source"> & {
+  | (BaseCreateSandboxParams & RuntimeOrImage)
+  | (Omit<BaseCreateSandboxParams, "source"> & {
       source: { type: "snapshot"; snapshotId: string };
+      // A snapshot already defines its runtime/image; neither may be set here.
+      runtime?: never;
+      image?: never;
     });
 
 /**
@@ -205,16 +223,15 @@ interface GetSandboxParams {
 }
 
 /**
- * Extends both {@link BaseCreateSandboxParams} and {@link GetSandboxParams}
- * (minus `name`, which is required on get but optional here) so that any
- * new parameter added to either flow is picked up automatically. The
- * structural overlap on `signal` / `onResume` is intentional — both
- * interfaces declare them with identical optional types.
+ * Combines {@link CreateSandboxParams} with get-specific options so that any
+ * new parameter added to either flow is picked up automatically.
  * @inline
  */
-interface GetOrCreateSandboxParams
-  extends BaseCreateSandboxParams,
-    Omit<GetSandboxParams, "name"> {
+type GetOrCreateSandboxParams = CreateSandboxParams & {
+  /**
+   * Whether to resume an existing session. Defaults to true.
+   */
+  resume?: boolean;
   /**
    * Called once after a sandbox is freshly created (not when an existing
    * sandbox is retrieved). Use this for one-time setup such as seeding
@@ -222,7 +239,7 @@ interface GetOrCreateSandboxParams
    * {@link Sandbox.getOrCreate} resolves.
    */
   onCreate?: (sandbox: Sandbox) => Promise<void>;
-}
+};
 
 function isSandboxStoppedError(err: unknown): boolean {
   return err instanceof APIError && err.response.status === 410;
@@ -619,15 +636,6 @@ export class Sandbox {
       WithFetchOptions,
   ): Promise<Sandbox & AsyncDisposable> {
     "use step";
-    if (
-      params &&
-      "runtime" in params &&
-      params.runtime &&
-      "image" in params &&
-      params.image
-    ) {
-      throw new Error("`image` and `runtime` are mutually exclusive.");
-    }
 
 
     const credentials = await getCredentials(params);
@@ -644,8 +652,8 @@ export class Sandbox {
       ports: params?.ports ?? [],
       timeout: params?.timeout,
       resources: params?.resources,
-      runtime: params && "runtime" in params ? params?.runtime : undefined,
-      image: params && "image" in params ? params?.image : undefined,
+      runtime: params?.runtime,
+      image: params?.image,
       networkPolicy: params?.networkPolicy,
       env: params?.env,
       tags: params?.tags,

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -86,6 +86,10 @@ export interface BaseCreateSandboxParams {
    */
   runtime?: RUNTIMES | (string & {});
   /**
+   * A Vercel Container Registry (VCR) image to start the sandbox from.
+   */
+  image?: string;
+  /**
    * Network policy to define network restrictions for the sandbox.
    * Defaults to full internet access if not specified.
    */
@@ -615,6 +619,17 @@ export class Sandbox {
       WithFetchOptions,
   ): Promise<Sandbox & AsyncDisposable> {
     "use step";
+    if (
+      params &&
+      "runtime" in params &&
+      params.runtime &&
+      "image" in params &&
+      params.image
+    ) {
+      throw new Error("`image` and `runtime` are mutually exclusive.");
+    }
+
+
     const credentials = await getCredentials(params);
     const client = new APIClient({
       teamId: credentials.teamId,
@@ -630,6 +645,7 @@ export class Sandbox {
       timeout: params?.timeout,
       resources: params?.resources,
       runtime: params && "runtime" in params ? params?.runtime : undefined,
+      image: params && "image" in params ? params?.image : undefined,
       networkPolicy: params?.networkPolicy,
       env: params?.env,
       tags: params?.tags,

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -163,7 +163,15 @@ export type RuntimeOrImage =
     }
   | {
       /**
-       * A Vercel Container Registry (VCR) image to start the sandbox from.
+       * A Vercel Container Registry (VCR) image to start the sandbox from,
+       * scoped to the sandbox's project. Accepts a repository name, an
+       * optional tag or digest, or a fully-qualified VCR URL. A bare
+       * repository name resolves to the `latest` tag.
+       *
+       * @example "my-repo" // latest tag
+       * @example "my-repo:v1" // specific tag
+       * @example "my-repo@sha256:..." // specific digest
+       * @example "vcr.vercel.com/my-team/my-project/my-repo:v1" // fully-qualified
        */
       image?: string;
       runtime?: never;

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -636,8 +636,6 @@ export class Sandbox {
       WithFetchOptions,
   ): Promise<Sandbox & AsyncDisposable> {
     "use step";
-
-
     const credentials = await getCredentials(params);
     const client = new APIClient({
       teamId: credentials.teamId,

--- a/skills/sandbox/SKILL.md
+++ b/skills/sandbox/SKILL.md
@@ -204,6 +204,37 @@ const sandbox = await Sandbox.create({
 });
 ```
 
+### From a Custom Image (VCR)
+
+Instead of a stock `runtime`, start a sandbox from a [Vercel Container
+Registry](https://vercel.com/docs/container-registry) (VCR) image stored in the
+sandbox's project. `image` and `runtime` are **mutually exclusive** — pass one
+or the other, never both.
+
+```typescript
+const sandbox = await Sandbox.create({
+  image: "my-repo:v1",
+  ports: [3000],
+});
+```
+
+`image` accepts a repository in the sandbox's project with an optional tag or
+digest, or a fully-qualified VCR URL. A bare repository name resolves to the
+`latest` tag:
+
+```typescript
+await Sandbox.create({ image: "my-repo" }); // latest tag
+await Sandbox.create({ image: "my-repo:v1" }); // specific tag
+await Sandbox.create({ image: "my-repo@sha256:..." }); // specific digest
+await Sandbox.create({
+  image: "vcr.vercel.com/my-team/my-project/my-repo:v1", // fully-qualified
+});
+```
+
+Push images to VCR with Docker-compatible tooling before referencing them. See the
+[Container Registry docs](https://vercel.com/docs/container-registry) for push
+instructions.
+
 ### Forking an Existing Sandbox
 
 `Sandbox.fork` seeds a new sandbox from another sandbox's current snapshot
@@ -824,6 +855,7 @@ sandbox logout
 # Create and connect
 sandbox create --connect
 sandbox create --name my-app
+sandbox create --image my-repo:v1            # Boot from a VCR image (not with --runtime)
 sandbox create --non-persistent              # Disable filesystem persistence
 sandbox create --snapshot-expiration 7d      # Default snapshot TTL
 sandbox create --keep-last-snapshots 1       # Retention policy


### PR DESCRIPTION
Add support for the new image parameter.

CLI
---

Add a new image parameter for the `sandbox create` command. It cannot be used with `--runtime`. Example:

```
sandbox create --image `foo/bar`
```

SDK
---

SDK also supports this new parameter in the create command. Like the CLI, it cannot be used with the `runtime` parameter. Example:

```
Sandbox.create({
  image: 'foo/bar'
});
```