### PR TITLE
[ci] Pin Node to 24.16.0 to fix release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          node-version: "24.16.0"
           cache: "pnpm"
 
       - run: pnpm install


### PR DESCRIPTION
The Release workflow has been failing on `main` since the GitHub runner's cached Node 24 bumped from **24.16.0** to **24.17.0** (between Jun 16 and Jun 29):

```
🦋 error FetchError: Invalid response body while trying to fetch
   https://api.github.com/graphql: Premature close
   at Gunzip.<anonymous> (.../node-fetch@2.7.0/lib/index.js:400:12)
   code: 'ERR_STREAM_PREMATURE_CLOSE'
```

| Release run | Date | Node | Result |
|-----|------|------|--------|
| 27634766358 | Jun 16 | 24.16.0 | ✅ |
| 28386878539 | Jun 29 | 24.17.0 | ❌ |

## Solution

Pin `setup-node` to `24.16.0` (the last known-good patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)