### PR TITLE
feat(vercel/sandbox): fix interactive shell

### DIFF
--- a/.changeset/interactive-prompt-posix-portable.md
+++ b/.changeset/interactive-prompt-posix-portable.md
@@ -2,4 +2,4 @@
 "sandbox": patch
 ---
 
-Fix the interactive shell prompt so that it is built from POSIX-portable primitives — it renders correctly regardless of which shell (`bash`, `dash`, busybox `ash`) a custom image ships as `/bin/sh`.
+Fix the interactive shell prompt so that it is built from POSIX-portable primitives — it renders correctly regardless of which POSIX compatible shell (`bash`, `dash`, busybox `ash`) a custom image ships as `/bin/sh`.

--- a/.changeset/interactive-prompt-posix-portable.md
+++ b/.changeset/interactive-prompt-posix-portable.md
@@ -1,0 +1,5 @@
+---
+"sandbox": patch
+---
+
+Fix the interactive shell prompt so that it is built from POSIX-portable primitives — it renders correctly regardless of which shell (`bash`, `dash`, busybox `ash`) a custom image ships as `/bin/sh`.

--- a/packages/sandbox/src/interactive-shell/interactive-shell.ts
+++ b/packages/sandbox/src/interactive-shell/interactive-shell.ts
@@ -18,8 +18,11 @@ const TERM = "xterm-256color";
  * A custom prompt so interactive sessions show the Vercel triangle and the
  * working directory (e.g. `▲ /vercel/sandbox/ `) instead of the shell's
  * default prompt. The server passes this through to the shell verbatim.
+ *
+ * This is built from primitives every POSIX shell honors so it renders the
+ * same regardless of which shell a customer image ships as `/bin/sh`.
  */
-const PS1 = `▲ \\[\\e[2m\\]\\w/\\[\\e[0m\\] `;
+const PS1 = `▲ \x1b[2m$PWD/\x1b[0m `;
 
 /**
  * Starts an interactive shell session with a sandbox. The API hands us a

--- a/packages/sandbox/src/interactive-shell/interactive-shell.ts
+++ b/packages/sandbox/src/interactive-shell/interactive-shell.ts
@@ -21,8 +21,16 @@ const TERM = "xterm-256color";
  *
  * This is built from primitives every POSIX shell honors so it renders the
  * same regardless of which shell a customer image ships as `/bin/sh`.
+ *
+ * The color escapes are wrapped in the raw readline "ignore" markers
+ * `\x01` (RL_PROMPT_START_IGNORE) and `\x02` (RL_PROMPT_END_IGNORE) — the
+ * same bytes that bash's `\[` / `\]` decode into. This lets bash's readline
+ * exclude the (zero-width) escape sequences from its prompt-width calculation
+ * so cursor positioning stays correct on long/wrapping lines and during line
+ * editing. In non-bash shells these are C0 control bytes that terminals treat
+ * as non-printing, so they don't affect rendering there.
  */
-const PS1 = `▲ \x1b[2m$PWD/\x1b[0m `;
+const PS1 = `▲ \x01\x1b[2m\x02$PWD/\x01\x1b[0m\x02 `;
 
 /**
  * Starts an interactive shell session with a sandbox. The API hands us a


### PR DESCRIPTION
Fix interactive shell, so that we render the Vercel icon correctly between different shells.

Before, with a custom image:

```
▲ \[\e[2m\]\w/\[\e[0m\] 
```

Now:

```
▲ /app
```