### PR TITLE
feat(sandbox,vercel-sandbox): improve timeout update and get

### DIFF
--- a/.changeset/sandbox-live-expires-at.md
+++ b/.changeset/sandbox-live-expires-at.md
@@ -1,0 +1,6 @@
+---
+"@vercel/sandbox": minor
+"sandbox": minor
+---
+
+Report the live timeout deadline of running sandboxes. `Sandbox.list` and `Sandbox.get` now expose `expiresAt`, reflecting the current session's deadline including any timeout extensions, and `sandbox list` renders it in the `TIMEOUT` column. `Sandbox.update({ timeout })` (and `sandbox config timeout`) now also extends the currently running session so an increased timeout takes effect immediately instead of only applying to future sessions.

--- a/packages/sandbox/src/commands/list.ts
+++ b/packages/sandbox/src/commands/list.ts
@@ -106,7 +106,14 @@ export const list = cmd.command({
       VCPUS: { value: (s) => s.vcpus ?? "-" },
       RUNTIME: { value: (s) => s.runtime ?? "-" },
       TIMEOUT: {
-        value: (s) => s.timeout != null ? timeAgo(s.createdAt + s.timeout) : "-",
+        // Prefer the live deadline (`expiresAt`) of the running session. Fall
+        // back to the configured timeout for non-running sandboxes that don't
+        // report `expiresAt`.
+        value: (s) => {
+          if (s.expiresAt != null) return timeAgo(s.expiresAt);
+          if (s.timeout != null) return timeAgo(s.createdAt + s.timeout);
+          return "-";
+        },
       },
       SNAPSHOT: { value: (s) => s.currentSnapshotId ?? "-" },
       TAGS: { value: (s) => s.tags && Object.keys(s.tags).length > 0 ? Object.entries(s.tags).map(([k, v]) => `${k}:${v}`).join(", ") : "-" }

--- a/packages/vercel-sandbox/src/api-client/validators.ts
+++ b/packages/vercel-sandbox/src/api-client/validators.ts
@@ -266,6 +266,7 @@ export const Sandbox = z.object({
   totalDurationMs: z.number().optional(),
   createdAt: z.number(),
   updatedAt: z.number(),
+  expiresAt: z.number().optional(),
   currentSessionId: z.string(),
   currentSnapshotId: z.string().optional(),
   status: Session.shape.status,

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -141,6 +141,81 @@ describe("updatePorts", () => {
   });
 });
 
+describe("update timeout", () => {
+  function setup(sessionOverrides?: Partial<SandboxMetaData>) {
+    const updateSandboxMock = vi.fn(async () => ({
+      json: { sandbox: makeSandboxMetadata() },
+    }));
+    const extendTimeoutMock = vi.fn(
+      async ({ duration }: { duration: number }) => ({
+        json: {
+          session: { id: "sbx_123", status: "running", timeout: duration },
+        },
+      }),
+    );
+    const sandbox = new Sandbox({
+      client: {
+        updateSandbox: updateSandboxMock,
+        extendTimeout: extendTimeoutMock,
+      } as unknown as APIClient,
+      routes: [],
+      sandbox: makeSandboxMetadata(),
+      session: {
+        id: "sbx_123",
+        status: "running",
+        timeout: 300_000,
+        ...sessionOverrides,
+      } as any,
+      projectId: "test-project",
+    });
+    return { sandbox, updateSandboxMock, extendTimeoutMock };
+  }
+
+  it("extends the running session by the positive increment", async () => {
+    const { sandbox, updateSandboxMock, extendTimeoutMock } = setup();
+
+    await sandbox.update({ timeout: 600_000 });
+
+    expect(updateSandboxMock).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 600_000 }),
+    );
+    // increment = new timeout (600_000) - current session timeout (300_000)
+    expect(extendTimeoutMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "sbx_123", duration: 300_000 }),
+    );
+  });
+
+  it("does not extend the session when the new timeout is not larger", async () => {
+    const { sandbox, updateSandboxMock, extendTimeoutMock } = setup({
+      timeout: 600_000,
+    });
+
+    await sandbox.update({ timeout: 600_000 });
+
+    expect(updateSandboxMock).toHaveBeenCalled();
+    expect(extendTimeoutMock).not.toHaveBeenCalled();
+  });
+
+  it("does not extend the session when it is not running", async () => {
+    const { sandbox, updateSandboxMock, extendTimeoutMock } = setup({
+      status: "stopped",
+    });
+
+    await sandbox.update({ timeout: 600_000 });
+
+    expect(updateSandboxMock).toHaveBeenCalled();
+    expect(extendTimeoutMock).not.toHaveBeenCalled();
+  });
+
+  it("does not extend the session when timeout is not part of the update", async () => {
+    const { sandbox, extendTimeoutMock } = setup();
+
+    await sandbox.update({ persistent: false });
+
+    expect(extendTimeoutMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("_runCommand error handling", () => {
   it("pipes non-detached runCommand logs from the wait stream", async () => {
     const command = makeCommand();

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -216,6 +216,82 @@ describe("update timeout", () => {
   });
 });
 
+describe("expiresAt", () => {
+  it("computes the deadline from startedAt + timeout for a running session", () => {
+    const sandbox = new Sandbox({
+      client: {} as unknown as APIClient,
+      routes: [],
+      sandbox: makeSandboxMetadata(),
+      session: {
+        id: "sbx_123",
+        status: "running",
+        startedAt: 1_000,
+        createdAt: 500,
+        timeout: 300_000,
+      } as any,
+      projectId: "test-project",
+    });
+
+    expect(sandbox.expiresAt).toEqual(new Date(1_000 + 300_000));
+  });
+
+  it("falls back to createdAt when the running session has no startedAt", () => {
+    const sandbox = new Sandbox({
+      client: {} as unknown as APIClient,
+      routes: [],
+      sandbox: makeSandboxMetadata(),
+      session: {
+        id: "sbx_123",
+        status: "running",
+        createdAt: 500,
+        timeout: 300_000,
+      } as any,
+      projectId: "test-project",
+    });
+
+    expect(sandbox.expiresAt).toEqual(new Date(500 + 300_000));
+  });
+
+  it("falls back to the sandbox expiresAt when the session is not running", () => {
+    const sandbox = new Sandbox({
+      client: {} as unknown as APIClient,
+      routes: [],
+      sandbox: { ...makeSandboxMetadata(), expiresAt: 1_700_000_000_000 },
+      session: {
+        id: "sbx_123",
+        status: "stopped",
+        createdAt: 500,
+        timeout: 300_000,
+      } as any,
+      projectId: "test-project",
+    });
+
+    expect(sandbox.expiresAt).toEqual(new Date(1_700_000_000_000));
+  });
+
+  it("returns the sandbox expiresAt when there is no session", () => {
+    const sandbox = new Sandbox({
+      client: {} as unknown as APIClient,
+      routes: [],
+      sandbox: { ...makeSandboxMetadata(), expiresAt: 1_700_000_000_000 },
+      projectId: "test-project",
+    });
+
+    expect(sandbox.expiresAt).toEqual(new Date(1_700_000_000_000));
+  });
+
+  it("returns undefined when there is no session and no sandbox expiresAt", () => {
+    const sandbox = new Sandbox({
+      client: {} as unknown as APIClient,
+      routes: [],
+      sandbox: makeSandboxMetadata(),
+      projectId: "test-project",
+    });
+
+    expect(sandbox.expiresAt).toBeUndefined();
+  });
+});
+
 describe("_runCommand error handling", () => {
   it("pipes non-detached runCommand logs from the wait stream", async () => {
     const command = makeCommand();

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -481,6 +481,24 @@ export class Sandbox {
   }
 
   /**
+   * When the currently running session will time out.
+   */
+  public get expiresAt(): Date | undefined {
+    if (this.session?.status === "running") {
+      const base = this.session.startedAt ?? this.session.createdAt;
+      return new Date(base.getTime() + this.session.timeout);
+    }
+
+    if (this.status === 'running') {
+      return this.sandbox.expiresAt !== undefined
+        ? new Date(this.sandbox.expiresAt)
+        : undefined;
+    }
+
+    return undefined;
+  }
+
+  /**
    * Key-value tags attached to the sandbox.
    */
   public get tags(): Record<string, string> | undefined {
@@ -1361,6 +1379,9 @@ export class Sandbox {
    * When `ports` is provided, it is treated as the full desired port list:
    * any currently exposed port omitted from the array will be deregistered.
    *
+   * When `timeout` is increased and a session is currently running, the running
+   * session's deadline is also extended.
+   *
    * @param params - Fields to update.
    * @param opts - Optional abort signal.
    */
@@ -1410,6 +1431,21 @@ export class Sandbox {
     this.sandbox = response.json.sandbox;
     if (params.ports !== undefined && response.json.routes) {
       this.session?.updateRoutes(response.json.routes);
+    }
+
+    // Apply the new timeout to the currently running session (only if it is a
+    // positive increment).
+    if (params.timeout !== undefined && this.session?.status === "running") {
+      const increment = params.timeout - this.session.timeout;
+      if (increment > 0) {
+        try {
+          await this.session.extendTimeout(increment, opts);
+        } catch (err) {
+          if (!isSandboxStoppedError(err) && !isSandboxStoppingError(err)) {
+            throw err;
+          }
+        }
+      }
     }
 
     // Update the current session config. This only applies to network policy.

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -489,13 +489,9 @@ export class Sandbox {
       return new Date(base.getTime() + this.session.timeout);
     }
 
-    if (this.status === 'running') {
-      return this.sandbox.expiresAt !== undefined
-        ? new Date(this.sandbox.expiresAt)
-        : undefined;
-    }
-
-    return undefined;
+    return this.sandbox.expiresAt !== undefined
+      ? new Date(this.sandbox.expiresAt)
+      : undefined;
   }
 
   /**


### PR DESCRIPTION
Get timeout
---

Improve how we fetch and show the timeout of a running sandbox at the CLI level.

- Before: we showed the static timeout. It did not take into account whether the timeout was extended or not.
- After: we take into account timeout extension and show it properly.

Example:

```
❯ sandbox list
NAME                         STATUS    CREATED         MEMORY     VCPUS   RUNTIME   TIMEOUT        SNAPSHOT   TAGS
black-dull-basilisk-DwTaCA   running   8 seconds ago   4,096 MB   2       node24    in 5 minutes   -          -   

❯ sandbox config timeout black-dull-basilisk-DwTaCA 10m
✅ Configuration updated for sandbox black-dull-basilisk-DwTaCA
   ╰ timeout: 10m

❯ sandbox list
NAME                         STATUS    CREATED          MEMORY     VCPUS   RUNTIME   TIMEOUT        SNAPSHOT   TAGS
black-dull-basilisk-DwTaCA   running   40 seconds ago   4,096 MB   2       node24    in 9 minutes   -          -   
```

Update timeout
---

Now, when updating the timeout at the CLI or SDK via the configuration, we will also extend the current session timeout to match the expected value. Note that to avoid breaking existing sessions, we only update the timeout for the current session IF the increase is positive.