### PR TITLE
feat(cli): un-deprecate `sandbox sh`

### DIFF
--- a/.changeset/spicy-showers-give.md
+++ b/.changeset/spicy-showers-give.md
@@ -1,0 +1,5 @@
+---
+"sandbox": patch
+---
+
+Un-deprecate `sandbox sh` as a quick way to run a sandbox and SSH into it directly

--- a/packages/sandbox/docs/index.md
+++ b/packages/sandbox/docs/index.md
@@ -11,6 +11,7 @@ Commands:
 
     ls | list                                  List all sandboxes for the specified account and project.
     create                                     Create a sandbox in the specified account and project.
+    sh                                         Create a sandbox and start an interactive shell
     fork           <source>                    Fork an existing sandbox into a new one. Copies config (cpu, timeout, network policy, tags, etc.) from the source sandbox; env vars are NOT copied and must be re-supplied via --env.
     config                                     View and update sandbox configuration
     cp | copy      <src> <dst>                 Copy files between your local filesystem and a remote sandbox
@@ -29,7 +30,7 @@ Examples:
 
 – Create a sandbox and start a shell
 
-  $ sandbox create --connect
+  $ sandbox sh
 
 – Run a command in a new sandbox
 
@@ -178,6 +179,51 @@ Examples:
 – Create and connect to a sandbox without a network access
 
   $ sandbox run --network-policy=none --connect
+```
+
+## `sandbox sh`
+
+```
+sh
+
+▲ sandbox sh [options]
+
+Create a sandbox and start an interactive shell
+
+Options:
+
+    --name <str>                               A user-chosen name for the sandbox. It must be unique per project. [optional]
+    --runtime <runtime>                        One of 'node22', 'node24', 'node26', 'python3.13' [optional]
+    --image <str>                              A Vercel Container Registry (VCR) image name and optional tag or sha to start the sandbox from (e.g. my-repo, my-repo:v1). [optional]
+    --timeout <num UNIT>                       The maximum duration a sandbox can run for. Example: 5m, 30m [default: 5 minutes]
+    --vcpus <COUNT>                            Number of vCPUs to allocate (each vCPU includes 2048 MB of memory) [optional]
+    --publish-port <PORT>, -p=<PORT>           Publish sandbox port(s) to DOMAIN.vercel.run
+    --snapshot, -s <snapshot_id>               Start the sandbox from a snapshot ID [optional]
+    --env <key=value>, -e=<key=value>          Default environment variables for sandbox commands
+    --tag <key=value>, -t=<key=value>          Key-value tags to associate with the sandbox (e.g. --tag env=staging)
+    --snapshot-expiration <DURATION|none>      Default snapshot expiration. Use "none" or 0 for no expiration. Example: 7d, 30d [optional]
+    --keep-last-snapshots <COUNT>              Keep only the N most recent snapshots of this sandbox (1-10). [optional]
+    --keep-last-snapshots-for <DURATION|none>  Expiration applied to kept snapshots. Use "none" or 0 for no expiration. Example: 7d, 30d [optional]
+    --delete-evicted-snapshots <true|false>    When "true" (the default), evicted snapshots are deleted immediately; when "false", they keep the default expiration. [optional]
+    --network-policy <MODE>                    Network policy mode: "allow-all" or "deny-all"
+      - allow-all: sandbox can access any website/domain
+      - deny-all: sandbox has no network access
+    Omit this option and use --allowed-domain / --allowed-cidr / --denied-cidr for custom policies. [optional]
+    --allowed-domain <str>                     Domain to allow traffic to (creates a custom network policy). Supports "*" for wildcards for a segment (e.g. '*.vercel.com', 'www.*.com'). If used as the first segment, will match any subdomain.
+    --allowed-cidr <str>                       CIDR to allow traffic to (creates a custom network policy). Takes precedence over 'allowed-domain'.
+    --denied-cidr <str>                        CIDR to deny traffic to (creates a custom network policy). Takes precedence over allowed domains/CIDRs.
+
+Flags:
+
+    --non-persistent  Disable automatic restore of the filesystem between sessions. [optional]
+    --silent          Don't write sandbox name to stdout [optional]
+    --help, -h        show help [optional]
+
+Auth & Scope:
+
+    --token <pat_or_oidc>   A Vercel authentication token. If not provided, will use the token stored in your system from `VERCEL_AUTH_TOKEN` or will start a log in process. [optional]
+    --project <my-project>  The project name or ID to associate with the command. Can be inferred from VERCEL_OIDC_TOKEN. [optional]
+    --scope <my-team>       The scope/team to associate with the command. Can be inferred from VERCEL_OIDC_TOKEN. [alias: --team] [optional]
 ```
 
 ## `sandbox fork`

--- a/packages/sandbox/scripts/print-usage.ts
+++ b/packages/sandbox/scripts/print-usage.ts
@@ -9,6 +9,7 @@ const docs = {
   "sandbox list": "list --help",
   "sandbox run": "run --help",
   "sandbox create": "create --help",
+  "sandbox sh": "sh --help",
   "sandbox fork": "fork --help",
   "sandbox exec": "exec --help",
   "sandbox stop": "stop --help",

--- a/packages/sandbox/src/app.ts
+++ b/packages/sandbox/src/app.ts
@@ -1,5 +1,6 @@
 import { subcommands } from "cmd-ts";
 import { create } from "./commands/create";
+import { sh } from "./commands/sh";
 import { fork } from "./commands/fork";
 import { run } from "./commands/run";
 import { list } from "./commands/list";
@@ -24,6 +25,7 @@ export const app = (opts?: { withoutAuth?: boolean; appName?: string }) =>
     cmds: {
       list,
       create,
+      sh,
       fork,
       config,
       copy: cp,
@@ -43,7 +45,7 @@ export const app = (opts?: { withoutAuth?: boolean; appName?: string }) =>
     examples: [
       {
         description: "Create a sandbox and start a shell",
-        command: "sandbox create --connect",
+        command: "sandbox sh",
       },
       {
         description: "Run a command in a new sandbox",

--- a/packages/sandbox/src/commands/sh.ts
+++ b/packages/sandbox/src/commands/sh.ts
@@ -1,0 +1,15 @@
+import * as cmd from "cmd-ts";
+import * as Create from "./create";
+import { omit } from "../util/omit";
+
+export const sh = cmd.command({
+  name: "sh",
+  description: "Create a sandbox and start an interactive shell",
+  args: omit(Create.args, "connect"),
+  async handler(args) {
+    return Create.create.handler({
+      ...args,
+      connect: true,
+    });
+  },
+});

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -12,18 +12,7 @@ async function main() {
   setDefaultHelpFormatter(vercelFormatter);
 
   try {
-    // We've renamed `sandbox sh` to `sandbox create --connect`. cmd-ts doesn't support aliases for commands
-    // with different arguments. Best effort deprecation warning, remap to the new command if the user just
-    // runs `sandbox sh ...`
-    let args = process.argv.slice(2);
-    if (args.length >= 1 && args[0] === "sh") {
-      args = ["create", "--connect", ...args.slice(1)];
-      process.stderr.write(
-        "Warning: `sandbox sh` is deprecated. Please use `sandbox create --connect` instead.\n",
-      );
-    }
-
-    await run(app(), args);
+    await run(app(), process.argv.slice(2));
   } catch (e) {
     await printTopLevelError(e);
     process.exit(1);


### PR DESCRIPTION
We had some feedback that `sandbox sh` was useful as a quick way to run a sandbox and SSH into it directly, without having to type `sandbox create --connect`

This PR un-deprecates `sandbox sh`, and supports all the options of `sandbox create`