### PR TITLE
feat(sdk): add `durationMs` to commands

### DIFF
--- a/.changeset/strong-flowers-double.md
+++ b/.changeset/strong-flowers-double.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": minor
+---
+
+Commands now surface how long they took to execute with the `durationMs` field

--- a/packages/vercel-sandbox/src/api-client/api-client.test.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.test.ts
@@ -227,6 +227,7 @@ describe("APIClient", () => {
         command: {
           ...first.command,
           exitCode: 0,
+          durationMs: 1234,
         },
       };
 
@@ -246,7 +247,10 @@ describe("APIClient", () => {
       });
 
       expect(result.command.exitCode).toBeNull();
-      await expect(result.finished).resolves.toMatchObject({ exitCode: 0 });
+      await expect(result.finished).resolves.toMatchObject({
+        exitCode: 0,
+        durationMs: 1234,
+      });
     });
 
     it("calls onLog for logs between command data when logs and wait are true", async () => {
@@ -265,6 +269,7 @@ describe("APIClient", () => {
         command: {
           ...first.command,
           exitCode: 0,
+          durationMs: 1234,
         },
       };
 
@@ -298,7 +303,10 @@ describe("APIClient", () => {
         wait: true,
         logs: true,
       });
-      await expect(result.finished).resolves.toMatchObject({ exitCode: 0 });
+      await expect(result.finished).resolves.toMatchObject({
+        exitCode: 0,
+        durationMs: 1234,
+      });
       expect(logLines).toEqual([
         { stream: "stdout", data: "hello\n" },
         { stream: "stderr", data: "warning\n" },

--- a/packages/vercel-sandbox/src/api-client/validators.ts
+++ b/packages/vercel-sandbox/src/api-client/validators.ts
@@ -160,6 +160,8 @@ export const Command = z.object({
   cwd: z.string(),
   sessionId: z.string(),
   exitCode: z.number().nullable(),
+  // optional because the duration was not preserved for older commands
+  durationMs: z.number().optional(),
   startedAt: z.number(),
 });
 

--- a/packages/vercel-sandbox/src/command.serialize.test.ts
+++ b/packages/vercel-sandbox/src/command.serialize.test.ts
@@ -69,6 +69,7 @@ describe("CommandFinished serialization", () => {
         sandboxId: mockSandboxId,
         cmd: mockCommandData,
         exitCode: 0,
+        durationMs: mockCommandData.durationMs,
         output: mockOutput,
       });
     });

--- a/packages/vercel-sandbox/src/command.serialize.test.ts
+++ b/packages/vercel-sandbox/src/command.serialize.test.ts
@@ -12,11 +12,11 @@ import {
   SerializedCommandFinished,
   CommandOutput,
 } from "./command";
-import type { CommandData } from "./api-client";
+import type { CommandData, CommandFinishedData } from "./api-client";
 import { APIClient } from "./api-client";
 
 describe("CommandFinished serialization", () => {
-  const mockCommandData: CommandData = {
+  const mockCommandData: CommandFinishedData = {
     id: "cmd_test123",
     name: "echo",
     args: ["hello", "world"],
@@ -24,6 +24,7 @@ describe("CommandFinished serialization", () => {
     sandboxId: "sbx_test456",
     exitCode: 0,
     startedAt: 1700000000000,
+    durationMs: 1234,
   };
 
   const mockSandboxId = "sbx_test456";
@@ -34,7 +35,7 @@ describe("CommandFinished serialization", () => {
   };
 
   const createMockCommandFinished = (
-    cmd: CommandData = mockCommandData,
+    cmd: CommandFinishedData = mockCommandData,
     sandboxId: string = mockSandboxId,
     exitCode: number = 0,
     output?: CommandOutput,
@@ -205,6 +206,7 @@ describe("CommandFinished serialization", () => {
       expect(commandFinished.cmdId).toBe(mockCommandData.id);
       expect(commandFinished.cwd).toBe(mockCommandData.cwd);
       expect(commandFinished.startedAt).toBe(mockCommandData.startedAt);
+      expect(commandFinished.durationMs).toBe(mockCommandData.durationMs);
     });
 
     it("restores output for stdout() and stderr() methods", async () => {
@@ -256,6 +258,7 @@ describe("CommandFinished serialization", () => {
 
       expect(deserialized.cmdId).toBe(originalCommand.cmdId);
       expect(deserialized.exitCode).toBe(42);
+      expect(deserialized.durationMs).toBe(originalCommand.durationMs);
       expect(await deserialized.stdout()).toBe(mockOutput.stdout);
       expect(await deserialized.stderr()).toBe(mockOutput.stderr);
     });

--- a/packages/vercel-sandbox/src/command.ts
+++ b/packages/vercel-sandbox/src/command.ts
@@ -1,5 +1,8 @@
 import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from "@workflow/serde";
-import { APIClient, type CommandData } from "./api-client/index.js";
+import {
+  APIClient,
+  type CommandData,
+} from "./api-client/index.js";
 import { getCredentials } from "./utils/get-credentials.js";
 import { resolveSignal, type Signal } from "./utils/resolveSignal.js";
 
@@ -26,6 +29,7 @@ export interface SerializedCommand {
  */
 export interface SerializedCommandFinished extends SerializedCommand {
   exitCode: number;
+  durationMs?: number;
 }
 
 /**
@@ -74,6 +78,8 @@ export class Command {
   protected cmd: CommandData;
 
   public exitCode: number | null;
+
+  public durationMs?: number;
 
   protected outputCache: Promise<{
     stdout: string;
@@ -125,6 +131,7 @@ export class Command {
     this.sessionId = sessionId;
     this.cmd = cmd;
     this.exitCode = cmd.exitCode ?? null;
+    this.durationMs = cmd.durationMs;
     if (output) {
       this._resolvedOutput = output;
       // Note: `both` is reconstructed as stdout + stderr concatenation,
@@ -240,6 +247,7 @@ export class Command {
       sessionId: this.sessionId,
       cmd: command.json.command,
       exitCode: command.json.command.exitCode,
+      durationMs: command.json.command.durationMs,
     });
   }
 
@@ -371,11 +379,17 @@ export class CommandFinished extends Command {
   public exitCode: number;
 
   /**
+   * The duration of the command execution in milliseconds.
+   */
+  public durationMs?: number;
+
+  /**
    * @param params - Object containing client, sandbox ID, command data, and exit code.
    * @param params.client - Optional API client. If not provided, will be lazily created using global credentials.
    * @param params.sessionId - The ID of the session where the command ran.
    * @param params.cmd - The command data.
    * @param params.exitCode - The exit code of the completed command.
+   * @param params.durationMs - Optional duration of the command execution in milliseconds.
    * @param params.output - Optional cached output to restore (used during deserialization).
    */
   constructor(params: {
@@ -383,10 +397,12 @@ export class CommandFinished extends Command {
     sessionId: string;
     cmd: CommandData;
     exitCode: number;
+    durationMs?: number;
     output?: CommandOutput;
   }) {
     super({ ...params });
     this.exitCode = params.exitCode;
+    this.durationMs = params.durationMs;
   }
 
   /**
@@ -401,6 +417,7 @@ export class CommandFinished extends Command {
     return {
       ...Command[WORKFLOW_SERIALIZE](instance),
       exitCode: instance.exitCode,
+      durationMs: instance.durationMs,
     };
   }
 
@@ -420,6 +437,7 @@ export class CommandFinished extends Command {
       sessionId: data.sandboxId,
       cmd: data.cmd,
       exitCode: data.exitCode,
+      durationMs: data.durationMs,
       output: data.output,
     });
   }

--- a/packages/vercel-sandbox/src/command.ts
+++ b/packages/vercel-sandbox/src/command.ts
@@ -402,7 +402,7 @@ export class CommandFinished extends Command {
   }) {
     super({ ...params });
     this.exitCode = params.exitCode;
-    this.durationMs = params.durationMs;
+    this.durationMs = params.durationMs ?? params.cmd.durationMs;
   }
 
   /**

--- a/packages/vercel-sandbox/src/session.ts
+++ b/packages/vercel-sandbox/src/session.ts
@@ -438,6 +438,7 @@ export class Session {
         sessionId: this.session.id,
         cmd: finished,
         exitCode: finished.exitCode ?? 0,
+        durationMs: finished.durationMs,
         output: { stdout, stderr },
       });
     }


### PR DESCRIPTION
The API is now returning a `durationMs` field on commands. Similar to the exit code, it's only populated when the command finished executing

This PR adds a new `durationMs` field to the commands classes