### PR TITLE
Experiment with retaining local CLI traces for error reports

### DIFF
--- a/.changeset/olive-donuts-tickle.md
+++ b/.changeset/olive-donuts-tickle.md
@@ -2,4 +2,4 @@
 "sandbox": minor
 ---
 
-Experiment with retaining local traces for error reports. Spans are written as OTLP/JSON lines to the XDG cache directory, with the 10 latest trace files retained for replay into Jaeger or Tempo.
+Experiment with retaining local traces for error reports. Spans are written as OTLP/JSON lines to the XDG cache directory, with the 10 latest trace files retained for replay into Jaeger or Tempo. Trace names and attributes avoid command arguments, environment values, paths, and credentials.

--- a/.changeset/olive-donuts-tickle.md
+++ b/.changeset/olive-donuts-tickle.md
@@ -1,0 +1,5 @@
+---
+"sandbox": minor
+---
+
+Experiment with retaining local traces for error reports. Spans are written as OTLP/JSON lines to the XDG cache directory, with the 10 latest trace files retained for replay into Jaeger or Tempo.

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -39,8 +39,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/core": "^1.30.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.57.2",
     "@opentelemetry/instrumentation-fetch": "^0.218.0",
+    "@opentelemetry/otlp-transformer": "^0.57.2",
     "@opentelemetry/resources": "^1.30.1",
     "@opentelemetry/sdk-trace-base": "^1.30.1",
     "@opentelemetry/sdk-trace-node": "^1.30.1",
@@ -49,6 +51,7 @@
     "async-retry": "1.3.3",
     "debug": "^4.4.1",
     "ws": "^8.21.0",
+    "xdg-app-paths": "5.1.0",
     "zod": "^4.1.1"
   },
   "devDependencies": {
@@ -68,7 +71,6 @@
     "open": "^10.2.0",
     "ora": "^8.2.0",
     "tsdown": "catalog:",
-    "vitest": "catalog:",
-    "xdg-app-paths": "5.1.0"
+    "vitest": "catalog:"
   }
 }

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -41,7 +41,7 @@
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/core": "^1.30.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.57.2",
-    "@opentelemetry/instrumentation-fetch": "^0.218.0",
+    "@opentelemetry/instrumentation-undici": "0.10.0",
     "@opentelemetry/otlp-transformer": "^0.57.2",
     "@opentelemetry/resources": "^1.30.1",
     "@opentelemetry/sdk-trace-base": "^1.30.1",

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -38,6 +38,13 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.57.2",
+    "@opentelemetry/instrumentation-fetch": "^0.218.0",
+    "@opentelemetry/resources": "^1.30.1",
+    "@opentelemetry/sdk-trace-base": "^1.30.1",
+    "@opentelemetry/sdk-trace-node": "^1.30.1",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@vercel/sandbox": "workspace:*",
     "async-retry": "1.3.3",
     "debug": "^4.4.1",

--- a/packages/sandbox/src/app.ts
+++ b/packages/sandbox/src/app.ts
@@ -16,6 +16,7 @@ import { snapshot } from "./commands/snapshot";
 import { snapshots } from "./commands/snapshots";
 import { sessions } from "./commands/sessions";
 import { config } from "./commands/config";
+import { traces } from "./commands/traces";
 
 export const app = (opts?: { withoutAuth?: boolean; appName?: string }) =>
   subcommands({
@@ -41,6 +42,7 @@ export const app = (opts?: { withoutAuth?: boolean; appName?: string }) =>
         login,
         logout,
       }),
+      _traces: traces,
     },
     examples: [
       {

--- a/packages/sandbox/src/args/auth.ts
+++ b/packages/sandbox/src/args/auth.ts
@@ -6,11 +6,23 @@ import * as OIDC from "@vercel/oidc";
 import { getCurrentSpan, traced } from "../otel";
 import { traceParser } from "../util/parser-trace";
 import { getAuth } from "@vercel/sandbox/dist/auth/index.js";
-import { markTokenAsFresh } from "../util/auth-freshness";
-
-export { isTokenFresh } from "../util/auth-freshness";
 
 const debug = createDebugger("sandbox:args:auth");
+
+let freshTokenAcquiredAt: number | undefined;
+
+const FRESH_TOKEN_WINDOW_MS = 15_000;
+
+export function isTokenFresh(): boolean {
+  return (
+    freshTokenAcquiredAt !== undefined &&
+    Date.now() - freshTokenAcquiredAt < FRESH_TOKEN_WINDOW_MS
+  );
+}
+
+function markTokenAsFresh(): void {
+  freshTokenAcquiredAt = Date.now();
+}
 
 const getVercelOidcToken = traced(OIDC.getVercelOidcToken);
 const getVercelToken = traced(OIDC.getVercelToken);

--- a/packages/sandbox/src/args/auth.ts
+++ b/packages/sandbox/src/args/auth.ts
@@ -2,103 +2,102 @@ import * as cmd from "cmd-ts";
 import { login } from "../commands/login";
 import createDebugger from "debug";
 import chalk from "chalk";
-import {
-  getVercelOidcToken,
-  getVercelToken,
-  AccessTokenMissingError,
-  RefreshAccessTokenFailedError,
-} from "@vercel/oidc";
+import * as OIDC from "@vercel/oidc";
+import { getCurrentSpan, traced } from "../otel";
+import { traceParser } from "../util/parser-trace";
 import { getAuth } from "@vercel/sandbox/dist/auth/index.js";
+import { markTokenAsFresh } from "../util/auth-freshness";
+
+export { isTokenFresh } from "../util/auth-freshness";
 
 const debug = createDebugger("sandbox:args:auth");
 
-let freshTokenAcquiredAt: number | undefined;
+const getVercelOidcToken = traced(OIDC.getVercelOidcToken);
+const getVercelToken = traced(OIDC.getVercelToken);
 
-const FRESH_TOKEN_WINDOW_MS = 15_000;
-
-export function isTokenFresh(): boolean {
-  return (
-    freshTokenAcquiredAt !== undefined &&
-    Date.now() - freshTokenAcquiredAt < FRESH_TOKEN_WINDOW_MS
-  );
-}
-
-function markTokenAsFresh(): void {
-  freshTokenAcquiredAt = Date.now();
-}
-
-export const token = cmd.option({
-  long: "token",
-  description:
-    "A Vercel authentication token. If not provided, will use the token stored in your system from `VERCEL_AUTH_TOKEN` or will start a log in process.",
-  type: {
-    ...cmd.string,
-    displayName: "pat_or_oidc",
-    defaultValueIsSerializable: false,
-    onMissing: async () => {
-      if (process.env.VERCEL_AUTH_TOKEN) {
-        return process.env.VERCEL_AUTH_TOKEN;
-      }
-
-      if (process.env.VERCEL_OIDC_TOKEN) {
-        try {
-          return await getVercelOidcToken();
-        } catch (cause) {
-          debug(`Failed to get or refresh OIDC token: ${getMessage(cause)}`);
-          console.warn(
-            chalk.yellow(
-              `${chalk.bold("warn:")} failed to get or refresh OIDC token, using personal token authentication.`,
-            ),
-          );
+export const token = traceParser(
+  "token",
+  cmd.option({
+    long: "token",
+    description:
+      "A Vercel authentication token. If not provided, will use the token stored in your system from `VERCEL_AUTH_TOKEN` or will start a log in process.",
+    type: {
+      ...cmd.string,
+      displayName: "pat_or_oidc",
+      defaultValueIsSerializable: false,
+      onMissing: traced({ name: "auth.onMissing" }, async () => {
+        if (process.env.VERCEL_AUTH_TOKEN) {
+          getCurrentSpan()?.setAttribute("auth.source", "environment");
+          return process.env.VERCEL_AUTH_TOKEN;
         }
-      }
 
-      // Try to get CLI token, which handles auth.json reading and refresh
-      try {
-        const previousToken = getAuth()?.token;
-        const storedToken = await getVercelToken();
-        if (previousToken && storedToken !== previousToken) {
-          markTokenAsFresh();
-        }
-        return storedToken;
-      } catch (error) {
-        // Handle specific auth errors by triggering login
-        if (
-          error instanceof AccessTokenMissingError ||
-          error instanceof RefreshAccessTokenFailedError
-        ) {
-          debug(
-            `CLI token unavailable (${error.name}), prompting for login...`,
-          );
-          console.warn(
-            chalk.yellow(
-              `${chalk.bold("notice:")} Your session has expired. Please log in again.`,
-            ),
-          );
-          await login.handler({});
-
-          // Try again after login
+        if (process.env.VERCEL_OIDC_TOKEN) {
           try {
-            const refreshed = await getVercelToken();
-            markTokenAsFresh();
-            return refreshed;
-          } catch (retryError) {
-            throw new Error(
-              [
-                `Failed to retrieve authentication token.`,
-                `${chalk.bold("hint:")} Try logging in again with \`sandbox login\`.`,
-                "╰▶ Docs: https://vercel.com/docs/vercel-sandbox/cli-reference#authentication",
-              ].join("\n"),
+            const oidcToken = await getVercelOidcToken();
+            getCurrentSpan()?.setAttribute("auth.source", "oidc");
+            return oidcToken;
+          } catch (cause) {
+            getCurrentSpan()?.addEvent("auth.oidc_fallback");
+            debug(`Failed to get or refresh OIDC token: ${getMessage(cause)}`);
+            console.warn(
+              chalk.yellow(
+                `${chalk.bold("warn:")} failed to get or refresh OIDC token, using personal token authentication.`,
+              ),
             );
           }
         }
 
-        // Re-throw unexpected errors
-        throw error;
-      }
+        // Try to get CLI token, which handles auth.json reading and refresh
+        try {
+          const previousToken = getAuth()?.token;
+          const storedToken = await getVercelToken();
+          if (previousToken && storedToken !== previousToken) {
+            markTokenAsFresh();
+            getCurrentSpan()?.addEvent("auth.token_refreshed");
+          }
+          getCurrentSpan()?.setAttribute("auth.source", "stored");
+          return storedToken;
+        } catch (error) {
+          // Handle specific auth errors by triggering login
+          if (
+            error instanceof OIDC.AccessTokenMissingError ||
+            error instanceof OIDC.RefreshAccessTokenFailedError
+          ) {
+            debug(
+              `CLI token unavailable (${error.name}), prompting for login...`,
+            );
+            console.warn(
+              chalk.yellow(
+                `${chalk.bold("notice:")} Your session has expired. Please log in again.`,
+              ),
+            );
+            await login.handler({});
+            getCurrentSpan()?.addEvent("auth.login_completed");
+
+            // Try again after login
+            try {
+              const refreshed = await getVercelToken();
+              markTokenAsFresh();
+              getCurrentSpan()?.setAttribute("auth.source", "login");
+              return refreshed;
+            } catch (retryError) {
+              throw new Error(
+                [
+                  `Failed to retrieve authentication token.`,
+                  `${chalk.bold("hint:")} Try logging in again with \`sandbox login\`.`,
+                  "╰▶ Docs: https://vercel.com/docs/vercel-sandbox/cli-reference#authentication",
+                ].join("\n"),
+              );
+            }
+          }
+
+          // Re-throw unexpected errors
+          throw error;
+        }
+      }),
     },
-  },
-});
+  }),
+);
 
 function getMessage(error: unknown): string {
   if (!(error instanceof Error)) {

--- a/packages/sandbox/src/args/scope.ts
+++ b/packages/sandbox/src/args/scope.ts
@@ -7,6 +7,8 @@ import type { ProvidesHelp } from "cmd-ts/dist/esm/helpdoc";
 import { NotOk } from "@vercel/sandbox/dist/auth/index.js";
 import chalk from "chalk";
 import createDebugger from "debug";
+import { trace } from "../otel";
+import { traceParser } from "../util/parser-trace";
 
 const debug = createDebugger("sandbox:scope");
 
@@ -67,7 +69,7 @@ export const scope: ArgParser<{
   projectSlug?: string;
   teamSlug?: string;
 }> &
-  ProvidesHelp = {
+  ProvidesHelp = traceParser("scope", {
   register(ctx) {
     token.register?.(ctx);
     project.register?.(ctx);
@@ -107,9 +109,19 @@ export const scope: ArgParser<{
     ) {
       try {
         const scope = await withFreshAuthRetry(() =>
-          inferScope({
-            token: t.value,
-            team: teamId.value,
+          trace("inferScope", async (span) => {
+            span.setAttribute("input.team", teamId.value || "[missing]");
+            const inferred = await inferScope({
+              token: t.value,
+              team: teamId.value,
+            });
+            span.setAttributes({
+              "inferred.project": inferred.project,
+              "inferred.team": inferred.owner,
+              "inferred.projectSlug": inferred.projectSlug ?? "[missing]",
+              "inferred.teamSlug": inferred.ownerSlug ?? "[missing]",
+            });
+            return inferred;
           }),
         );
         projectId.value ??= scope.project;
@@ -159,4 +171,4 @@ export const scope: ArgParser<{
       category: "Auth & Scope",
     }));
   },
-};
+});

--- a/packages/sandbox/src/client.ts
+++ b/packages/sandbox/src/client.ts
@@ -2,6 +2,21 @@ import { Sandbox, APIError, Snapshot } from "@vercel/sandbox";
 import { version } from "./pkg";
 import { withFreshAuthRetry } from "./util/fresh-auth-retry";
 import { formatApiError } from "./util/format-error";
+import { traced } from "./otel";
+
+const wrapped = {
+  Sandbox: {
+    get: traced({ name: "Sandbox.get" }, Sandbox.get),
+    create: traced({ name: "Sandbox.create" }, Sandbox.create),
+    fork: traced({ name: "Sandbox.fork" }, Sandbox.fork),
+    list: traced({ name: "Sandbox.list" }, Sandbox.list),
+  },
+  Snapshot: {
+    list: traced({ name: "Snapshot.list" }, Snapshot.list),
+    get: traced({ name: "Snapshot.get" }, Snapshot.get),
+    tree: traced({ name: "Snapshot.tree" }, Snapshot.tree),
+  },
+};
 
 /**
  * A {@link Sandbox} wrapper that adds user-agent headers and error handling.
@@ -12,33 +27,39 @@ export const sandboxClient: Pick<
 > = {
   get: (params) =>
     withErrorHandling(() =>
-      Sandbox.get({ fetch: fetchWithUserAgent, resume: false, ...params }),
+      wrapped.Sandbox.get({
+        fetch: fetchWithUserAgent,
+        resume: false,
+        ...params,
+      }),
     ),
   create: (params) =>
     withErrorHandling(() =>
-      Sandbox.create({ fetch: fetchWithUserAgent, ...params }),
+      wrapped.Sandbox.create({ fetch: fetchWithUserAgent, ...params }),
     ),
   fork: (params) =>
     withErrorHandling(() =>
-      Sandbox.fork({ fetch: fetchWithUserAgent, ...params }),
+      wrapped.Sandbox.fork({ fetch: fetchWithUserAgent, ...params }),
     ),
   list: (params) =>
     withErrorHandling(() =>
-      Sandbox.list({ fetch: fetchWithUserAgent, ...params } as typeof params),
+      wrapped.Sandbox.list({
+        fetch: fetchWithUserAgent,
+        ...params,
+      } as typeof params),
     ),
 };
 
-export const snapshotClient: Pick<
-  typeof Snapshot,
-  "get" | "list" | "tree"
-> = {
+export const snapshotClient: Pick<typeof Snapshot, "get" | "list" | "tree"> = {
   list: (params) =>
     withErrorHandling(() =>
-      Snapshot.list({ fetch: fetchWithUserAgent, ...params }),
+      wrapped.Snapshot.list({ fetch: fetchWithUserAgent, ...params }),
     ),
-  get: (params) => withErrorHandling(() => Snapshot.get({ ...params })),
+  get: (params) => withErrorHandling(() => wrapped.Snapshot.get({ ...params })),
   tree: (params) =>
-    withErrorHandling(() => Snapshot.tree({ fetch: fetchWithUserAgent, ...params })),
+    withErrorHandling(() =>
+      wrapped.Snapshot.tree({ fetch: fetchWithUserAgent, ...params }),
+    ),
 };
 
 const fetchWithUserAgent: typeof globalThis.fetch = (input, init) => {

--- a/packages/sandbox/src/commands/cp.ts
+++ b/packages/sandbox/src/commands/cp.ts
@@ -7,6 +7,7 @@ import { scope } from "../args/scope";
 import consume from "node:stream/consumers";
 import ora from "ora";
 import chalk from "chalk";
+import { trace } from "../otel";
 
 export const args = {} as const;
 
@@ -54,25 +55,31 @@ export const cp = cmd.command({
     const spinner = ora({ text: `Reading source file (${source.path})...` }).start();
     let sourceFile: Buffer<ArrayBufferLike> | null = null;
 
-    if (source.type === "local") {
-      sourceFile = await fs.readFile(source.path).catch((err) => {
-        if (err.code === "ENOENT") {
-          return null;
+    sourceFile = await trace("copy.read", async (span) => {
+      span.setAttribute("copy.source", source.type);
+      let content: Buffer<ArrayBufferLike> | null = null;
+      if (source.type === "local") {
+        content = await fs.readFile(source.path).catch((err) => {
+          if (err.code === "ENOENT") {
+            return null;
+          }
+          throw err;
+        });
+      } else {
+        const sandbox = await sandboxClient.get({
+          name: source.sandboxName,
+          teamId: scope.team,
+          token: scope.token,
+          projectId: scope.project,
+        });
+        const file = await sandbox.readFile({ path: source.path });
+        if (file) {
+          content = await consume.buffer(file);
         }
-        throw err;
-      })
-    } else {
-      const sandbox = await sandboxClient.get({
-        name: source.sandboxName,
-        teamId: scope.team,
-        token: scope.token,
-        projectId: scope.project,
-      });
-      const file = await sandbox.readFile({ path: source.path });
-      if (file) {
-        sourceFile = await consume.buffer(file);
       }
-    }
+      if (content) span.setAttribute("copy.bytes", content.byteLength);
+      return content;
+    });
 
     if (!sourceFile) {
       if (source.type === "remote") {
@@ -86,22 +93,29 @@ export const cp = cmd.command({
       } else {
         spinner.fail(`Source file (${source.path}) not found.`);
       }
+      process.exitCode = 1;
       return;
     }
 
     spinner.text = `Writing to destination file (${dest.path})...`;
 
-    if (dest.type === "local") {
-      await fs.writeFile(dest.path, sourceFile);
-    } else {
-      const sandbox = await sandboxClient.get({
-        name: dest.sandboxName,
-        teamId: scope.team,
-        projectId: scope.project,
-        token: scope.token,
+    await trace("copy.write", async (span) => {
+      span.setAttributes({
+        "copy.destination": dest.type,
+        "copy.bytes": sourceFile.byteLength,
       });
-      await sandbox.writeFiles([{ path: dest.path, content: sourceFile }]);
-    }
+      if (dest.type === "local") {
+        await fs.writeFile(dest.path, sourceFile);
+      } else {
+        const sandbox = await sandboxClient.get({
+          name: dest.sandboxName,
+          teamId: scope.team,
+          projectId: scope.project,
+          token: scope.token,
+        });
+        await sandbox.writeFiles([{ path: dest.path, content: sourceFile }]);
+      }
+    });
 
     spinner.succeed(`Copied ${source.path} to ${dest.path} successfully!`);
   },

--- a/packages/sandbox/src/commands/exec.ts
+++ b/packages/sandbox/src/commands/exec.ts
@@ -10,6 +10,8 @@ import { scope } from "../args/scope";
 import { Duration } from "../types/duration";
 import { sandboxClient } from "../client";
 import chalk from "chalk";
+import { SpanStatusCode } from "@opentelemetry/api";
+import { trace } from "../otel";
 
 export const args = {
   sandbox: cmd.positional({
@@ -122,15 +124,30 @@ export const exec = cmd.command({
 
     if (!interactive) {
       console.error(printCommand(command, args));
-      const result = await sandbox.runCommand({
-        cmd: command,
-        args,
-        stderr: process.stderr,
-        stdout: process.stdout,
-        sudo: asSudo,
-        cwd,
-        env: envVars,
-        timeoutMs: timeout ? ms(timeout) : undefined,
+      const result = await trace("Sandbox.runCommand", async (span) => {
+        span.setAttributes({
+          "command.interactive": false,
+          "command.sudo": asSudo,
+          "command.timeout_configured": timeout !== undefined,
+        });
+        const result = await sandbox.runCommand({
+          cmd: command,
+          args,
+          stderr: process.stderr,
+          stdout: process.stdout,
+          sudo: asSudo,
+          cwd,
+          env: envVars,
+          timeoutMs: timeout ? ms(timeout) : undefined,
+        });
+        span.setAttribute("command.exit_code", result.exitCode);
+        if (result.exitCode !== 0) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: `Command exited with code ${result.exitCode}`,
+          });
+        }
+        return result;
       });
 
       // Exit code 137 (128 + SIGKILL) is how a `--timeout` kill surfaces.

--- a/packages/sandbox/src/commands/remove.ts
+++ b/packages/sandbox/src/commands/remove.ts
@@ -3,6 +3,8 @@ import { Listr } from "listr2";
 import { sandboxName } from "../args/sandbox-name";
 import { scope } from "../args/scope";
 import { sandboxClient } from "../client";
+import { getCurrentSpan, trace } from "../otel";
+import { SpanStatusCode } from "@opentelemetry/api";
 
 export const remove = cmd.command({
   name: "remove",
@@ -35,14 +37,19 @@ export const remove = cmd.command({
             projectId: project,
             name,
           });
-          await sandbox.delete();
+          await trace("Sandbox.delete", () => sandbox.delete());
         },
       }),
     );
     try {
       await new Listr(tasks, { concurrent: true }).run();
-    } catch {
+    } catch (error) {
       // Listr already rendered the error; just set exit code
+      // Preserve the failure in the active command trace even though Listr
+      // already consumed and displayed it.
+      const span = getCurrentSpan();
+      if (error instanceof Error) span?.recordException(error);
+      span?.setStatus({ code: SpanStatusCode.ERROR });
       process.exitCode = 1;
     }
   },

--- a/packages/sandbox/src/commands/run.ts
+++ b/packages/sandbox/src/commands/run.ts
@@ -5,6 +5,7 @@ import * as Exec from "./exec";
 import { sandboxClient } from "../client";
 import { StyledError } from "../error";
 import { omit } from "../util/omit";
+import { trace } from "../otel";
 
 const args = {
   ...Create.args,
@@ -58,10 +59,10 @@ export const run = cmd.command({
       await Exec.exec.handler({ ...rest, sandbox, timeout: undefined });
     } finally {
       if (removeAfterUse) {
-        await sandbox.delete();
+        await trace("run.cleanup.delete", () => sandbox.delete());
       }
       if (stopAfterUse) {
-        await sandbox.stop();
+        await trace("run.cleanup.stop", () => sandbox.stop());
       }
     }
   },

--- a/packages/sandbox/src/commands/sh.ts
+++ b/packages/sandbox/src/commands/sh.ts
@@ -1,15 +1,15 @@
 import * as cmd from "cmd-ts";
 import * as Create from "./create";
 import { omit } from "../util/omit";
+import { trace } from "../otel";
 
 export const sh = cmd.command({
   name: "sh",
   description: "Create a sandbox and start an interactive shell",
   args: omit(Create.args, "connect"),
   async handler(args) {
-    return Create.create.handler({
-      ...args,
-      connect: true,
+    return await trace("sh", () => {
+      return Create.create.handler({ ...args, connect: true });
     });
   },
 });

--- a/packages/sandbox/src/commands/snapshot.ts
+++ b/packages/sandbox/src/commands/snapshot.ts
@@ -7,6 +7,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { Duration } from "../types/duration";
 import ms from "ms";
+import { trace } from "../otel";
 
 export const args = {
   stop: cmd.flag({
@@ -74,9 +75,11 @@ export const snapshot = cmd.command({
     }
 
     const spinner = silent ? undefined : ora("Creating snapshot...").start();
-    const snapshot = await sandbox.snapshot({
-      expiration: expiration === undefined ? undefined : ms(expiration),
-    });
+    const snapshot = await trace("Sandbox.snapshot", () =>
+      sandbox.snapshot({
+        expiration: expiration === undefined ? undefined : ms(expiration),
+      }),
+    );
     spinner?.succeed(`Snapshot ${snapshot.snapshotId} created.`);
   },
 });

--- a/packages/sandbox/src/commands/snapshots.ts
+++ b/packages/sandbox/src/commands/snapshots.ts
@@ -8,6 +8,7 @@ import { sandboxName } from "../args/sandbox-name";
 import { snapshotId } from "../args/snapshot-id";
 import { sandboxClient, snapshotClient } from "../client";
 import { acquireRelease } from "../util/disposables";
+import { trace } from "../otel";
 import { formatBytes, formatNextCursorHint, table, timeAgo } from "../util/output";
 import { renderSnapshotTree } from "../util/snapshot-tree";
 
@@ -159,7 +160,7 @@ const remove = cmd.command({
                 `Snapshot ${snapshotId} is in status "${snapshot.status}" and cannot be deleted.`,
               );
             }
-            await snapshot.delete();
+            await trace("Snapshot.delete", () => snapshot.delete());
           },
         };
       },

--- a/packages/sandbox/src/commands/stop.ts
+++ b/packages/sandbox/src/commands/stop.ts
@@ -6,6 +6,7 @@ import { sandboxName } from "../args/sandbox-name";
 import { scope } from "../args/scope";
 import { sandboxClient } from "../client";
 import { formatBytes, formatRunDuration, timeAgo } from "../util/output";
+import { trace } from "../otel";
 
 type StopResult = Awaited<ReturnType<Sandbox["stop"]>>;
 
@@ -104,16 +105,18 @@ export const stop = cmd.command({
     }).start();
 
     const results = await Promise.allSettled(
-      names.map(async (name) => {
-        const sandbox = await sandboxClient.get({
-          token,
-          teamId: team,
-          projectId: project,
-          name,
-        });
-        const sessionSnapshot = await sandbox.stop();
-        return { name, sandbox, sessionSnapshot };
-      }),
+      names.map((name) =>
+        trace("Sandbox.stop", async () => {
+          const sandbox = await sandboxClient.get({
+            token,
+            teamId: team,
+            projectId: project,
+            name,
+          });
+          const sessionSnapshot = await sandbox.stop();
+          return { name, sandbox, sessionSnapshot };
+        }),
+      ),
     );
 
     spinner.stop();

--- a/packages/sandbox/src/commands/traces.ts
+++ b/packages/sandbox/src/commands/traces.ts
@@ -1,0 +1,10 @@
+import * as cmd from "cmd-ts";
+import { getTracesPath } from "../otel";
+
+export const traces = cmd.command({
+  name: "traces",
+  args: {},
+  async handler() {
+    console.log(getTracesPath());
+  },
+});

--- a/packages/sandbox/src/file-span-exporter.ts
+++ b/packages/sandbox/src/file-span-exporter.ts
@@ -1,0 +1,86 @@
+import { ExportResultCode, type ExportResult } from "@opentelemetry/core";
+import { JsonTraceSerializer } from "@opentelemetry/otlp-transformer";
+import type {
+  ReadableSpan,
+  SpanExporter,
+} from "@opentelemetry/sdk-trace-base";
+import { appendFileSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Appends spans as OTLP/JSON `ExportTraceServiceRequest` lines (JSONL) to a
+ * file under the given directory, one file per process invocation.
+ *
+ * Writes are synchronous so every ended span is on disk immediately, which
+ * keeps traces intact through `process.exit()` and signals. Each line is a
+ * self-contained OTLP payload that can be replayed into Jaeger or Tempo via
+ * their OTLP HTTP endpoints.
+ */
+export class FileSpanExporter implements SpanExporter {
+  private filePath: string | undefined;
+  private disabled = false;
+
+  constructor(private readonly directory: string) {}
+
+  export(
+    spans: ReadableSpan[],
+    resultCallback: (result: ExportResult) => void,
+  ): void {
+    if (this.disabled) {
+      resultCallback({ code: ExportResultCode.FAILED });
+      return;
+    }
+
+    try {
+      const serialized = JsonTraceSerializer.serializeRequest(spans);
+      if (!serialized) {
+        resultCallback({ code: ExportResultCode.FAILED });
+        return;
+      }
+
+      const line = Buffer.concat([Buffer.from(serialized), NEWLINE]);
+      appendFileSync(this.getFilePath(), line);
+      resultCallback({ code: ExportResultCode.SUCCESS });
+    } catch (error) {
+      // If we can't write (read-only cwd, etc), give up quietly. Tracing
+      // must never take the CLI down with it.
+      this.disabled = true;
+      resultCallback({
+        code: ExportResultCode.FAILED,
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+    }
+  }
+
+  private getFilePath(): string {
+    if (!this.filePath) {
+      mkdirSync(this.directory, { recursive: true });
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      this.filePath = join(this.directory, `${timestamp}-${process.pid}.jsonl`);
+      pruneTraceFiles(this.directory, MAX_TRACE_FILES - 1);
+    }
+    return this.filePath;
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+function pruneTraceFiles(directory: string, keep: number): void {
+  const traceFiles = readdirSync(directory)
+    .filter((fileName) => fileName.endsWith(".jsonl"))
+    .sort()
+    .reverse();
+
+  for (const fileName of traceFiles.slice(keep)) {
+    rmSync(join(directory, fileName), { force: true });
+  }
+}
+
+const MAX_TRACE_FILES = 10;
+const NEWLINE = Buffer.from("\n");

--- a/packages/sandbox/src/interactive-shell/extend-sandbox-timeout.ts
+++ b/packages/sandbox/src/interactive-shell/extend-sandbox-timeout.ts
@@ -2,6 +2,7 @@ import type { Sandbox } from "@vercel/sandbox";
 import ms from "ms";
 import createDebugger from "debug";
 import { setTimeout } from "node:timers/promises";
+import { trace } from "../otel";
 
 const debug = createDebugger("sandbox:timeout");
 
@@ -28,7 +29,9 @@ export async function extendSandboxTimeoutPeriodically(
       debug(`sleeping for ${sleepMs}ms until next timeout extension`);
       await setTimeout(sleepMs, null, { signal });
     }
-    await sandbox.extendTimeout(ms("5 minutes"));
+    await trace("Sandbox.extendTimeout", () =>
+      sandbox.extendTimeout(ms("5 minutes")),
+    );
     const updatedTimeout = session.timeout;
     if (updatedTimeout == null) return;
     const nextTick = session.createdAt.getTime() + updatedTimeout;

--- a/packages/sandbox/src/interactive-shell/interactive-shell.ts
+++ b/packages/sandbox/src/interactive-shell/interactive-shell.ts
@@ -1,4 +1,5 @@
 import { Sandbox } from "@vercel/sandbox";
+import { SpanStatusCode } from "@opentelemetry/api";
 import createDebugger from "debug";
 import { WebSocket } from "ws";
 import { printCommand } from "../util/print-command";
@@ -6,6 +7,7 @@ import ora from "ora";
 import { acquireRelease, createAbortController, defer } from "../util/disposables";
 import chalk from "chalk";
 import { extendSandboxTimeoutPeriodically } from "./extend-sandbox-timeout";
+import { trace } from "../otel";
 
 const debug = createDebugger("sandbox:interactive-shell");
 
@@ -69,7 +71,9 @@ export async function startInteractiveShell(options: {
   );
 
   progress.text = "Opening interactive session...";
-  const { url, token } = await options.sandbox.openInteractive();
+  const { url, token } = await trace("Sandbox.openInteractive", () =>
+    options.sandbox.openInteractive(),
+  );
 
   const [command, ...args] = options.execution;
   const execution: [string, ...string[]] = options.sudo
@@ -86,10 +90,12 @@ export async function startInteractiveShell(options: {
     }
   });
 
-  await new Promise<void>((resolve, reject) => {
-    client.once("open", () => resolve());
-    client.once("error", (err) => reject(err));
-  });
+  await trace("Interactive.connect", () =>
+    new Promise<void>((resolve, reject) => {
+      client.once("open", () => resolve());
+      client.once("error", (err) => reject(err));
+    }),
+  );
   debug("connected to %s", url);
 
   client.send(
@@ -156,9 +162,23 @@ export async function startInteractiveShell(options: {
 
   console.error(printCommand(options.execution[0], options.execution.slice(1)));
 
-  await new Promise<void>((resolve, reject) => {
-    client.once("close", () => resolve());
-    client.once("error", (err) => reject(err));
+  await trace("Interactive.session", async (span) => {
+    await new Promise<void>((resolve, reject) => {
+      client.once("close", (code) => {
+        span.setAttribute("websocket.close_code", code);
+        resolve();
+      });
+      client.once("error", (err) => reject(err));
+    });
+    if (process.exitCode !== undefined) {
+      span.setAttribute("command.exit_code", process.exitCode);
+      if (process.exitCode !== 0) {
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: `Command exited with code ${process.exitCode}`,
+        });
+      }
+    }
   });
 
   extension.abort("client disconnected");

--- a/packages/sandbox/src/otel.ts
+++ b/packages/sandbox/src/otel.ts
@@ -10,8 +10,8 @@ let provider:
   | import("@opentelemetry/sdk-trace-node").NodeTracerProvider
   | undefined;
 let shutdownRegistered = false;
-let fetchInstrumentation:
-  | import("@opentelemetry/instrumentation-fetch").FetchInstrumentation
+let undiciInstrumentation:
+  | import("@opentelemetry/instrumentation-undici").UndiciInstrumentation
   | undefined;
 
 export function traced<Args extends unknown[], T>(
@@ -71,10 +71,10 @@ export function getTracesPath() {
 
 export async function setupOtel(): Promise<typeof provider> {
   try {
-    const [fileExporter, fetch, resources, traceBase, traceNode, conventions] =
+    const [fileExporter, undici, resources, traceBase, traceNode, conventions] =
       await Promise.all([
         import("./file-span-exporter"),
-        import("@opentelemetry/instrumentation-fetch"),
+        import("@opentelemetry/instrumentation-undici"),
         import("@opentelemetry/resources"),
         import("@opentelemetry/sdk-trace-base"),
         import("@opentelemetry/sdk-trace-node"),
@@ -104,26 +104,20 @@ export async function setupOtel(): Promise<typeof provider> {
       spanProcessors,
     });
     provider.register();
-    fetchInstrumentation = new fetch.FetchInstrumentation({
-      propagateTraceHeaderCorsUrls: [/.*/],
-      applyCustomAttributesOnSpan(span, req, res) {
-        let urlString = "url" in res ? res.url : "url" in req ? req.url : "";
-        if (urlString) {
-          try {
-            const url = new URL(urlString);
-            url.search = "";
-            urlString = url.toString();
-          } catch {}
-        }
-
-        span.updateName(`${req.method || "GET"} ${urlString}`);
+    undiciInstrumentation = new undici.UndiciInstrumentation({
+      requireParentforSpans: true,
+      requestHook(span, request) {
+        // Keep query strings out of locally retained traces. Undici exposes
+        // origin and path separately, so no credentials are needed here.
+        const pathname = request.path.split("?", 1)[0];
+        span.updateName(`${request.method} ${request.origin}${pathname}`);
       },
     });
-    fetchInstrumentation.enable();
+    undiciInstrumentation.enable();
     registerShutdown();
   } catch {
     provider = undefined;
-    fetchInstrumentation = undefined;
+    undiciInstrumentation = undefined;
   }
 
   return provider;
@@ -143,7 +137,7 @@ function registerShutdown() {
   shutdownRegistered = true;
 
   process.once("beforeExit", () => {
-    fetchInstrumentation?.disable();
+    undiciInstrumentation?.disable();
     void provider?.shutdown().catch(() => undefined);
   });
 }

--- a/packages/sandbox/src/otel.ts
+++ b/packages/sandbox/src/otel.ts
@@ -3,6 +3,8 @@ import {
   trace as otelTrace,
   type Span,
 } from "@opentelemetry/api";
+import path from "node:path";
+import XDGAppPaths from "xdg-app-paths";
 
 let provider:
   | import("@opentelemetry/sdk-trace-node").NodeTracerProvider
@@ -63,15 +65,15 @@ export async function trace<T>(
   });
 }
 
-export async function setupOtel(): Promise<typeof provider> {
-  if (!hasOtelExporterConfig()) {
-    return undefined;
-  }
+export function getTracesPath() {
+  return path.join(XDGAppPaths("com.vercel.sandbox").cache(), "traces");
+}
 
+export async function setupOtel(): Promise<typeof provider> {
   try {
-    const [exporter, fetch, resources, traceBase, traceNode, conventions] =
+    const [fileExporter, fetch, resources, traceBase, traceNode, conventions] =
       await Promise.all([
-        import("@opentelemetry/exporter-trace-otlp-http"),
+        import("./file-span-exporter"),
         import("@opentelemetry/instrumentation-fetch"),
         import("@opentelemetry/resources"),
         import("@opentelemetry/sdk-trace-base"),
@@ -79,14 +81,27 @@ export async function setupOtel(): Promise<typeof provider> {
         import("@opentelemetry/semantic-conventions"),
       ]);
 
+    // Always write traces to disk as OTLP/JSON lines so they can be loaded
+    // into Jaeger/Tempo later, even without an OTLP endpoint configured.
+    const spanProcessors = [
+      new traceBase.SimpleSpanProcessor(
+        new fileExporter.FileSpanExporter(getTracesPath()),
+      ),
+    ];
+
+    if (hasOtelExporterConfig()) {
+      const exporter = await import("@opentelemetry/exporter-trace-otlp-http");
+      spanProcessors.push(
+        new traceBase.SimpleSpanProcessor(new exporter.OTLPTraceExporter({})),
+      );
+    }
+
     provider = new traceNode.NodeTracerProvider({
       resource: new resources.Resource({
         [conventions.ATTR_SERVICE_NAME]:
           process.env.OTEL_SERVICE_NAME ?? "sandbox-cli",
       }),
-      spanProcessors: [
-        new traceBase.SimpleSpanProcessor(new exporter.OTLPTraceExporter({})),
-      ],
+      spanProcessors,
     });
     provider.register();
     fetchInstrumentation = new fetch.FetchInstrumentation({

--- a/packages/sandbox/src/otel.ts
+++ b/packages/sandbox/src/otel.ts
@@ -38,6 +38,14 @@ export async function trace<T>(
   const tracer = otelTrace.getTracer("sandbox-cli");
 
   return tracer.startActiveSpan(name, async (span) => {
+    let setStatus: undefined | (typeof span)["setStatus"] =
+      span.setStatus.bind(span);
+    span.setStatus = (status) => {
+      setStatus?.(status);
+      setStatus = undefined;
+      return span;
+    };
+
     try {
       const result = await callback(span);
       span.setStatus({ code: SpanStatusCode.OK });

--- a/packages/sandbox/src/otel.ts
+++ b/packages/sandbox/src/otel.ts
@@ -1,0 +1,141 @@
+import {
+  SpanStatusCode,
+  trace as otelTrace,
+  type Span,
+} from "@opentelemetry/api";
+
+let provider:
+  | import("@opentelemetry/sdk-trace-node").NodeTracerProvider
+  | undefined;
+let shutdownRegistered = false;
+let fetchInstrumentation:
+  | import("@opentelemetry/instrumentation-fetch").FetchInstrumentation
+  | undefined;
+
+export function traced<Args extends unknown[], T>(
+  ...bag:
+    | [{ name: string }, (...args: Args) => Promise<T>]
+    | [(...args: Args) => Promise<T>]
+): (...args: Args) => Promise<T> {
+  const fn = bag.length === 1 ? bag[0] : bag[1];
+  const opts = bag.length === 2 ? bag[0] : { name: fn.name };
+
+  return async (...args) => {
+    return trace(opts.name || "ANONYMOUS SPAN", () => {
+      return fn(...args);
+    });
+  };
+}
+
+export function getCurrentSpan() {
+  return otelTrace.getActiveSpan();
+}
+
+export async function trace<T>(
+  name: string,
+  callback: (span: Span) => Promise<T>,
+): Promise<T> {
+  const tracer = otelTrace.getTracer("sandbox-cli");
+
+  return tracer.startActiveSpan(name, async (span) => {
+    try {
+      const result = await callback(span);
+      span.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (error) {
+      recordException(span, error);
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: getErrorMessage(error),
+      });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+export async function setupOtel(): Promise<typeof provider> {
+  if (!hasOtelExporterConfig()) {
+    return undefined;
+  }
+
+  try {
+    const [exporter, fetch, resources, traceBase, traceNode, conventions] =
+      await Promise.all([
+        import("@opentelemetry/exporter-trace-otlp-http"),
+        import("@opentelemetry/instrumentation-fetch"),
+        import("@opentelemetry/resources"),
+        import("@opentelemetry/sdk-trace-base"),
+        import("@opentelemetry/sdk-trace-node"),
+        import("@opentelemetry/semantic-conventions"),
+      ]);
+
+    provider = new traceNode.NodeTracerProvider({
+      resource: new resources.Resource({
+        [conventions.ATTR_SERVICE_NAME]:
+          process.env.OTEL_SERVICE_NAME ?? "sandbox-cli",
+      }),
+      spanProcessors: [
+        new traceBase.SimpleSpanProcessor(new exporter.OTLPTraceExporter({})),
+      ],
+    });
+    provider.register();
+    fetchInstrumentation = new fetch.FetchInstrumentation({
+      propagateTraceHeaderCorsUrls: [/.*/],
+      applyCustomAttributesOnSpan(span, req, res) {
+        let urlString = "url" in res ? res.url : "url" in req ? req.url : "";
+        if (urlString) {
+          try {
+            const url = new URL(urlString);
+            url.search = "";
+            urlString = url.toString();
+          } catch {}
+        }
+
+        span.updateName(`${req.method || "GET"} ${urlString}`);
+      },
+    });
+    fetchInstrumentation.enable();
+    registerShutdown();
+  } catch {
+    provider = undefined;
+    fetchInstrumentation = undefined;
+  }
+
+  return provider;
+}
+
+function hasOtelExporterConfig(): boolean {
+  return Boolean(
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ||
+      process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+  );
+}
+
+function registerShutdown() {
+  if (shutdownRegistered) {
+    return;
+  }
+  shutdownRegistered = true;
+
+  process.once("beforeExit", () => {
+    fetchInstrumentation?.disable();
+    void provider?.shutdown().catch(() => undefined);
+  });
+}
+
+function recordException(span: Span, error: unknown) {
+  if (error instanceof Error) {
+    span.recordException(error);
+  } else {
+    span.recordException(String(error));
+  }
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -10,17 +10,24 @@ dotenv.config({
 });
 
 async function main() {
-  await setupOtel();
+  const args = process.argv.slice(2);
+
+  if (!isTracesCommand(args)) {
+    await setupOtel();
+  }
+
   setDefaultHelpFormatter(vercelFormatter);
 
   try {
-    await trace(`$ sandbox ${process.argv.slice(2).join(" ")}`, () =>
-      run(app(), process.argv.slice(2)),
-    );
+    await trace(`$ sandbox ${args.join(" ")}`, () => run(app(), args));
   } catch (e) {
     await printTopLevelError(e);
     process.exit(1);
   }
+}
+
+function isTracesCommand(args: string[]): boolean {
+  return args[0] === "_traces" || args[0] === "traces";
 }
 
 main();

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -3,16 +3,20 @@ import { app } from "./app";
 import dotenv from "dotenv-flow";
 import { printTopLevelError } from "./util/format-error";
 import { vercelFormatter } from "cmd-ts/batteries/vercel-formatter";
+import { setupOtel, trace } from "./otel";
 
 dotenv.config({
   silent: true,
 });
 
 async function main() {
+  await setupOtel();
   setDefaultHelpFormatter(vercelFormatter);
 
   try {
-    await run(app(), process.argv.slice(2));
+    await trace(`$ sandbox ${process.argv.slice(2).join(" ")}`, () =>
+      run(app(), process.argv.slice(2)),
+    );
   } catch (e) {
     await printTopLevelError(e);
     process.exit(1);

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -3,6 +3,7 @@ import { app } from "./app";
 import dotenv from "dotenv-flow";
 import { printTopLevelError } from "./util/format-error";
 import { vercelFormatter } from "cmd-ts/batteries/vercel-formatter";
+import { SpanStatusCode } from "@opentelemetry/api";
 import { setupOtel, trace } from "./otel";
 
 dotenv.config({
@@ -19,12 +20,49 @@ async function main() {
   setDefaultHelpFormatter(vercelFormatter);
 
   try {
-    await trace(`$ sandbox ${args.join(" ")}`, () => run(app(), args));
+    const command = getCommandName(args);
+    await trace(`sandbox ${command}`, async (span) => {
+      span.setAttribute("cli.command", command);
+      await run(app(), args);
+      if (process.exitCode && process.exitCode !== 0) {
+        span.setAttribute("cli.exit_code", process.exitCode);
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: `Command exited with code ${process.exitCode}`,
+        });
+      }
+    });
   } catch (e) {
     await printTopLevelError(e);
     process.exit(1);
   }
 }
+
+function getCommandName(args: string[]): string {
+  const command = args.find((arg) => COMMAND_NAMES.has(arg));
+  return command ?? "unknown";
+}
+
+const COMMAND_NAMES = new Set([
+  "config",
+  "connect",
+  "copy",
+  "cp",
+  "create",
+  "exec",
+  "fork",
+  "list",
+  "login",
+  "logout",
+  "remove",
+  "rm",
+  "run",
+  "sessions",
+  "sh",
+  "snapshot",
+  "snapshots",
+  "stop",
+]);
 
 function isTracesCommand(args: string[]): boolean {
   return args[0] === "_traces" || args[0] === "traces";

--- a/packages/sandbox/src/util/fresh-auth-retry.ts
+++ b/packages/sandbox/src/util/fresh-auth-retry.ts
@@ -3,6 +3,7 @@ import { APIError } from "@vercel/sandbox";
 import { NotOk } from "@vercel/sandbox/dist/auth/index.js";
 import createDebugger from "debug";
 import { isTokenFresh } from "../args/auth";
+import { getCurrentSpan } from "../otel";
 
 const debug = createDebugger("sandbox:fresh-auth-retry");
 
@@ -21,6 +22,7 @@ export async function withFreshAuthRetry<T>(
         const status = getAuthFailureStatus(error);
         if (status !== undefined && isTokenFresh()) {
           debug(`fresh-auth retry attempt ${attempt} (status ${status})`);
+          getCurrentSpan()?.addEvent("auth.retry", { attempt, status });
           throw error;
         }
         bail(error as Error);

--- a/packages/sandbox/src/util/parser-trace.ts
+++ b/packages/sandbox/src/util/parser-trace.ts
@@ -1,0 +1,22 @@
+import { ArgParser } from "cmd-ts/dist/esm/argparser";
+import { trace } from "../otel";
+import { SpanStatusCode } from "@opentelemetry/api";
+
+export function traceParser<T extends ArgParser<any>>(
+  name: string,
+  parser: T,
+): T {
+  return {
+    ...parser,
+    async parse(ctx) {
+      return await trace(name, async (span) => {
+        const value = await parser.parse(ctx);
+        if (value._tag === "error") {
+          span.setStatus({ code: SpanStatusCode.ERROR });
+          span.recordException(JSON.stringify(value.error, null, 2));
+        }
+        return value;
+      });
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,27 @@ importers:
 
   packages/sandbox:
     dependencies:
+      '@opentelemetry/api':
+        specifier: 1.9.0
+        version: 1.9.0
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.57.2
+        version: 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-fetch':
+        specifier: ^0.218.0
+        version: 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources':
+        specifier: ^1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.28.0
+        version: 1.41.1
       '@vercel/sandbox':
         specifier: workspace:*
         version: link:../vercel-sandbox
@@ -1654,9 +1675,133 @@ packages:
     resolution: {integrity: sha512-5N/X/FzlJaYfpaHwDC0YHzOzKDWa41s9t+4FpCDu4f9OMReds4JeNBaaWk9rlIzdKjh2M6AC5Q18ORfECRkHGA==}
     engines: {node: '>=18.0.0'}
 
+  '@opentelemetry/api-logs@0.218.0':
+    resolution: {integrity: sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api-logs@0.57.2':
+    resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
+    engines: {node: '>=14'}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@1.30.1':
+    resolution: {integrity: sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@1.30.1':
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.7.1':
+    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-trace-otlp-http@0.57.2':
+    resolution: {integrity: sha512-sB/gkSYFu+0w2dVQ0PWY9fAMl172PKMZ/JrHkkW8dmjCL0CYkmXeE+ssqIL/yBUTPOvpLIpenX5T9RwXRBW/3g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-fetch@0.218.0':
+    resolution: {integrity: sha512-eP/Y5hDupb+6MwZSaMw4ZdsDz8YgfJbJ4Ta86BMVeOmI2EArwXcd0v1nfNIvUzXTPi7nakidwqeuUa3FwRwECg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.218.0':
+    resolution: {integrity: sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.57.2':
+    resolution: {integrity: sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.57.2':
+    resolution: {integrity: sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagator-b3@1.30.1':
+    resolution: {integrity: sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@1.30.1':
+    resolution: {integrity: sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@1.30.1':
+    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@2.7.1':
+    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.57.2':
+    resolution: {integrity: sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@1.30.1':
+    resolution: {integrity: sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@1.30.1':
+    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@1.30.1':
+    resolution: {integrity: sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-web@2.7.1':
+    resolution: {integrity: sha512-K806OouCSOjMd8Nr7+ZCq3QT22tdAzzS/7h8vprfiKjkgFQ99/dvwU8d12WJANA6D5Qtme65hyBAqAu9CkQuxQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
 
   '@oxc-project/runtime@0.96.0':
     resolution: {integrity: sha512-34lh4o9CcSw09Hx6fKihPu85+m+4pmDlkXwJrLvN5nMq5JrcGhhihVM415zDqT8j8IixO1PYYdQZRN4SwQCncg==}
@@ -1664,6 +1809,33 @@ packages:
 
   '@oxc-project/types@0.98.0':
     resolution: {integrity: sha512-Vzmd6FsqVuz5HQVcRC/hrx7Ujo3WEVeQP7C2UNP5uy1hUY4SQvMB+93jxkI1KRHz9a/6cni3glPOtvteN+zpsw==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@quansync/fs@0.1.5':
     resolution: {integrity: sha512-lNS9hL2aS2NZgNW7BBj+6EBl4rOf8l+tQ0eRY6JWCI8jI2kc53gSoqbjojU0OnAWhzoXiOjFyGsHcDGePB3lhA==}
@@ -3158,6 +3330,9 @@ packages:
   citty@0.2.1:
     resolution: {integrity: sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==}
 
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -3525,6 +3700,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -3932,6 +4110,10 @@ packages:
     resolution: {integrity: sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==}
     engines: {node: '>=4'}
 
+  import-in-the-middle@3.3.0:
+    resolution: {integrity: sha512-v4+k+PLt4z6g2ydEcXhfinTJxfgKJDWOW0v0GZNA5n2qToHFObpH4nGLhJdwnXnX4T14oREx/M62dS9GkpmSbQ==}
+    engines: {node: '>=18'}
+
   indent-string@3.2.0:
     resolution: {integrity: sha512-BYqTHXTGUIvg7t1r4sJNKcbDZkL92nkXA8YtRpbjFHRHGDL/NtUeiBJMeE60kIFN/Mg8ESaWQvftaYMGJzQZCQ==}
     engines: {node: '>=4'}
@@ -4327,6 +4509,9 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -4608,6 +4793,9 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -4975,6 +5163,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -5092,6 +5284,10 @@ packages:
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -7167,7 +7363,7 @@ snapshots:
       is-wsl: 2.2.0
       lilconfig: 3.1.3
       minimatch: 10.2.4
-      semver: 7.7.4
+      semver: 7.8.1
       string-width: 4.2.3
       supports-color: 8.1.1
       tinyglobby: 0.2.15
@@ -7179,11 +7375,167 @@ snapshots:
     dependencies:
       '@oclif/core': 4.8.1
 
+  '@opentelemetry/api-logs@0.218.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api-logs@0.57.2':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/exporter-trace-otlp-http@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/instrumentation-fetch@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-web': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.218.0
+      import-in-the-middle: 3.3.0
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-transformer@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      protobufjs: 7.6.5
+
+  '@opentelemetry/propagator-b3@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/propagator-jaeger@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      semver: 7.8.1
+
+  '@opentelemetry/sdk-trace-web@2.7.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/semantic-conventions@1.28.0': {}
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
 
   '@oxc-project/runtime@0.96.0': {}
 
   '@oxc-project/types@0.98.0': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@quansync/fs@0.1.5':
     dependencies:
@@ -8985,6 +9337,8 @@ snapshots:
 
   citty@0.2.1: {}
 
+  cjs-module-lexer@2.2.0: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -9284,6 +9638,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.3.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -9872,6 +10228,12 @@ snapshots:
       caller-path: 2.0.0
       resolve-from: 3.0.0
 
+  import-in-the-middle@3.3.0:
+    dependencies:
+      cjs-module-lexer: 2.2.0
+      es-module-lexer: 2.3.0
+      module-details-from-path: 1.0.4
+
   indent-string@3.2.0: {}
 
   indent-string@4.0.0: {}
@@ -10214,6 +10576,8 @@ snapshots:
       slice-ansi: 7.1.0
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.0
+
+  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -10681,6 +11045,8 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
+  module-details-from-path@1.0.4: {}
+
   mri@1.2.0: {}
 
   ms@2.0.0: {}
@@ -11013,6 +11379,20 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 20.19.11
+      long: 5.3.2
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -11172,6 +11552,13 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   resolve-alpn@1.2.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,9 +290,9 @@ importers:
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.57.2
         version: 0.57.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-fetch':
-        specifier: ^0.218.0
-        version: 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-undici':
+        specifier: 0.10.0
+        version: 0.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer':
         specifier: ^0.57.2
         version: 0.57.2(@opentelemetry/api@1.9.0)
@@ -316,7 +316,7 @@ importers:
         version: 1.3.3
       debug:
         specifier: ^4.4.1
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3
       ws:
         specifier: ^8.21.0
         version: 8.21.0
@@ -1681,10 +1681,6 @@ packages:
     resolution: {integrity: sha512-5N/X/FzlJaYfpaHwDC0YHzOzKDWa41s9t+4FpCDu4f9OMReds4JeNBaaWk9rlIzdKjh2M6AC5Q18ORfECRkHGA==}
     engines: {node: '>=18.0.0'}
 
-  '@opentelemetry/api-logs@0.218.0':
-    resolution: {integrity: sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==}
-    engines: {node: '>=8.0.0'}
-
   '@opentelemetry/api-logs@0.57.2':
     resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
     engines: {node: '>=14'}
@@ -1705,27 +1701,21 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/core@2.7.1':
-    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
   '@opentelemetry/exporter-trace-otlp-http@0.57.2':
     resolution: {integrity: sha512-sB/gkSYFu+0w2dVQ0PWY9fAMl172PKMZ/JrHkkW8dmjCL0CYkmXeE+ssqIL/yBUTPOvpLIpenX5T9RwXRBW/3g==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/instrumentation-fetch@0.218.0':
-    resolution: {integrity: sha512-eP/Y5hDupb+6MwZSaMw4ZdsDz8YgfJbJ4Ta86BMVeOmI2EArwXcd0v1nfNIvUzXTPi7nakidwqeuUa3FwRwECg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
+  '@opentelemetry/instrumentation-undici@0.10.0':
+    resolution: {integrity: sha512-vm+V255NGw9gaSsPD6CP0oGo8L55BffBc8KnxqsMuc6XiAD1L8SFNzsW0RHhxJFqy9CJaJh+YiJ5EHXuZ5rZBw==}
+    engines: {node: '>=14'}
     peerDependencies:
-      '@opentelemetry/api': ^1.3.0
+      '@opentelemetry/api': ^1.7.0
 
-  '@opentelemetry/instrumentation@0.218.0':
-    resolution: {integrity: sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
+  '@opentelemetry/instrumentation@0.57.2':
+    resolution: {integrity: sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -1759,12 +1749,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/resources@2.7.1':
-    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
   '@opentelemetry/sdk-logs@0.57.2':
     resolution: {integrity: sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==}
     engines: {node: '>=14'}
@@ -1783,21 +1767,9 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/sdk-trace-base@2.7.1':
-    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
   '@opentelemetry/sdk-trace-node@1.30.1':
     resolution: {integrity: sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==}
     engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace-web@2.7.1':
-    resolution: {integrity: sha512-K806OouCSOjMd8Nr7+ZCq3QT22tdAzzS/7h8vprfiKjkgFQ99/dvwU8d12WJANA6D5Qtme65hyBAqAu9CkQuxQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
@@ -2670,6 +2642,9 @@ packages:
   '@types/retry@0.12.5':
     resolution: {integrity: sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==}
 
+  '@types/shimmer@1.2.0':
+    resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
+
   '@types/tar-stream@3.1.4':
     resolution: {integrity: sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==}
 
@@ -2970,6 +2945,11 @@ packages:
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
+
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
 
   acorn-walk@8.3.4:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
@@ -3336,8 +3316,8 @@ packages:
   citty@0.2.1:
     resolution: {integrity: sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==}
 
-  cjs-module-lexer@2.2.0:
-    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -3707,9 +3687,6 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
-  es-module-lexer@2.3.0:
-    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
-
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -3964,9 +3941,6 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
-  get-tsconfig@4.10.1:
-    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
-
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
 
@@ -4116,9 +4090,8 @@ packages:
     resolution: {integrity: sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==}
     engines: {node: '>=4'}
 
-  import-in-the-middle@3.3.0:
-    resolution: {integrity: sha512-v4+k+PLt4z6g2ydEcXhfinTJxfgKJDWOW0v0GZNA5n2qToHFObpH4nGLhJdwnXnX4T14oREx/M62dS9GkpmSbQ==}
-    engines: {node: '>=18'}
+  import-in-the-middle@1.15.0:
+    resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
 
   indent-string@3.2.0:
     resolution: {integrity: sha512-BYqTHXTGUIvg7t1r4sJNKcbDZkL92nkXA8YtRpbjFHRHGDL/NtUeiBJMeE60kIFN/Mg8ESaWQvftaYMGJzQZCQ==}
@@ -5291,9 +5264,9 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
-  require-in-the-middle@8.0.1:
-    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
-    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+  require-in-the-middle@7.5.2:
+    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
+    engines: {node: '>=8.6.0'}
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -5478,6 +5451,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shimmer@1.2.1:
+    resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -7381,10 +7357,6 @@ snapshots:
     dependencies:
       '@oclif/core': 4.8.1
 
-  '@opentelemetry/api-logs@0.218.0':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-
   '@opentelemetry/api-logs@0.57.2':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -7400,11 +7372,6 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.28.0
 
-  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.41.1
-
   '@opentelemetry/exporter-trace-otlp-http@0.57.2(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -7414,22 +7381,23 @@ snapshots:
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
 
-  '@opentelemetry/instrumentation-fetch@0.218.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-undici@0.10.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.218.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-web': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.218.0
-      import-in-the-middle: 3.3.0
-      require-in-the-middle: 8.0.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@types/shimmer': 1.2.0
+      import-in-the-middle: 1.15.0
+      require-in-the-middle: 7.5.2
+      semver: 7.8.1
+      shimmer: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -7466,12 +7434,6 @@ snapshots:
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.28.0
 
-  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-
   '@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -7492,13 +7454,6 @@ snapshots:
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.28.0
 
-  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-
   '@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -7508,12 +7463,6 @@ snapshots:
       '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
       semver: 7.8.1
-
-  '@opentelemetry/sdk-trace-web@2.7.1(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/semantic-conventions@1.28.0': {}
 
@@ -8322,6 +8271,8 @@ snapshots:
 
   '@types/retry@0.12.5': {}
 
+  '@types/shimmer@1.2.0': {}
+
   '@types/tar-stream@3.1.4':
     dependencies:
       '@types/node': 20.19.11
@@ -8992,6 +8943,10 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.15.0
@@ -9343,7 +9298,7 @@ snapshots:
 
   citty@0.2.1: {}
 
-  cjs-module-lexer@2.2.0: {}
+  cjs-module-lexer@1.4.3: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -9387,7 +9342,7 @@ snapshots:
   cmd-ts@0.15.0:
     dependencies:
       chalk: 5.6.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       didyoumean: 1.2.2
       strip-ansi: 7.1.2
     transitivePeerDependencies:
@@ -9488,6 +9443,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -9551,8 +9510,7 @@ snapshots:
 
   detect-libc@2.0.4: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   devalue@5.6.3: {}
 
@@ -9644,8 +9602,6 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
-
-  es-module-lexer@2.3.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -10005,10 +9961,6 @@ snapshots:
 
   get-stream@6.0.1: {}
 
-  get-tsconfig@4.10.1:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
-
   get-tsconfig@4.13.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -10234,10 +10186,11 @@ snapshots:
       caller-path: 2.0.0
       resolve-from: 3.0.0
 
-  import-in-the-middle@3.3.0:
+  import-in-the-middle@1.15.0:
     dependencies:
-      cjs-module-lexer: 2.2.0
-      es-module-lexer: 2.3.0
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 1.4.3
       module-details-from-path: 1.0.4
 
   indent-string@3.2.0: {}
@@ -10457,7 +10410,7 @@ snapshots:
 
   lightningcss@1.30.1:
     dependencies:
-      detect-libc: 2.0.4
+      detect-libc: 2.1.2
     optionalDependencies:
       lightningcss-darwin-arm64: 1.30.1
       lightningcss-darwin-x64: 1.30.1
@@ -11559,10 +11512,11 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  require-in-the-middle@8.0.1:
+  require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       module-details-from-path: 1.0.4
+      resolve: 1.22.10
     transitivePeerDependencies:
       - supports-color
 
@@ -11816,6 +11770,8 @@ snapshots:
   shebang-regex@1.0.0: {}
 
   shebang-regex@3.0.0: {}
+
+  shimmer@1.2.1: {}
 
   side-channel-list@1.0.0:
     dependencies:
@@ -12179,7 +12135,7 @@ snapshots:
   tsx@4.20.3:
     dependencies:
       esbuild: 0.25.9
-      get-tsconfig: 4.10.1
+      get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -12376,7 +12332,7 @@ snapshots:
   vite-node@3.2.1(@types/node@22.15.12)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.1.4(@types/node@22.15.12)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.1)
@@ -12421,7 +12377,7 @@ snapshots:
       '@vitest/spy': 3.2.1
       '@vitest/utils': 3.2.1
       chai: 5.3.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       expect-type: 1.2.2
       magic-string: 0.30.21
       pathe: 2.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,12 +284,18 @@ importers:
       '@opentelemetry/api':
         specifier: 1.9.0
         version: 1.9.0
+      '@opentelemetry/core':
+        specifier: ^1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.57.2
         version: 0.57.2(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-fetch':
         specifier: ^0.218.0
         version: 0.218.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer':
+        specifier: ^0.57.2
+        version: 0.57.2(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources':
         specifier: ^1.30.1
         version: 1.30.1(@opentelemetry/api@1.9.0)
@@ -314,6 +320,9 @@ importers:
       ws:
         specifier: ^8.21.0
         version: 8.21.0
+      xdg-app-paths:
+        specifier: 5.1.0
+        version: 5.1.0
       zod:
         specifier: ^4.1.1
         version: 4.1.5
@@ -366,9 +375,6 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.12)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.1)
-      xdg-app-paths:
-        specifier: 5.1.0
-        version: 5.1.0
 
   packages/vercel-sandbox:
     dependencies:


### PR DESCRIPTION
## Summary

This is an experiment toward letting users attach useful traces when reporting CLI errors.

- always retain CLI spans locally as OTLP/JSONL, including failed command spans and recorded exceptions
- keep only the 10 most recent invocation files in the platform XDG cache directory
- preserve configured OTLP HTTP export alongside local retention
- add diagnostic spans for command execution, file copy, lifecycle cleanup, snapshots, interactive connection/session setup, timeout extension, and auth retries/fallbacks
- mark non-throwing failures and non-zero remote command exits as errors
- use sanitized root span names and avoid command arguments, environment values, paths, credentials, and WebSocket URLs
- add a hidden `sandbox _traces` command that prints the trace directory without tracing itself

No traces are uploaded automatically by this change. The files remain local until a future reporting flow explicitly submits them.

## Testing

- `pnpm typecheck`
- `pnpm build`
- `pnpm test --run` (58 tests pass; existing `test/args/scope.test.ts` suite fails during collection because its `@vercel/oidc` mock omits `getVercelToken`)
