### PR TITLE
fix(sandbox): throw SandboxUserAlreadyExistsError on duplicate user creation

### DIFF
--- a/.changeset/typed-sandbox-user-exists.md
+++ b/.changeset/typed-sandbox-user-exists.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Expose a typed error when creating a sandbox user whose username already exists.

--- a/packages/vercel-sandbox/src/index.ts
+++ b/packages/vercel-sandbox/src/index.ts
@@ -11,7 +11,10 @@ export {
   type NetworkTransformer,
 } from "./session.js";
 export type { SerializedSandbox } from "./sandbox.js";
-export { SandboxUser } from "./sandbox-user.js";
+export {
+  SandboxUser,
+  SandboxUserAlreadyExistsError,
+} from "./sandbox-user.js";
 export type { ExecutionContext } from "./execution-context.js";
 export { Snapshot } from "./snapshot.js";
 export type { SerializedSnapshot } from "./snapshot.js";

--- a/packages/vercel-sandbox/src/sandbox-user.test.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.test.ts
@@ -1,6 +1,10 @@
-import { expect, it, beforeEach, afterEach, describe } from "vitest";
+import { expect, it, beforeEach, afterEach, describe, vi } from "vitest";
 import { Sandbox } from "./sandbox.js";
-import { SandboxUser } from "./sandbox-user.js";
+import {
+  SandboxUser,
+  SandboxUserAlreadyExistsError,
+} from "./sandbox-user.js";
+import { CommandFinished } from "./command.js";
 
 describe("validateName (unit)", () => {
   it("asUser rejects invalid usernames synchronously", () => {
@@ -38,6 +42,58 @@ describe("validateName (unit)", () => {
     // root's home is /root, not /home/root
     expect(sandbox.asUser("root").homeDir).toBe("/root");
     expect(sandbox.asUser("alice").homeDir).toBe("/home/alice");
+  });
+
+  it("classifies useradd exit code 9 as an existing user", async () => {
+    const sandbox = new Sandbox({
+      client: {} as any,
+      routes: [],
+      sandbox: { id: "test" } as any,
+    });
+    vi.spyOn(sandbox, "getDefaultUser").mockResolvedValue({
+      username: "root",
+      group: "root",
+    });
+    vi.spyOn(sandbox, "runCommand").mockResolvedValue(
+      new CommandFinished({
+        sessionId: "test",
+        cmd: {} as any,
+        exitCode: 9,
+      }),
+    );
+
+    await expect(sandbox.createUser("alice")).rejects.toMatchObject({
+      name: "SandboxUserAlreadyExistsError",
+      username: "alice",
+    });
+  });
+
+  it("preserves other useradd failures as generic provisioning errors", async () => {
+    const sandbox = new Sandbox({
+      client: {} as any,
+      routes: [],
+      sandbox: { id: "test" } as any,
+    });
+    vi.spyOn(sandbox, "getDefaultUser").mockResolvedValue({
+      username: "root",
+      group: "root",
+    });
+    vi.spyOn(sandbox, "runCommand").mockResolvedValue(
+      new CommandFinished({
+        sessionId: "test",
+        cmd: {} as any,
+        exitCode: 1,
+        output: { stdout: "", stderr: "permission denied" },
+      }),
+    );
+
+    const create = sandbox.createUser("alice");
+    await expect(create).rejects.toThrow(
+      'Failed to create user "alice": permission denied',
+    );
+    await expect(create).rejects.not.toBeInstanceOf(
+      SandboxUserAlreadyExistsError,
+    );
   });
 });
 
@@ -119,9 +175,12 @@ describe.skipIf(process.env.RUN_INTEGRATION_TESTS !== "1")(
 
       it("throws on duplicate username", async () => {
         await sandbox.createUser("alice");
-        await expect(sandbox.createUser("alice")).rejects.toThrow(
-          'Failed to create user "alice"',
+        const duplicate = sandbox.createUser("alice");
+
+        await expect(duplicate).rejects.toBeInstanceOf(
+          SandboxUserAlreadyExistsError,
         );
+        await expect(duplicate).rejects.toMatchObject({ username: "alice" });
       });
     });
 

--- a/packages/vercel-sandbox/src/sandbox-user.ts
+++ b/packages/vercel-sandbox/src/sandbox-user.ts
@@ -10,6 +10,19 @@ import type { ExecutionContext } from "./execution-context.js";
 import { validateName } from "./utils/validate-name.js";
 
 /**
+ * Thrown when {@link Sandbox.createUser} is called for an existing username.
+ */
+export class SandboxUserAlreadyExistsError extends Error {
+  readonly username: string;
+
+  constructor(username: string) {
+    super(`Failed to create user "${username}": user already exists`);
+    this.name = "SandboxUserAlreadyExistsError";
+    this.username = username;
+  }
+}
+
+/**
  * A user context within a sandbox.
  *
  * All file and command operations default to running as this user.

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -25,7 +25,10 @@ import { fromAPINetworkPolicy } from "./utils/network-policy.js";
 import { attachPaginator } from "./utils/paginator.js";
 import { setTimeout } from "node:timers/promises";
 import { FileSystem } from "./filesystem.js";
-import { SandboxUser } from "./sandbox-user.js";
+import {
+  SandboxUser,
+  SandboxUserAlreadyExistsError,
+} from "./sandbox-user.js";
 import type { ExecutionContext } from "./execution-context.js";
 import { validateName } from "./utils/validate-name.js";
 
@@ -1436,6 +1439,11 @@ export class Sandbox implements ExecutionContext {
       signal: opts?.signal,
     });
     if (useradd.exitCode !== 0) {
+      // useradd reserves exit code 9 for an already-taken username. Expose
+      // that expected race separately without masking provisioning failures.
+      if (useradd.exitCode === 9) {
+        throw new SandboxUserAlreadyExistsError(username);
+      }
       const stderr = await useradd.stderr();
       throw new Error(`Failed to create user "${username}": ${stderr}`);
     }


### PR DESCRIPTION
## Reproduction

`createUser` is not idempotent:

```ts
await sandbox.createUser("coder"); // succeeds
await sandbox.createUser("coder"); // rejects with a generic Error
```

This commonly happens when reconnecting to a persistent sandbox or retrying setup after the user was already created. The generic error cannot be safely distinguished from a real provisioning failure.

This PR exposes `SandboxUserAlreadyExistsError`, allowing callers to recover only from the existing-user case:

```ts
try {
  return await sandbox.createUser("coder");
} catch (error) {
  if (error instanceof SandboxUserAlreadyExistsError) {
    return sandbox.asUser("coder");
  }
  throw error;
}
```

Other `useradd`, `chown`, and `chmod` failures remain unchanged.

## Why not `ensureUser`?

An `ensureUser` API could hide this recovery logic, but it would need to define whether an existing user is simply returned or whether its home directory, shell, ownership, and permissions are validated or repaired. This PR exposes the precise failure condition without choosing those broader semantics.