### PR TITLE
feat(sdk): clarify usage of `transform` and `forwardURL`

### DIFF
--- a/.changeset/wet-bottles-refuse.md
+++ b/.changeset/wet-bottles-refuse.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Clarify that network policies can only contain one of `transform` or `forwardURL`

--- a/packages/vercel-sandbox/src/api-client/validators.ts
+++ b/packages/vercel-sandbox/src/api-client/validators.ts
@@ -39,11 +39,17 @@ export const NetworkPolicyTransformValidator = z.object({
   headers: z.record(z.string(), z.string()).optional(),
 });
 
-export const NetworkPolicyRuleValidator = z.object({
-  match: RuleMatchValidator.optional(),
-  transform: z.array(NetworkPolicyTransformValidator).optional(),
-  forwardURL: z.string().optional(),
-});
+export const NetworkPolicyRuleValidator = z
+  .object({
+    match: RuleMatchValidator.optional(),
+    transform: z.array(NetworkPolicyTransformValidator).optional(),
+    forwardURL: z.string().optional(),
+  })
+  .refine(
+    ({ transform, forwardURL }) =>
+      transform === undefined || forwardURL === undefined,
+    { message: "transform and forwardURL cannot be used together" },
+  );
 
 export const V2NetworkPolicyObjectValidator = z.object({
   allow: z

--- a/packages/vercel-sandbox/src/api-client/validators.ts
+++ b/packages/vercel-sandbox/src/api-client/validators.ts
@@ -49,6 +49,11 @@ export const NetworkPolicyRuleValidator = z
     ({ transform, forwardURL }) =>
       transform === undefined || forwardURL === undefined,
     { message: "transform and forwardURL cannot be used together" },
+  )
+  .refine(
+    ({ transform, forwardURL }) =>
+      transform !== undefined || forwardURL !== undefined,
+    { message: "transform or forwardURL must be provided" },
   );
 
 export const V2NetworkPolicyObjectValidator = z.object({

--- a/packages/vercel-sandbox/src/network-policy.ts
+++ b/packages/vercel-sandbox/src/network-policy.ts
@@ -57,24 +57,35 @@ export type NetworkPolicyMatch = {
  */
 export type NetworkPolicyRule = {
   /**
-   * Optional request matcher. When provided, transforms only apply to requests
-   * that match every specified dimension.
+   * Optional request matcher. When provided, transforms and forwarding rules
+   * only apply to requests that match every specified dimension.
    */
   match?: NetworkPolicyMatch;
-  /**
-   * Transforms to apply to matching requests.
-   */
-  transform?: NetworkTransformer[];
-  /**
-   * HTTPS proxy URL to forward matching requests to. Must not include query string or fragment.
-   *
-   * You can use the `defineSandboxProxy` helper from `@vercel/sandbox/proxy` to implement the proxy handler
-   * automatically, which handles authorization and extracts metadata about the request and sandbox.
-   *
-   * @see https://vercel.com/docs/vercel-sandbox/concepts/firewall#requests-proxying
-   */
-  forwardURL?: string;
-};
+} & (
+  | {
+      /**
+       * Transforms to apply to matching requests.
+       *
+       * `transform` cannot be used together with `forwardURL`.
+       */
+      transform: NetworkTransformer[];
+      forwardURL?: never;
+    }
+  | {
+      transform?: never;
+      /**
+       * HTTPS proxy URL to forward matching requests to. Must not include query string or fragment.
+       *
+       * You can use the `defineSandboxProxy` helper from `@vercel/sandbox/proxy` to implement the proxy handler
+       * automatically, which handles authorization and extracts metadata about the request and sandbox.
+       *
+       * `forwardURL` cannot be used together with `transform`.
+       *
+       * @see https://vercel.com/docs/vercel-sandbox/concepts/firewall#requests-proxying
+       */
+      forwardURL: string;
+    }
+);
 
 /**
  * Network policy to define network restrictions for the sandbox.

--- a/packages/vercel-sandbox/src/utils/network-policy.test.ts
+++ b/packages/vercel-sandbox/src/utils/network-policy.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { NetworkPolicy } from "../network-policy.js";
 import { fromAPINetworkPolicy, toAPINetworkPolicy } from "./network-policy.js";
 
 describe("toAPINetworkPolicy", () => {
@@ -201,6 +202,23 @@ describe("toAPINetworkPolicy", () => {
         "registry.npmjs.org": [],
       },
     });
+  });
+
+  it("rejects rules with transform and forwardURL", () => {
+    const networkPolicy = {
+      allow: {
+        "api.example.com": [
+          {
+            transform: [{ headers: { authorization: "Bearer secret" } }],
+            forwardURL: "https://proxy.example.com",
+          },
+        ],
+      },
+    } as unknown as NetworkPolicy;
+
+    expect(() => toAPINetworkPolicy(networkPolicy)).toThrow(
+      "transform and forwardURL cannot be used together",
+    );
   });
 
   it("converts empty custom object", () => {

--- a/packages/vercel-sandbox/src/utils/network-policy.test.ts
+++ b/packages/vercel-sandbox/src/utils/network-policy.test.ts
@@ -221,6 +221,18 @@ describe("toAPINetworkPolicy", () => {
     );
   });
 
+  it("rejects rules without transform or forwardURL", () => {
+    const networkPolicy = {
+      allow: {
+        "api.example.com": [{ match: { method: ["GET"] } }],
+      },
+    } as unknown as NetworkPolicy;
+
+    expect(() => toAPINetworkPolicy(networkPolicy)).toThrow(
+      "transform or forwardURL must be provided",
+    );
+  });
+
   it("converts empty custom object", () => {
     expect(toAPINetworkPolicy({})).toEqual({});
   });

--- a/packages/vercel-sandbox/src/utils/network-policy.ts
+++ b/packages/vercel-sandbox/src/utils/network-policy.ts
@@ -11,11 +11,13 @@ type APIResponseNetworkPolicy = z.infer<typeof NetworkPolicyResponseValidator>;
 export function toAPINetworkPolicy(
   policy: NetworkPolicy,
 ): APIRequestNetworkPolicy {
-  if (policy === "allow-all" || policy === "deny-all") {
-    return { mode: policy };
-  }
+  const apiPolicy =
+    policy === "allow-all" || policy === "deny-all"
+      ? { mode: policy }
+      : policy;
 
-  return policy;
+  NetworkPolicyRequestValidator.parse(apiPolicy);
+  return apiPolicy;
 }
 
 export function fromAPINetworkPolicy(


### PR DESCRIPTION
Within network policies, `transform` and `forwardURL` are exclusive and should not be used together

The API currently accepts this combinaison and doesn't reject it: `forwardURL` takes precedence and `transform` doesn't apply. We cannot currently update the API without a breaking change/new version because some customers might already accidentaly depend on it

This PR updates the JS doc and validation of the SDK only, so that customers upgrading it have a chance to remove any usage of both `transform` and `forwardURL` within the same network policy