### PR TITLE
feat(sandbox,vercel-sandbox): support the image parameter from a sandbox

### DIFF
--- a/.changeset/silver-images-report.md
+++ b/.changeset/silver-images-report.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": minor
+---
+
+Expose the source `image` of a sandbox as a property on `Sandbox`, populated when the sandbox was created from a container image

--- a/.changeset/tidy-columns-listen.md
+++ b/.changeset/tidy-columns-listen.md
@@ -1,0 +1,5 @@
+---
+"sandbox": minor
+---
+
+Show the source image in `sandbox ls` by renaming the `RUNTIME` column to `RUNTIME/IMAGE`, which falls back to the image reference for image-based sandboxes

--- a/packages/sandbox/src/commands/list.ts
+++ b/packages/sandbox/src/commands/list.ts
@@ -14,6 +14,14 @@ import {
 } from "../util/output";
 import { ObjectFromKeyValue } from "../args/key-value-pair";
 
+function formatImage(image: string): string {
+  const [repository, digest] = image.split("@");
+  if (!digest) return image;
+  const [algorithm, hex] = digest.split(":");
+  if (!hex) return image;
+  return `${repository}@${algorithm}:${hex.slice(0, 12)}…`;
+}
+
 export const list = cmd.command({
   name: "list",
   aliases: ["ls"],
@@ -128,7 +136,9 @@ export const list = cmd.command({
           s.memory != null ? memoryFormatter.format(s.memory) : "-",
       },
       VCPUS: { value: (s) => s.vcpus ?? "-" },
-      "RUNTIME/IMAGE": { value: (s) => s.runtime ?? s.image ?? "-" },
+      "RUNTIME/IMAGE": {
+        value: (s) => s.runtime ?? (s.image ? formatImage(s.image) : "-"),
+      },
       TIMEOUT: {
         // Prefer the live deadline (`expiresAt`) of the running session. Fall
         // back to the configured timeout for non-running sandboxes that don't

--- a/packages/sandbox/src/commands/list.ts
+++ b/packages/sandbox/src/commands/list.ts
@@ -5,7 +5,13 @@ import { scope } from "../args/scope";
 import chalk, { ChalkInstance } from "chalk";
 import ora from "ora";
 import { acquireRelease } from "../util/disposables";
-import { table, timeAgo, formatBytes, formatRunDuration, formatNextCursorHint } from "../util/output";
+import {
+  table,
+  timeAgo,
+  formatBytes,
+  formatRunDuration,
+  formatNextCursorHint,
+} from "../util/output";
 import { ObjectFromKeyValue } from "../args/key-value-pair";
 
 export const list = cmd.command({
@@ -25,7 +31,8 @@ export const list = cmd.command({
     }),
     sortBy: cmd.option({
       long: "sort-by",
-      description: "Sort sandboxes by field. Options: createdAt (default), name, statusUpdatedAt",
+      description:
+        "Sort sandboxes by field. Options: createdAt (default), name, statusUpdatedAt",
       type: cmd.optional(
         cmd.oneOf(["createdAt", "name", "statusUpdatedAt"] as const),
       ),
@@ -52,14 +59,25 @@ export const list = cmd.command({
     }),
     scope,
   },
-  async handler({ scope: { token, team, project }, all, namePrefix, sortBy, sortOrder, tags, limit, cursor }) {
+  async handler({
+    scope: { token, team, project },
+    all,
+    namePrefix,
+    sortBy,
+    sortOrder,
+    tags,
+    limit,
+    cursor,
+  }) {
     if (namePrefix) {
       if (sortBy && sortBy !== "name") {
-        console.error(chalk.red("Error: --sort-by must be 'name' when using --name-prefix"));
+        console.error(
+          chalk.red("Error: --sort-by must be 'name' when using --name-prefix"),
+        );
         return;
       }
 
-      sortBy = 'name';
+      sortBy = "name";
     }
 
     const { sandboxes, pagination } = await (async () => {
@@ -91,7 +109,10 @@ export const list = cmd.command({
     });
 
     type SandboxRow = (typeof sandboxes)[number];
-    type Column = { value: (s: SandboxRow) => string | number; color?: (s: SandboxRow) => ChalkInstance };
+    type Column = {
+      value: (s: SandboxRow) => string | number;
+      color?: (s: SandboxRow) => ChalkInstance;
+    };
 
     const columns: Record<string, Column> = {
       NAME: { value: (s) => s.name },
@@ -102,9 +123,12 @@ export const list = cmd.command({
       CREATED: {
         value: (s) => timeAgo(s.createdAt),
       },
-      MEMORY: { value: (s) => s.memory != null ? memoryFormatter.format(s.memory) : "-" },
+      MEMORY: {
+        value: (s) =>
+          s.memory != null ? memoryFormatter.format(s.memory) : "-",
+      },
       VCPUS: { value: (s) => s.vcpus ?? "-" },
-      RUNTIME: { value: (s) => s.runtime ?? "-" },
+      "RUNTIME/IMAGE": { value: (s) => s.runtime ?? s.image ?? "-" },
       TIMEOUT: {
         // Prefer the live deadline (`expiresAt`) of the running session. Fall
         // back to the configured timeout for non-running sandboxes that don't
@@ -116,13 +140,27 @@ export const list = cmd.command({
         },
       },
       SNAPSHOT: { value: (s) => s.currentSnapshotId ?? "-" },
-      TAGS: { value: (s) => s.tags && Object.keys(s.tags).length > 0 ? Object.entries(s.tags).map(([k, v]) => `${k}:${v}`).join(", ") : "-" }
+      TAGS: {
+        value: (s) =>
+          s.tags && Object.keys(s.tags).length > 0
+            ? Object.entries(s.tags)
+                .map(([k, v]) => `${k}:${v}`)
+                .join(", ")
+            : "-",
+      },
     };
     if (all) {
-      columns.CPU = { value: (s) => s.totalActiveCpuDurationMs ? formatRunDuration(s.totalActiveCpuDurationMs) : "-" };
+      columns.CPU = {
+        value: (s) =>
+          s.totalActiveCpuDurationMs
+            ? formatRunDuration(s.totalActiveCpuDurationMs)
+            : "-",
+      };
       columns["NETWORK (OUT/IN)"] = {
-        value: (s) => (s.totalEgressBytes || s.totalIngressBytes) ?
-          `${formatBytes(s.totalEgressBytes ?? 0)} / ${formatBytes(s.totalIngressBytes ?? 0)}` : "- / -",
+        value: (s) =>
+          s.totalEgressBytes || s.totalIngressBytes
+            ? `${formatBytes(s.totalEgressBytes ?? 0)} / ${formatBytes(s.totalIngressBytes ?? 0)}`
+            : "- / -",
       };
     }
 

--- a/packages/vercel-sandbox/src/api-client/api-client.test.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.test.ts
@@ -632,6 +632,30 @@ describe("APIClient", () => {
       const [url] = mockFetch.mock.calls[0];
       expect(url).toContain("resume=true");
     });
+
+    it("exposes the source image when present", async () => {
+      const body = {
+        sandbox: {
+          ...makeSandboxMetadata(),
+          runtime: undefined,
+          image: "my-repo@sha256:2c4e8f9a1b3d5e7f",
+        },
+        session: makeSession(),
+        routes: [],
+      };
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(body), {
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      const result = await client.getSandbox({
+        name: "my-sandbox",
+        projectId: "proj_123",
+      });
+
+      expect(result.json.sandbox.image).toBe("my-repo@sha256:2c4e8f9a1b3d5e7f");
+    });
   });
 
   describe("listSandboxes", () => {
@@ -871,7 +895,9 @@ describe("APIClient", () => {
     let client: APIClient;
     let mockFetch: ReturnType<typeof vi.fn>;
 
-    const makeSnapshot = (overrides: Partial<Record<string, unknown>> = {}) => ({
+    const makeSnapshot = (
+      overrides: Partial<Record<string, unknown>> = {},
+    ) => ({
       id: "snap_123",
       sourceSessionId: "sbx_123",
       region: "iad1",
@@ -895,7 +921,10 @@ describe("APIClient", () => {
       const body = {
         snapshots: [
           {
-            snapshot: makeSnapshot({ id: "snap_parent", parentId: "snap_root" }),
+            snapshot: makeSnapshot({
+              id: "snap_parent",
+              parentId: "snap_root",
+            }),
             siblings: [],
             count: "1",
           },
@@ -1059,9 +1088,9 @@ describe("APIClient", () => {
       const [, opts] = mockFetch.mock.calls[0];
       const body = JSON.parse(opts.body);
       // Presence of the key with null — not undefined/missing — is the signal.
-      expect(Object.prototype.hasOwnProperty.call(body, "keepLastSnapshots")).toBe(
-        true,
-      );
+      expect(
+        Object.prototype.hasOwnProperty.call(body, "keepLastSnapshots"),
+      ).toBe(true);
       expect(body.keepLastSnapshots).toBeNull();
     });
   });
@@ -1343,5 +1372,4 @@ describe("APIClient", () => {
       expect(stream).toBeNull();
     });
   });
-
 });

--- a/packages/vercel-sandbox/src/api-client/validators.ts
+++ b/packages/vercel-sandbox/src/api-client/validators.ts
@@ -127,10 +127,12 @@ export const Session = z.object({
   interactivePort: z.number().optional(),
   networkPolicy: NetworkPolicyResponseValidator.optional(),
   activeCpuDurationMs: z.number().optional(),
-  networkTransfer: z.object({
-    ingress: z.number(),
-    egress: z.number(),
-  }).optional(),
+  networkTransfer: z
+    .object({
+      ingress: z.number(),
+      egress: z.number(),
+    })
+    .optional(),
 });
 
 export type SandboxRouteData = z.infer<typeof SandboxRoute>;
@@ -204,7 +206,9 @@ export const CommandResponse = z.object({
   command: Command,
 });
 
-export type CommandFinishedData = z.infer<typeof CommandFinishedResponse>["command"];
+export type CommandFinishedData = z.infer<
+  typeof CommandFinishedResponse
+>["command"];
 
 export const CommandFinishedResponse = z.object({
   command: CommandFinished,
@@ -271,6 +275,7 @@ export const Sandbox = z.object({
   vcpus: z.number().optional(),
   memory: z.number().optional(),
   runtime: z.string().optional(),
+  image: z.string().optional(),
   timeout: z.number().optional(),
   networkPolicy: NetworkPolicyResponseValidator.optional(),
   totalEgressBytes: z.number().optional(),

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -94,9 +94,35 @@ const makeCommand = (): CommandData => ({
   startedAt: 1,
 });
 
+describe("source getters", () => {
+  const makeSandbox = (overrides?: Partial<SandboxMetaData>) =>
+    new Sandbox({
+      client: {} as any,
+      routes: [],
+      session: {} as any,
+      sandbox: { ...makeSandboxMetadata(), ...overrides },
+      projectId: "test-project",
+    });
+
+  it("exposes the runtime and leaves image undefined for runtime sandboxes", () => {
+    const sandbox = makeSandbox();
+    expect(sandbox.runtime).toBe("node24");
+    expect(sandbox.image).toBeUndefined();
+  });
+
+  it("exposes the image for image-based sandboxes", () => {
+    const sandbox = makeSandbox({
+      runtime: undefined,
+      image: "my-repo@sha256:2c4e8f9a1b3d5e7f",
+    });
+    expect(sandbox.image).toBe("my-repo@sha256:2c4e8f9a1b3d5e7f");
+    expect(sandbox.runtime).toBeUndefined();
+  });
+});
+
 describe("updatePorts", () => {
   it.each([
-    ["updatePorts", (sandbox: Sandbox) => sandbox.update({ports: [4000]})],
+    ["updatePorts", (sandbox: Sandbox) => sandbox.update({ ports: [4000] })],
     ["update", (sandbox: Sandbox) => sandbox.update({ ports: [4000] })],
   ])("%s sends a full port list to updateSandbox", async (_, updatePorts) => {
     const updatedSandbox = makeSandboxMetadata();

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -25,10 +25,7 @@ import { fromAPINetworkPolicy } from "./utils/network-policy.js";
 import { attachPaginator } from "./utils/paginator.js";
 import { setTimeout } from "node:timers/promises";
 import { FileSystem } from "./filesystem.js";
-import {
-  SandboxUser,
-  SandboxUserAlreadyExistsError,
-} from "./sandbox-user.js";
+import { SandboxUser, SandboxUserAlreadyExistsError } from "./sandbox-user.js";
 import type { ExecutionContext } from "./execution-context.js";
 import { validateName } from "./utils/validate-name.js";
 
@@ -407,9 +404,21 @@ export class Sandbox implements ExecutionContext {
     return this.sandbox.memory;
   }
 
-  /** Runtime identifier (e.g. "node24", "python3.13"). */
+  /**
+   * Runtime identifier (e.g. "node24", "python3.13").
+   * Mutually exclusive with {@link Sandbox.image}.
+   */
   public get runtime(): string | undefined {
     return this.sandbox.runtime;
+  }
+
+  /**
+   * Digest-pinned reference of the container image the sandbox was created
+   * from, when it was created from an image (`"{repository}@{manifestDigest}"`).
+   * Mutually exclusive with {@link Sandbox.runtime}.
+   */
+  public get image(): string | undefined {
+    return this.sandbox.image;
   }
 
   /**
@@ -642,7 +651,10 @@ export class Sandbox implements ExecutionContext {
       projectId: data.projectId,
     });
     if (data.metadata) {
-      sandbox.session = new Session({ routes: data.routes, snapshot: data.metadata });
+      sandbox.session = new Session({
+        routes: data.routes,
+        snapshot: data.metadata,
+      });
     }
     return sandbox;
   }
@@ -1140,10 +1152,7 @@ export class Sandbox implements ExecutionContext {
    */
   async mkDir(path: string, opts?: { signal?: AbortSignal }): Promise<void> {
     "use step";
-    return this.withResume(
-      () => this.session!.mkDir(path, opts),
-      opts?.signal,
-    );
+    return this.withResume(() => this.session!.mkDir(path, opts), opts?.signal);
   }
 
   /**
@@ -1549,7 +1558,9 @@ export class Sandbox implements ExecutionContext {
     });
     if (mkdirResult.exitCode !== 0) {
       const stderr = await mkdirResult.stderr();
-      throw new Error(`Failed to create shared directory ${sharedDir}: ${stderr}`);
+      throw new Error(
+        `Failed to create shared directory ${sharedDir}: ${stderr}`,
+      );
     }
 
     // Set ownership: the default user (so the HTTP file API can write into the
@@ -1665,10 +1676,7 @@ export class Sandbox implements ExecutionContext {
     signal?: AbortSignal;
   }): Promise<Snapshot> {
     "use step";
-    return this.withResume(
-      () => this.session!.snapshot(opts),
-      opts?.signal,
-    );
+    return this.withResume(() => this.session!.snapshot(opts), opts?.signal);
   }
 
   /**


### PR DESCRIPTION
Support, in the SDK/CLI, the `image` parameter. We already supported it when creating sandboxes with image, but now we also support showing it.

In the CLI, we show it under `runtime/image` as they are both mutually exclusive. And in the future, `image` will be replacing runtime.

In the SDK, we just added a new `image` property to sandbox.

Notes: there are also some other changes made by the linter.