### PR TITLE
feat(sdk): reduce default API call retries

### DIFF
--- a/.changeset/calm-spoons-retry.md
+++ b/.changeset/calm-spoons-retry.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Reduce default API call retries

--- a/packages/vercel-sandbox/src/api-client/with-retry.test.ts
+++ b/packages/vercel-sandbox/src/api-client/with-retry.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withRetry } from "./with-retry.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("withRetry", () => {
+  it("makes two retries with randomized backoff", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const requestTimes: number[] = [];
+    const rawFetch = vi.fn(async () => {
+      requestTimes.push(Date.now());
+      return new Response(null, { status: 500 });
+    });
+
+    const responsePromise = withRetry(rawFetch)("https://example.com");
+    await vi.runAllTimersAsync();
+
+    await expect(responsePromise).resolves.toMatchObject({ status: 500 });
+    expect(rawFetch).toHaveBeenCalledTimes(3);
+    expectRetryTimes(requestTimes);
+  });
+
+  it("uses normal backoff for 429 responses", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const requestTimes: number[] = [];
+    const rawFetch = vi.fn(async () => {
+      requestTimes.push(Date.now());
+      return new Response(null, {
+        status: 429,
+        headers: { "Retry-After": "60" },
+      });
+    });
+
+    const responsePromise = withRetry(rawFetch)("https://example.com");
+    await vi.runAllTimersAsync();
+
+    await expect(responsePromise).resolves.toMatchObject({ status: 429 });
+    expect(rawFetch).toHaveBeenCalledTimes(3);
+    expectRetryTimes(requestTimes);
+  });
+});
+
+function expectRetryTimes(requestTimes: number[]) {
+  expect(requestTimes[0]).toBe(0);
+  expect(requestTimes[1]).toBeGreaterThanOrEqual(400);
+  expect(requestTimes[1]).toBeLessThanOrEqual(800);
+
+  const secondDelay = requestTimes[2] - requestTimes[1];
+  expect(secondDelay).toBeGreaterThanOrEqual(800);
+  expect(secondDelay).toBeLessThanOrEqual(1600);
+}

--- a/packages/vercel-sandbox/src/api-client/with-retry.ts
+++ b/packages/vercel-sandbox/src/api-client/with-retry.ts
@@ -1,6 +1,5 @@
 import type { Options as RetryOptions } from "async-retry";
 import { APIError } from "./api-error.js";
-import { setTimeout } from "node:timers/promises";
 import retry from "async-retry";
 
 export interface RequestOptions {
@@ -24,15 +23,14 @@ export function withRetry<T extends RequestInit>(
     opts: T & RequestOptions = <T & RequestOptions>{},
   ) => {
     /**
-     * Timeouts by default will be [10, 60, 360, 2160, 12960]
+     * Timeouts by default will be [400, 800]
      * before randomization is added.
      */
     const retryOpts = Object.assign(
       {
-        minTimeout: 10,
-        retries: 5,
-        factor: 6,
-        maxRetryAfter: 20,
+        minTimeout: 400,
+        retries: 2,
+        factor: 2,
       },
       opts.retry,
     );
@@ -54,27 +52,7 @@ export function withRetry<T extends RequestInit>(
           }
           const response = await rawFetch(url, opts);
 
-          /**
-           * When the response is 429 we will try to parse the Retry-After
-           * header. If the header exists we will try to parse it and, if
-           * the wait time is higher than the maximum defined, we respond.
-           * Otherwise we wait for the time given in the header and throw
-           * to retry.
-           */
           if (response.status === 429) {
-            const retryAfter = parseInt(
-              response.headers.get("retry-after") || "",
-              10,
-            );
-
-            if (retryAfter && !isNaN(retryAfter)) {
-              if (retryAfter > retryOpts.maxRetryAfter) {
-                return response;
-              }
-
-              await setTimeout(retryAfter * 1e3);
-            }
-
             throw new APIError(response);
           }
 


### PR DESCRIPTION
The current retries are quite expensive: 5 retries with 10ms-12s delay

Reduce to 2 retries with 400-800ms delay, and remove the unused `retry-after` logic: since we bucket in per-minute, the `maxRetryAfter` of 20s always opted out of waiting 1min