### PR TITLE
fix(sandbox-mock): re-export SandboxUserAlreadyExistsError

### DIFF
--- a/.changeset/mock-export-sandbox-user-already-exists-error.md
+++ b/.changeset/mock-export-sandbox-user-already-exists-error.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox-mock": patch
+---
+
+Re-export `SandboxUserAlreadyExistsError` from `@vercel/sandbox-mock` so the mock's public surface matches the real SDK.

--- a/packages/vercel-sandbox-mock/src/index.ts
+++ b/packages/vercel-sandbox-mock/src/index.ts
@@ -18,6 +18,7 @@ export type {
 export {
   Session,
   SandboxUser,
+  SandboxUserAlreadyExistsError,
   Command,
   CommandFinished,
   FileSystem,


### PR DESCRIPTION
CI on `main` fails in `@vercel/sandbox-mock`'s `package-exports.test.ts`, which asserts the mock re-exports every runtime value the real SDK exposes:

```
missing export: SandboxUserAlreadyExistsError
```

`SandboxUserAlreadyExistsError` was added to `@vercel/sandbox` (#250) but never added to the mock's re-export list, so the mock's public surface drifted from the real SDK.