### PR TITLE
feat(vercel-sandbox): support the fork API

### DIFF
--- a/packages/sandbox/src/commands/fork.ts
+++ b/packages/sandbox/src/commands/fork.ts
@@ -53,7 +53,7 @@ export const args = {
     short: "e",
     type: ObjectFromKeyValue,
     description:
-      "Environment variables to set on the fork. Env vars from the source sandbox are not copied (encrypted server-side).",
+      "Environment variables to set on the fork. When provided, fully replaces the env vars copied from the source (no per-key merge).",
   }),
   tags: cmd.multioption({
     long: "tag",
@@ -70,7 +70,7 @@ export const args = {
 export const fork = cmd.command({
   name: "fork",
   description:
-    "Fork an existing sandbox into a new one. Copies config (cpu, timeout, network policy, tags, etc.) from the source sandbox; env vars are NOT copied and must be re-supplied via --env.",
+    "Fork an existing sandbox into a new one. Copies config (cpu, timeout, network policy, tags, env vars, etc.) from the source sandbox; any flag passed here overrides the copied value.",
   args,
   examples: [
     {

--- a/packages/vercel-sandbox-mock/src/fork.test.ts
+++ b/packages/vercel-sandbox-mock/src/fork.test.ts
@@ -1,0 +1,103 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, test } from "vitest";
+import { Sandbox } from "./sandbox";
+
+const MINUTE = 60_000;
+const DAY = 24 * 60 * MINUTE;
+
+const uniq = () => `fork-${randomUUID().slice(0, 8)}`;
+
+async function readEnv(sandbox: Sandbox, name: string): Promise<string> {
+  const result = await sandbox.runCommand("printenv", [name]);
+  return (await result.stdout()).trim();
+}
+
+describe("Sandbox.fork", () => {
+  test("copies the source config when no overrides are given", async () => {
+    const name = uniq();
+    const source = await Sandbox.create({
+      name,
+      resources: { vcpus: 4 },
+      timeout: 10 * MINUTE,
+      tags: { kind: "source" },
+      env: { FORKED: "yes" },
+      ports: [3000, 8080],
+      persistent: true,
+      networkPolicy: "allow-all",
+      snapshotExpiration: 7 * DAY,
+      keepLastSnapshots: { count: 3 },
+    });
+
+    let fork: Sandbox | undefined;
+    try {
+      fork = await Sandbox.fork({ sourceSandbox: name });
+
+      expect(fork.name).not.toBe(name);
+      expect(fork.vcpus).toBe(4);
+      expect(fork.timeout).toBe(10 * MINUTE);
+      expect(fork.tags).toEqual({ kind: "source" });
+      expect(fork.persistent).toBe(true);
+      expect(fork.networkPolicy).toBe("allow-all");
+      expect(fork.snapshotExpiration).toBe(7 * DAY);
+      expect(fork.keepLastSnapshots?.count).toBe(3);
+
+      const forkPorts = fork.routes.map((route) => route.port).sort((a, b) => a - b);
+      expect(forkPorts).toEqual([3000, 8080]);
+
+      expect(await readEnv(fork, "FORKED")).toBe("yes");
+    } finally {
+      await Promise.allSettled([fork?.delete(), source.delete()]);
+    }
+  });
+
+  test("applies overrides on top of the copied source config", async () => {
+    const name = uniq();
+    const source = await Sandbox.create({
+      name,
+      resources: { vcpus: 1 },
+      timeout: 5 * MINUTE,
+      tags: { kind: "source" },
+      env: { FORKED: "source" },
+      persistent: true,
+      networkPolicy: "allow-all",
+      snapshotExpiration: 7 * DAY,
+      keepLastSnapshots: { count: 3 },
+    });
+
+    const forkName = `${name}-child`;
+    let fork: Sandbox | undefined;
+    try {
+      fork = await Sandbox.fork({
+        sourceSandbox: name,
+        name: forkName,
+        resources: { vcpus: 2 },
+        timeout: 10 * MINUTE,
+        tags: { kind: "override" },
+        env: { FORKED: "override" },
+        persistent: false,
+        networkPolicy: "deny-all",
+        snapshotExpiration: 14 * DAY,
+        keepLastSnapshots: { count: 5 },
+      });
+
+      expect(fork.name).toBe(forkName);
+      expect(fork.vcpus).toBe(2);
+      expect(fork.timeout).toBe(10 * MINUTE);
+      expect(fork.tags).toEqual({ kind: "override" });
+      expect(fork.persistent).toBe(false);
+      expect(fork.networkPolicy).toBe("deny-all");
+      expect(fork.snapshotExpiration).toBe(14 * DAY);
+      expect(fork.keepLastSnapshots?.count).toBe(5);
+
+      expect(await readEnv(fork, "FORKED")).toBe("override");
+    } finally {
+      await Promise.allSettled([fork?.delete(), source.delete()]);
+    }
+  });
+
+  test("rejects when the source sandbox does not exist", async () => {
+    await expect(
+      Sandbox.fork({ sourceSandbox: `missing-${randomUUID().slice(0, 8)}` }),
+    ).rejects.toMatchObject({ response: { status: 404 } });
+  });
+});

--- a/packages/vercel-sandbox-mock/src/server/mock-server.ts
+++ b/packages/vercel-sandbox-mock/src/server/mock-server.ts
@@ -109,6 +109,7 @@ export class MockServer {
     }
     // /v2/sandboxes/:name
     const name = decodeURIComponent(rest[0]);
+    if (rest[1] === "fork" && method === "POST") return this.#forkSandbox(name, init);
     if (method === "GET") return this.#getSandbox(name, url);
     if (method === "PATCH") return this.#updateSandbox(name, init);
     if (method === "DELETE") return this.#deleteSandbox(name);
@@ -164,6 +165,59 @@ export class MockServer {
       sandbox: sandboxPayload(record, session),
       session: sessionPayload(session),
       routes: routesPayload(name, ports),
+      resumed: false,
+    });
+  }
+
+  async #forkSandbox(sourceName: string, init?: RequestInit): Promise<Response> {
+    const source = this.#sandboxes.get(sourceName);
+    if (!source) return apiError(404, "not_found", `Sandbox not found: ${sourceName}`);
+
+    const body = readJson<CreateBody>(init);
+    const name = body.name ?? `sandbox-${randomUUID()}`;
+
+    // Copy the source's config; any body field overrides the copied value.
+    const record: SandboxRecord = {
+      name,
+      persistent: body.persistent ?? source.persistent,
+      region: source.region,
+      vcpus: body.resources?.vcpus ?? source.vcpus,
+      memory: source.memory,
+      runtime: body.runtime ?? source.runtime,
+      timeout: body.timeout ?? source.timeout,
+      tags: body.tags ?? source.tags,
+      networkPolicy: body.networkPolicy ?? source.networkPolicy,
+      cwd: source.cwd,
+      env: body.env ?? source.env,
+      ports: body.ports ?? source.ports,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      snapshotExpiration: body.snapshotExpiration ?? source.snapshotExpiration,
+      keepLastSnapshots: body.keepLastSnapshots ?? source.keepLastSnapshots,
+      sessionId: "",
+      users: createUserState(),
+    };
+
+    // Restore from the source's current snapshot when it has one.
+    let restore: SnapshotFileEntry[] | undefined;
+    if (source.currentSnapshotId) {
+      const snapshot = this.#snapshots.get(source.currentSnapshotId);
+      if (snapshot && snapshot.status !== "deleted") {
+        restore = snapshot.files;
+        record.sourceSnapshotId = snapshot.id;
+      }
+    }
+
+    const session = await this.#startSession(record, {
+      sourceSnapshotId: record.sourceSnapshotId,
+      restore,
+    });
+    this.#sandboxes.set(name, record);
+
+    return json({
+      sandbox: sandboxPayload(record, session),
+      session: sessionPayload(session),
+      routes: routesPayload(name, record.ports),
       resumed: false,
     });
   }

--- a/packages/vercel-sandbox/src/api-client/api-client.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.ts
@@ -212,6 +212,58 @@ export class APIClient extends BaseClient {
     );
   }
 
+  async forkSandbox(
+    params: WithPrivate<{
+      sourceSandbox: string;
+      projectId: string;
+      name?: string;
+      ports?: number[];
+      timeout?: number;
+      resources?: { vcpus: number };
+      persistent?: boolean;
+      image?: string;
+      networkPolicy?: NetworkPolicy;
+      env?: Record<string, string>;
+      tags?: Record<string, string>;
+      snapshotExpiration?: number;
+      keepLastSnapshots?: {
+        count: number;
+        expiration?: number;
+        deleteEvicted?: boolean;
+      };
+      signal?: AbortSignal;
+    }>,
+  ) {
+    const privateParams = getPrivateParams(params);
+    return parseOrThrow(
+      SandboxAndSessionResponse,
+      await this.request(
+        `/v2/sandboxes/${encodeURIComponent(params.sourceSandbox)}/fork`,
+        {
+          method: "POST",
+          query: { projectId: params.projectId },
+          body: JSON.stringify({
+            name: params.name,
+            ports: params.ports,
+            timeout: params.timeout,
+            resources: params.resources,
+            image: params.image,
+            persistent: params.persistent,
+            networkPolicy: params.networkPolicy
+              ? toAPINetworkPolicy(params.networkPolicy)
+              : undefined,
+            env: params.env,
+            tags: params.tags,
+            snapshotExpiration: params.snapshotExpiration,
+            keepLastSnapshots: params.keepLastSnapshots,
+            ...privateParams,
+          }),
+          signal: params.signal,
+        },
+      ),
+    );
+  }
+
   async runCommand(params: {
     sessionId: string;
     cwd?: string;

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -192,14 +192,12 @@ export type CreateSandboxParams =
 /**
  * Parameters for {@link Sandbox.fork}.
  *
- * The fork inherits the source sandbox's current filesystem snapshot and copies
- * as many config fields from the source as the server exposes. Any field set
- * here acts as an override of the copied value.
- *
- * `env` is not copied (encrypted server-side); pass it explicitly to set
- * environment variables on the fork. `runtime` is not exposed: when the
- * source has a snapshot, it is inherited; otherwise it is copied from the
- * source sandbox.
+ * The fork inherits the source sandbox's current filesystem snapshot and the
+ * server copies its config — resources, timeout, ports, tags, network policy,
+ * image, persistence, snapshot settings, and environment variables. Any field
+ * set here acts as an override of the copied value. `runtime` is not exposed:
+ * when the source has a snapshot it is inherited, otherwise the source's
+ * runtime/image is copied.
  * @inline
  */
 export type ForkSandboxParams = Omit<
@@ -210,6 +208,11 @@ export type ForkSandboxParams = Omit<
    * Name of the source sandbox to fork from.
    */
   sourceSandbox: string;
+  /**
+   * A Vercel Container Registry (VCR) image to start the fork from, overriding
+   * the image copied from the source.
+   */
+  image?: string;
 };
 
 /** @inline */
@@ -720,14 +723,13 @@ export class Sandbox implements ExecutionContext {
   }
 
   /**
-   * Fork an existing sandbox into a new one. Any field passed in `params`
-   * overrides the source value.
+   * Fork an existing sandbox into a new one.
    *
-   * If the source sandbox has no current snapshot, falls back to creating a
-   * fresh sandbox with the same copied config plus the source's `runtime`.
-   *
-   * `env` is not copied (encrypted server-side); pass it explicitly to set
-   * environment variables on the fork.
+   * The server restores the fork from the source's current snapshot (or the
+   * source's runtime/image when it has none) and copies its config — resources,
+   * timeout, ports, tags, network policy, image, persistence, snapshot
+   * settings, and environment variables. Any field passed in `params` overrides
+   * the copied value.
    *
    * @param params - Fork parameters and optional credentials.
    *   `sourceSandbox` is the name of the source sandbox; everything else
@@ -751,63 +753,40 @@ export class Sandbox implements ExecutionContext {
       WithFetchOptions,
   ): Promise<Sandbox & AsyncDisposable> {
     "use step";
-    const { sourceSandbox: sourceName, ...overrides } = params;
-
-    // Forward only what `Sandbox.get` consumes; don't leak fork-only inputs.
-    const credentialFields = params as Partial<Credentials>;
-    const sourceSandbox = await Sandbox.get({
-      token: credentialFields.token,
-      projectId: credentialFields.projectId,
-      teamId: credentialFields.teamId,
+    const credentials = await getCredentials(params);
+    const client = new APIClient({
+      teamId: credentials.teamId,
+      token: credentials.token,
       fetch: params.fetch,
+    });
+
+    const privateParams = getPrivateParams(params);
+    const response = await client.forkSandbox({
+      sourceSandbox: params.sourceSandbox,
+      projectId: credentials.projectId,
+      name: params.name,
+      ports: params.ports,
+      timeout: params.timeout,
+      resources: params.resources,
+      image: params.image,
+      networkPolicy: params.networkPolicy,
+      env: params.env,
+      tags: params.tags,
+      snapshotExpiration: params.snapshotExpiration,
+      keepLastSnapshots: params.keepLastSnapshots,
+      persistent: params.persistent,
       signal: params.signal,
-      ...getPrivateParams(params),
-      name: sourceName,
-      resume: false,
-    } as Parameters<typeof Sandbox.get>[0]);
+      ...privateParams,
+    });
 
-    const sourcePorts = sourceSandbox.routes
-      .filter((r) => r.port !== sourceSandbox.interactivePort)
-      .map((r) => r.port);
-
-    const copied: Omit<BaseCreateSandboxParams, "source" | "runtime"> = {
-      ...(sourceSandbox.vcpus !== undefined && {
-        resources: { vcpus: sourceSandbox.vcpus },
-      }),
-      ...(sourceSandbox.timeout !== undefined && {
-        timeout: sourceSandbox.timeout,
-      }),
-      ...(sourceSandbox.networkPolicy !== undefined && {
-        networkPolicy: sourceSandbox.networkPolicy,
-      }),
-      ...(sourceSandbox.tags !== undefined && { tags: sourceSandbox.tags }),
-      ...(sourcePorts.length > 0 && { ports: sourcePorts }),
-      persistent: sourceSandbox.persistent,
-      ...(sourceSandbox.snapshotExpiration !== undefined && {
-        snapshotExpiration: sourceSandbox.snapshotExpiration,
-      }),
-      ...(sourceSandbox.keepLastSnapshots !== undefined && {
-        keepLastSnapshots: sourceSandbox.keepLastSnapshots,
-      }),
-    };
-
-    const snapshotId = sourceSandbox.currentSnapshotId;
-    if (snapshotId) {
-      return Sandbox.create({
-        ...copied,
-        ...overrides,
-        source: { type: "snapshot", snapshotId },
-      } as Parameters<typeof Sandbox.create>[0]);
-    }
-
-    // No snapshot: seed a fresh sandbox using the source's runtime.
-    return Sandbox.create({
-      ...copied,
-      ...(sourceSandbox.runtime !== undefined && {
-        runtime: sourceSandbox.runtime,
-      }),
-      ...overrides,
-    } as Parameters<typeof Sandbox.create>[0]);
+    return new DisposableSandbox({
+      client,
+      session: response.json.session,
+      sandbox: response.json.sandbox,
+      routes: response.json.routes,
+      projectId: credentials.projectId,
+      onResume: params.onResume,
+    });
   }
 
   /**

--- a/skills/sandbox/SKILL.md
+++ b/skills/sandbox/SKILL.md
@@ -239,17 +239,18 @@ instructions.
 
 `Sandbox.fork` seeds a new sandbox from another sandbox's current snapshot
 and copies its config (`resources`, `timeout`, `networkPolicy`, `tags`,
-`ports`, `persistent`, `snapshotExpiration`, `keepLastSnapshots`). Any field
-you pass overrides the inherited value. `env` is not copied (encrypted
-server-side) and must be re-supplied. If the source has no current snapshot,
-the fork falls back to a fresh create using the source's `runtime` plus the
-copied config.
+`ports`, `image`, `persistent`, `snapshotExpiration`, `keepLastSnapshots`,
+and `env`). Any field you pass overrides the inherited value. If the source
+has no current snapshot, the fork falls back to the source's `runtime`/`image`
+plus the copied config. You can only fork a sandbox in a project you have
+access to; forking an unknown source returns a 404.
 
 ```typescript
-// Inherit everything from the source
+// Inherit everything from the source (env included)
 const fork = await Sandbox.fork({ sourceSandbox: "prod-agent" });
 
-// Override specific fields; the rest are copied from the source
+// Override specific fields; the rest are copied from the source.
+// A provided `env` fully replaces the source's env (no per-key merge).
 const fork = await Sandbox.fork({
   sourceSandbox: "prod-agent",
   name: "forked-prod-agent",
@@ -949,7 +950,7 @@ sandbox create --snapshot-expiration 7d      # Default snapshot TTL
 sandbox create --keep-last-snapshots 1       # Retention policy
 sandbox create --tag env=staging             # Repeatable
 
-# Fork an existing sandbox (inherits config; env is NOT copied)
+# Fork an existing sandbox (inherits config, incl. env; --env replaces it)
 sandbox fork <source>
 sandbox fork <source> --name my-fork --vcpus 4 --env FOO=1
 


### PR DESCRIPTION
Instead of implementing the Fork on the client-side, use the new API endpoint that implements the sandbox fork.