### PR TITLE
chore: add changeset for fork API support

### DIFF
--- a/.changeset/fork-api-support.md
+++ b/.changeset/fork-api-support.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": minor
+---
+
+Support the sandbox fork API. Instead of implementing fork on the client-side, `Sandbox.fork()` now calls the `POST /v2/sandboxes/:name/fork` endpoint, which copies the source sandbox's env (and image) server-side.


### PR DESCRIPTION
[#258](https://github.com/vercel/sandbox/pull/258) landed support for the sandbox fork API but was missing a changeset, so the change won't be picked up by the release automation.

It is a `minor` as we are updating the feature (now we support passing environment variables, image, etc.).