### PR TITLE
Add @vercel/core-platform to .vercel.approvers

### DIFF
--- a/.vercel.approvers
+++ b/.vercel.approvers
@@ -1,1 +1,2 @@
 @vercel/compute
+@vercel/core-platform


### PR DESCRIPTION
Adds the `@vercel/core-platform` team to `.vercel.approvers` alongside the existing `@vercel/compute` entry, so `ownership.vercel.sh` recognizes both teams as owners of this repo.

Stacked on top of #262, which introduces `.vercel.approvers` (that file doesn't exist on `main` yet), so this PR targets the `ownership` branch and its diff is just the one added line. Once #262 merges, GitHub will retarget this PR to `main`.

Existing entries are unchanged and un-reordered — `@vercel/core-platform` is appended on its own line, matching the file's one-team-per-line `@org/team` format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)