### PR TITLE
feat(docs): update docs for shared images

### DIFF
--- a/.changeset/ripe-clouds-matter.md
+++ b/.changeset/ripe-clouds-matter.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Add support for shared VCR images

--- a/README.md
+++ b/README.md
@@ -172,8 +172,12 @@ Build and push a `linux/amd64` image to VCR:
 
 ```sh
 vercel vcr login docker
-docker build --platform linux/amd64 -t vcr.vercel.com/team-slug/project-slug/my-repository:latest .
-docker push vcr.vercel.com/team-slug/project-slug/my-repository:latest
+
+IMAGE=vcr.vercel.com/team-slug/project-slug/my-repository:latest
+
+docker build --platform linux/amd64 -t $IMAGE .
+
+docker push $IMAGE
 ```
 
 Then start a sandbox from it:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ infrastructure][hive] that powers 2M+ builds a day at Vercel.
 
 ## Getting started
 
-To get started using Node.js 22+, create a new project:
+To get started using Node.js 24, create a new project:
 
 ```sh
 mkdir my-sandbox-app && cd my-sandbox-app
@@ -162,9 +162,35 @@ recreate an API client using OIDC or environment credentials when needed.
 - Sandboxes have a maximum runtime duration of 24 hours for Pro/Enterprise and 45 minutes for Hobby,
   with a default of 5 minutes. This can be configured using the `timeout` option of `Sandbox.create()`.
 
+
+## Custom images
+
+A sandbox can boot from any OCI image by pushing it to
+[Vercel Container Registry (VCR)][vcr-docs] and passing `image` to `Sandbox.create()`.
+
+Build and push a `linux/amd64` image to VCR (zstd compression recommended):
+
+```sh
+vercel vcr login docker
+docker buildx build \
+  --platform linux/amd64 \
+  --output "type=image,name=vcr.vercel.com/team-slug/project-slug/my-repository:latest,push=true,oci-mediatypes=true,compression=zstd,compression-level=3,force-compression=true" \
+  .
+```
+
+Then start a sandbox from it:
+
+```ts
+const sandbox = await Sandbox.create({
+  image: "my-repository:latest",
+});
+```
+
+See the [images documentation][images-docs] for more details.
+
 ## System
 
-The base system is an Amazon Linux 2023 system with the following additional
+The base system when an `image` is omitted is an Amazon Linux 2023 system with the following additional
 packages installed.
 
 ```
@@ -222,8 +248,9 @@ available [here](https://docs.aws.amazon.com/linux/al2023/release-notes/all-pack
 
 [create-token]: https://vercel.com/account/settings/tokens
 [hive]: https://vercel.com/blog/a-deep-dive-into-hive-vercels-builds-infrastructure
+[vcr-docs]: https://vercel.com/docs/container-registry
+[images-docs]: https://vercel.com/docs/sandbox/concepts/images
 [al-2023-packages]: https://docs.aws.amazon.com/linux/al2023/release-notes/all-packages-AL2023.7.html
-
 
 The skill provides comprehensive guidance on using the `@vercel/sandbox` SDK, including code patterns, best practices, and API reference.
 

--- a/README.md
+++ b/README.md
@@ -168,14 +168,12 @@ recreate an API client using OIDC or environment credentials when needed.
 A sandbox can boot from any OCI image by pushing it to
 [Vercel Container Registry (VCR)][vcr-docs] and passing `image` to `Sandbox.create()`.
 
-Build and push a `linux/amd64` image to VCR (zstd compression recommended):
+Build and push a `linux/amd64` image to VCR:
 
 ```sh
 vercel vcr login docker
-docker buildx build \
-  --platform linux/amd64 \
-  --output "type=image,name=vcr.vercel.com/team-slug/project-slug/my-repository:latest,push=true,oci-mediatypes=true,compression=zstd,compression-level=3,force-compression=true" \
-  .
+docker build --platform linux/amd64 -t vcr.vercel.com/team-slug/project-slug/my-repository:latest .
+docker push vcr.vercel.com/team-slug/project-slug/my-repository:latest
 ```
 
 Then start a sandbox from it:

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -167,14 +167,15 @@ export type RuntimeOrImage =
   | {
       /**
        * A Vercel Container Registry (VCR) image to start the sandbox from,
-       * scoped to the sandbox's project. Accepts a repository name, an
+       * scoped to the sandbox's project or a shared image from any project. Accepts a repository name, an
        * optional tag or digest, or a fully-qualified VCR URL. A bare
        * repository name resolves to the `latest` tag.
        *
        * @example "my-repo" // latest tag
        * @example "my-repo:v1" // specific tag
        * @example "my-repo@sha256:..." // specific digest
-       * @example "vcr.vercel.com/my-team/my-project/my-repo:v1" // fully-qualified
+       * @example "other-team/other-project/repo:v1" // Shared image from another team 
+       * @example "vcr.vercel.com/my-team/my-project/repo:v1" // fully-qualified
        */
       image?: string;
       runtime?: never;

--- a/skills/sandbox/SKILL.md
+++ b/skills/sandbox/SKILL.md
@@ -211,6 +211,11 @@ Registry](https://vercel.com/docs/container-registry) (VCR) image stored in the
 sandbox's project. `image` and `runtime` are **mutually exclusive** — pass one
 or the other, never both.
 
+The stock runtimes are Amazon Linux 2023 systems. If a sandbox needs a
+different distro or system tooling beyond what AL2023 provides, prefer baking
+it into a custom image over installing packages with `dnf install` + `sudo`
+at runtime.
+
 ```typescript
 const sandbox = await Sandbox.create({
   image: "my-repo:v1",
@@ -930,6 +935,10 @@ await sandbox.runCommand({
   sudo: true,
 });
 ```
+
+This is fine for one-offs, but `dnf` limits you to what is packaged for the
+Amazon Linux 2023 base system. If you need a different distro or base
+environment, use a [custom image](#from-a-custom-image-vcr) instead.
 
 ## CLI Quick Reference
 


### PR DESCRIPTION
Update documentation to prioritise using an `image` over a runtime, update docs to mention that an image can be shared.