### PR TITLE
Add @vercel/core-platform to .vercel.approvers

### DIFF
--- a/.vercel.approvers
+++ b/.vercel.approvers
@@ -1,1 +1,2 @@
 @vercel/compute
+@vercel/core-platform


### PR DESCRIPTION
Adds the `@vercel/core-platform` team to `.vercel.approvers` alongside the existing `@vercel/compute` entry, so `ownership.vercel.sh` recognizes both teams as owners of this repo.

Follows the file's existing one-team-per-line `@org/team` format. The existing entry is unchanged and un-reordered — `@vercel/core-platform` is appended on its own line (which also keeps the list alphabetical).

Follow-up to #262, which introduced the file. This supersedes #263, which was stacked on #262's `ownership` branch and got auto-closed when that branch was deleted on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)