### PR TITLE
add VMI's

### DIFF
--- a/.changeset/sandbox-images-initial.md
+++ b/.changeset/sandbox-images-initial.md
@@ -1,0 +1,9 @@
+---
+"sandbox-image-ubuntu": minor
+"sandbox-image-node": minor
+"sandbox-image-python": minor
+"sandbox-image-universal": minor
+"sandbox-image-arch": minor
+---
+
+Initial release of the `vercel/sandbox/*` images: `ubuntu` (base), `node` (22/24/26), `python` (3.14), `universal` (Node.js, Python, coding agents and utilities) and `arch` (with yay/AUR support).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,9 @@ NOTE: Running the tests creates actual sandboxes.
 3. `vc link` to a project that you want to use for experimentation.
 4. `vc env pull` so you get an `.env.local` with a `VERCEL_OIDC_TOKEN`
 5. `cd packages/sandbox && pnpm test`
+
+## Sandbox images
+
+The Dockerfiles for the `vercel/sandbox/*` images live in
+[`images/`](./images). See the [images README](./images/README.md) for the
+full list of images and how to build them.

--- a/README.md
+++ b/README.md
@@ -228,8 +228,7 @@ The skill provides comprehensive guidance on using the `@vercel/sandbox` SDK, in
 
 ## Images
 
-The Dockerfiles for Vercel Managed Images are published under `vercel/sandbox/*` (Ubuntu,
-Node.js, Python, universal, Arch Linux) live in [`images/`](https://github.com/vercel/sandbox/tree/main/images). See the
+The Dockerfiles for Vercel Managed Images published under `vercel/sandbox/*` live in [`images/`](https://github.com/vercel/sandbox/tree/main/images). See the
 [images README](https://github.com/vercel/sandbox/tree/main/images#readme) for the full list and build instructions.
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -224,8 +224,13 @@ available [here](https://docs.aws.amazon.com/linux/al2023/release-notes/all-pack
 [hive]: https://vercel.com/blog/a-deep-dive-into-hive-vercels-builds-infrastructure
 [al-2023-packages]: https://docs.aws.amazon.com/linux/al2023/release-notes/all-packages-AL2023.7.html
 
-
 The skill provides comprehensive guidance on using the `@vercel/sandbox` SDK, including code patterns, best practices, and API reference.
+
+## Images
+
+The Dockerfiles for Vercel Managed Images are published under `vercel/sandbox/*` (Ubuntu,
+Node.js, Python, universal, Arch Linux) live in [`images/`](https://github.com/vercel/sandbox/tree/main/images). See the
+[images README](https://github.com/vercel/sandbox/tree/main/images#readme) for the full list and build instructions.
 
 ## Authors
 

--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,27 @@
+# Vercel Managed Images
+
+Dockerfiles for Vercel Managed Images published to Vercel Container Registry (VCR) under
+`vercel/sandbox/*`.
+
+| Image                                            | Base                    | Contents                                          |
+| ------------------------------------------------ | ----------------------- | ------------------------------------------------- |
+| [`vercel/sandbox/universal:latest`](./universal) | `vercel/sandbox/ubuntu` | Node.js 24, Python 3.14, coding agents, utilities |
+| [`vercel/sandbox/node:22\|24\|26`](./node)       | `vercel/sandbox/ubuntu` | Node.js (major pinned), pnpm                      |
+| [`vercel/sandbox/python:3.14`](./python)         | `vercel/sandbox/ubuntu` | Python 3.14 (pinned), pip, venv, uv               |
+| [`vercel/sandbox/arch:latest`](./arch)           | `archlinux:latest`      | Arch Linux, yay (AUR), base-devel, git            |
+| [`vercel/sandbox/ubuntu:latest`](./ubuntu)       | `ubuntu:26.04`          | Ubuntu + sudo                                     |
+
+All images are built for `linux/amd64`.
+
+## Building locally
+
+```sh
+cd images
+
+# Build all images
+docker buildx bake
+
+# Build a single image
+docker buildx bake node-24
+docker buildx bake universal
+```

--- a/images/README.md
+++ b/images/README.md
@@ -3,13 +3,13 @@
 Dockerfiles for Vercel Managed Images published to Vercel Container Registry (VCR) under
 `vercel/sandbox/*`.
 
-| Image                                            | Base                    | Contents                                          |
-| ------------------------------------------------ | ----------------------- | ------------------------------------------------- |
-| [`vercel/sandbox/universal:latest`](./universal) | `vercel/sandbox/ubuntu` | Node.js 24, Python 3.14, coding agents, utilities |
-| [`vercel/sandbox/node:22\|24\|26`](./node)       | `vercel/sandbox/ubuntu` | Node.js (major pinned), pnpm                      |
-| [`vercel/sandbox/python:3.14`](./python)         | `vercel/sandbox/ubuntu` | Python 3.14 (pinned), pip, venv, uv               |
-| [`vercel/sandbox/arch:latest`](./arch)           | `archlinux:latest`      | Arch Linux, yay (AUR), base-devel, git            |
-| [`vercel/sandbox/ubuntu:latest`](./ubuntu)       | `ubuntu:26.04`          | Ubuntu + sudo                                     |
+| Image                                            | Base                    | Contents                                                  |
+| ------------------------------------------------ | ----------------------- | --------------------------------------------------------- |
+| [`vercel/sandbox/universal:latest`](./universal) | `vercel/sandbox/ubuntu` | Node.js LTS (24), Python (3.14), coding agents, utilities |
+| [`vercel/sandbox/node:22\|24\|26`](./node)       | `vercel/sandbox/ubuntu` | Node.js (major pinned), pnpm                              |
+| [`vercel/sandbox/python:3.14`](./python)         | `vercel/sandbox/ubuntu` | Python 3.14 (pinned), pip, venv, uv                       |
+| [`vercel/sandbox/arch:latest`](./arch)           | `archlinux:latest`      | Arch Linux, yay (AUR), base-devel, git                    |
+| [`vercel/sandbox/ubuntu:latest`](./ubuntu)       | `ubuntu:26.04`          | Ubuntu + sudo                                             |
 
 All images are built for `linux/amd64`.
 

--- a/images/arch/Dockerfile
+++ b/images/arch/Dockerfile
@@ -8,7 +8,6 @@ RUN pacman -Syu --noconfirm && \
   pacman -S --noconfirm --needed sudo base-devel git && \
   rm -rf /var/cache/pacman/pkg/*
 
-# create `arch` (uid 1000) with passwordless sudo.
 RUN useradd -m -u 1000 -s /bin/bash arch && \
   printf '%s\n' \
   'Defaults always_set_home' \

--- a/images/arch/Dockerfile
+++ b/images/arch/Dockerfile
@@ -1,0 +1,30 @@
+FROM archlinux:latest
+
+# pacman's download sandbox does not work in containerized environments
+RUN sed -i '/^\[options\]/a DisableSandbox' /etc/pacman.conf
+
+# base-devel and git are required to build AUR packages with yay.
+RUN pacman -Syu --noconfirm && \
+  pacman -S --noconfirm --needed sudo base-devel git && \
+  rm -rf /var/cache/pacman/pkg/*
+
+# create `arch` (uid 1000) with passwordless sudo.
+RUN useradd -m -u 1000 -s /bin/bash arch && \
+  printf '%s\n' \
+  'Defaults always_set_home' \
+  'Defaults !env_reset' \
+  'Defaults !fqdn' \
+  'arch ALL=(ALL) NOPASSWD:ALL' \
+  > /etc/sudoers.d/sandbox && \
+  chmod 0440 /etc/sudoers.d/sandbox
+
+USER arch
+WORKDIR /home/arch
+
+# yay (AUR helper)
+RUN git clone https://aur.archlinux.org/yay-bin.git /tmp/yay-bin && \
+  cd /tmp/yay-bin && \
+  makepkg -si --noconfirm && \
+  rm -rf /tmp/yay-bin && \
+  sudo rm -rf /var/cache/pacman/pkg/* && \
+  yay --version

--- a/images/arch/README.md
+++ b/images/arch/README.md
@@ -1,0 +1,16 @@
+# arch
+
+`vercel/sandbox/arch:latest`
+
+Arch Linux with no language runtimes (no Node.js, no Python). Arch has one
+of the largest package repositories: use `sudo pacman -S <pkg>` for official
+packages and `yay -S <pkg>` for the [AUR](https://aur.archlinux.org/).
+Rolling release, rebuilt on a regular cadence to stay current.
+
+Runs as `arch` user (uid 1000) with passwordless sudo.
+
+## Packages
+
+- `base-devel` and `git` (required to build AUR packages)
+- `yay` (AUR helper, from `yay-bin`)
+- `sudo`

--- a/images/arch/package.json
+++ b/images/arch/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "sandbox-image-arch",
+  "version": "0.0.0",
+  "private": true
+}

--- a/images/docker-bake.hcl
+++ b/images/docker-bake.hcl
@@ -1,0 +1,67 @@
+group "default" {
+  targets = ["ubuntu", "node", "python", "universal", "arch"]
+}
+
+target "_common" {
+  platforms = ["linux/amd64"]
+}
+
+target "ubuntu" {
+  inherits = ["_common"]
+  context  = "ubuntu"
+  tags     = ["vercel/sandbox/ubuntu:latest"]
+}
+
+target "node" {
+  matrix = {
+    major = ["22", "24", "26"]
+  }
+
+  name     = "node-${major}"
+  inherits = ["_common"]
+  context  = "node"
+  tags     = ["vercel/sandbox/node:${major}"]
+
+  contexts = {
+    base = "target:ubuntu"
+  }
+
+  args = {
+    NODE_MAJOR = major
+  }
+}
+
+target "python" {
+  inherits = ["_common"]
+  context  = "python"
+  tags     = ["vercel/sandbox/python:3.14"]
+
+  contexts = {
+    base = "target:ubuntu"
+  }
+
+  args = {
+    PYTHON_VERSION = "3.14"
+  }
+}
+
+target "universal" {
+  inherits = ["_common"]
+  context  = "universal"
+  tags     = ["vercel/sandbox/universal:latest"]
+
+  contexts = {
+    base = "target:ubuntu"
+  }
+
+  args = {
+    NODE_MAJOR     = "24"
+    PYTHON_VERSION = "3.14"
+  }
+}
+
+target "arch" {
+  inherits = ["_common"]
+  context  = "arch"
+  tags     = ["vercel/sandbox/arch:latest"]
+}

--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -1,0 +1,41 @@
+FROM base AS fetch
+USER root
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl libarchive-tools && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG NODE_MAJOR
+RUN tarball="$(curl -fsSL "https://nodejs.org/dist/latest-v${NODE_MAJOR}.x/SHASUMS256.txt" \
+      | grep -oE 'node-v[0-9]+\.[0-9]+\.[0-9]+-linux-x64\.tar\.xz' | head -n1)" && \
+    mkdir -p /opt/node && \
+    curl -fsSL "https://nodejs.org/dist/latest-v${NODE_MAJOR}.x/${tarball}" \
+      | bsdtar -xJ --strip-components=1 -C /opt/node && \
+    rm -f /opt/node/CHANGELOG.md /opt/node/LICENSE /opt/node/README.md
+
+FROM base
+USER root
+
+# Node.js requires libatomic.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libatomic1 && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=fetch /opt/node /usr/local
+
+RUN npm install -g pnpm@10 && \
+    npm cache clean --force
+
+USER ubuntu
+
+RUN mkdir -p ~/.global/npm ~/.global/pnpm && \
+    npm config set prefix ~/.global/npm && \
+    pnpm config set global-dir ~/.global/pnpm && \
+    pnpm config set global-bin-dir ~/.global/pnpm/bin
+
+ENV PATH="/home/ubuntu/.global/pnpm/bin:/home/ubuntu/.global/npm/bin:${PATH}"
+
+RUN node --version && \
+    npm --version && \
+    pnpm --version

--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
 
 COPY --from=fetch /opt/node /usr/local
 
-RUN npm install -g pnpm@10 && \
+RUN npm install -g pnpm@11 && \
     npm cache clean --force
 
 USER ubuntu

--- a/images/node/README.md
+++ b/images/node/README.md
@@ -1,0 +1,16 @@
+# node
+
+`vercel/sandbox/node:22` | `vercel/sandbox/node:24` | `vercel/sandbox/node:26`
+
+Node.js on top of the [ubuntu](../ubuntu) base image. Each tag pins a major version
+and installs the latest release of that line at build time, so tags roll
+forward with rebuilds.
+
+Runs as the default `ubuntu` user (uid 1000) with passwordless sudo.
+
+## Packages
+
+- Node.js (latest release of the tag's major line), with `npm`, `npx` and
+  `corepack`
+- `pnpm` 10
+- `libatomic1`

--- a/images/node/README.md
+++ b/images/node/README.md
@@ -12,5 +12,5 @@ Runs as the default `ubuntu` user (uid 1000) with passwordless sudo.
 
 - Node.js (latest release of the tag's major line), with `npm`, `npx` and
   `corepack`
-- `pnpm` 10
+- `pnpm` 11
 - `libatomic1`

--- a/images/node/package.json
+++ b/images/node/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "sandbox-image-node",
+  "version": "0.0.0",
+  "private": true
+}

--- a/images/python/Dockerfile
+++ b/images/python/Dockerfile
@@ -1,0 +1,26 @@
+FROM base
+USER root
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG PYTHON_VERSION=3.14
+
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  "python${PYTHON_VERSION}" \
+  "python${PYTHON_VERSION}-venv" \
+  python3-pip \
+  python-is-python3 && \
+  rm -f /usr/lib/python3*/EXTERNALLY-MANAGED && \
+  rm -rf /var/lib/apt/lists/* && \
+  pip install uv && \
+  rm -rf /root/.cache/pip
+
+USER ubuntu
+
+# User-installed console scripts (pip, uv tool) land in ~/.local/bin.
+ENV PATH="/home/ubuntu/.local/bin:${PATH}"
+
+RUN python --version | grep -F "Python ${PYTHON_VERSION}." && \
+  python3 --version && \
+  pip --version && \
+  uv --version

--- a/images/python/README.md
+++ b/images/python/README.md
@@ -1,0 +1,16 @@
+# python
+
+`vercel/sandbox/python:3.14`
+
+Python on top of the [ubuntu](../ubuntu) base image. Pinned to Python 3.14
+via the versioned package from the Ubuntu archive; the build fails if the
+distro stops shipping that version.
+
+Runs as the default `ubuntu` user (uid 1000) with passwordless sudo.
+
+## Packages
+
+- `python3.14` and `python3.14-venv` (pinned versioned packages)
+- `python3-pip`
+- `python-is-python3` (provides the `python` command)
+- `uv` and `uvx` (installed via pip)

--- a/images/python/package.json
+++ b/images/python/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "sandbox-image-python",
+  "version": "0.0.0",
+  "private": true
+}

--- a/images/ubuntu/Dockerfile
+++ b/images/ubuntu/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:26.04
+
+ENV LANG=C.UTF-8
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends ca-certificates sudo && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN printf '%s\n' \
+      'Defaults always_set_home' \
+      'Defaults !env_reset' \
+      'Defaults !fqdn' \
+      'ubuntu ALL=(ALL) NOPASSWD:ALL' \
+      > /etc/sudoers.d/sandbox && \
+    chmod 0440 /etc/sudoers.d/sandbox
+
+USER ubuntu
+WORKDIR /home/ubuntu

--- a/images/ubuntu/README.md
+++ b/images/ubuntu/README.md
@@ -1,0 +1,14 @@
+# ubuntu
+
+`vercel/sandbox/ubuntu:latest`
+
+The base image for all Ubuntu-based sandbox images: contains only Ubuntu and
+no additional tooling. Tracks the latest Ubuntu LTS (currently 26.04) and
+rolls forward to newer releases when they become available.
+
+Runs as the default `ubuntu` user (uid 1000) with passwordless sudo.
+
+## Packages
+
+- `ca-certificates`
+- `sudo`

--- a/images/ubuntu/package.json
+++ b/images/ubuntu/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "sandbox-image-ubuntu",
+  "version": "0.0.0",
+  "private": true
+}

--- a/images/universal/Dockerfile
+++ b/images/universal/Dockerfile
@@ -1,0 +1,106 @@
+FROM base AS node
+USER root
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl libarchive-tools && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG NODE_MAJOR=24
+RUN tarball="$(curl -fsSL "https://nodejs.org/dist/latest-v${NODE_MAJOR}.x/SHASUMS256.txt" \
+      | grep -oE 'node-v[0-9]+\.[0-9]+\.[0-9]+-linux-x64\.tar\.xz' | head -n1)" && \
+    mkdir -p /opt/node && \
+    curl -fsSL "https://nodejs.org/dist/latest-v${NODE_MAJOR}.x/${tarball}" \
+      | bsdtar -xJ --strip-components=1 -C /opt/node && \
+    rm -f /opt/node/CHANGELOG.md /opt/node/LICENSE /opt/node/README.md
+
+FROM base
+USER root
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG PYTHON_VERSION=3.14
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    install -d -m 0755 /etc/apt/keyrings && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      awscli \
+      bzip2 \
+      dnsutils \
+      file \
+      fzf \
+      gh \
+      git \
+      git-lfs \
+      gnupg \
+      iproute2 \
+      iputils-ping \
+      jq \
+      less \
+      libatomic1 \
+      lsof \
+      nano \
+      netcat-openbsd \
+      openssl \
+      procps \
+      python-is-python3 \
+      "python${PYTHON_VERSION}" \
+      "python${PYTHON_VERSION}-venv" \
+      python3-pip \
+      ripgrep \
+      rsync \
+      sqlite3 \
+      sudo \
+      tmux \
+      tree \
+      unzip \
+      vim \
+      wget \
+      xz-utils \
+      zip && \
+    rm -f /usr/lib/python3*/EXTERNALLY-MANAGED && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip install uv && \
+    rm -rf /root/.cache/pip && \
+    git lfs install --system
+
+COPY --from=node /opt/node /usr/local
+
+RUN npm install -g pnpm@10 && \
+    npm cache clean --force
+
+# Coding agents.
+RUN npm install -g \
+      opencode-ai \
+      @anthropic-ai/claude-code \
+      @openai/codex && \
+    npm install -g --ignore-scripts @earendil-works/pi-coding-agent && \
+    npm cache clean --force
+
+USER ubuntu
+
+RUN mkdir -p ~/.global/npm ~/.global/pnpm && \
+    npm config set prefix ~/.global/npm && \
+    pnpm config set global-dir ~/.global/pnpm && \
+    pnpm config set global-bin-dir ~/.global/pnpm/bin
+
+ENV PATH="/home/ubuntu/.local/bin:/home/ubuntu/.global/pnpm/bin:/home/ubuntu/.global/npm/bin:${PATH}"
+
+RUN node --version && \
+    python --version | grep -F "Python ${PYTHON_VERSION}." && \
+    pip --version && \
+    uv --version && \
+    git --version && \
+    gh --version && \
+    aws --version && \
+    sudo whoami && \
+    opencode --version && \
+    claude --version && \
+    codex --version && \
+    pi --version

--- a/images/universal/Dockerfile
+++ b/images/universal/Dockerfile
@@ -72,8 +72,12 @@ RUN apt-get update && \
 
 COPY --from=node /opt/node /usr/local
 
-RUN npm install -g pnpm@10 && \
+RUN npm install -g pnpm@11 && \
     npm cache clean --force
+
+# Bun.
+COPY --from=oven/bun:latest /usr/local/bin/bun /usr/local/bin/
+RUN ln -s bun /usr/local/bin/bunx
 
 # Coding agents.
 RUN npm install -g \
@@ -93,6 +97,7 @@ RUN mkdir -p ~/.global/npm ~/.global/pnpm && \
 ENV PATH="/home/ubuntu/.local/bin:/home/ubuntu/.global/pnpm/bin:/home/ubuntu/.global/npm/bin:${PATH}"
 
 RUN node --version && \
+    bun --version && \
     python --version | grep -F "Python ${PYTHON_VERSION}." && \
     pip --version && \
     uv --version && \

--- a/images/universal/Dockerfile
+++ b/images/universal/Dockerfile
@@ -30,7 +30,6 @@ RUN apt-get update && \
       > /etc/apt/sources.list.d/github-cli.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-      awscli \
       bzip2 \
       dnsutils \
       file \
@@ -103,7 +102,6 @@ RUN node --version && \
     uv --version && \
     git --version && \
     gh --version && \
-    aws --version && \
     sudo whoami && \
     opencode --version && \
     claude --version && \

--- a/images/universal/README.md
+++ b/images/universal/README.md
@@ -26,7 +26,6 @@ Runs as the default `ubuntu` user (uid 1000) with passwordless sudo.
 
 ### Utilities
 
-- `awscli` (v2)
 - `curl`, `wget`
 - `git`, `git-lfs` (hooks pre-configured), `gh`
 - `jq`, `ripgrep`, `fzf`, `tree`, `file`, `less`

--- a/images/universal/README.md
+++ b/images/universal/README.md
@@ -12,7 +12,8 @@ Runs as the default `ubuntu` user (uid 1000) with passwordless sudo.
 ### Runtimes
 
 - Node.js 24 with `npm`, `npx`, `corepack` and
-  `pnpm` 10
+  `pnpm` 11
+- Bun (`bun`, `bunx`)
 - Python 3.14 with `pip`, `venv`, `uv` and
   `python-is-python3`
 

--- a/images/universal/README.md
+++ b/images/universal/README.md
@@ -1,0 +1,39 @@
+# universal
+
+`vercel/sandbox/universal:latest`
+
+The default image, built on the [ubuntu](../ubuntu) base
+image. Contains common tooling for most use cases.
+
+Runs as the default `ubuntu` user (uid 1000) with passwordless sudo.
+
+## Packages
+
+### Runtimes
+
+- Node.js 24 with `npm`, `npx`, `corepack` and
+  `pnpm` 10
+- Python 3.14 with `pip`, `venv`, `uv` and
+  `python-is-python3`
+
+### Coding agents
+
+- opencode (`opencode`)
+- Claude Code (`claude`)
+- Codex (`codex`)
+- pi (`pi`)
+
+### Utilities
+
+- `awscli` (v2)
+- `curl`, `wget`
+- `git`, `git-lfs` (hooks pre-configured), `gh`
+- `jq`, `ripgrep`, `fzf`, `tree`, `file`, `less`
+- `vim`, `nano`, `tmux`
+- `rsync`
+- `sqlite3`
+- `unzip`, `zip`, `xz-utils`, `bzip2`
+- `gnupg`, `openssl`
+- `sudo`, `procps`
+- Network/debug tools: `iproute2` (`ss`), `lsof`, `netcat-openbsd` (`nc`),
+  `dnsutils` (`dig`), `iputils-ping` (`ping`)

--- a/images/universal/package.json
+++ b/images/universal/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "sandbox-image-universal",
+  "version": "0.0.0",
+  "private": true
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,16 @@ importers:
         specifier: ^5
         version: 5.8.3
 
+  images/arch: {}
+
+  images/node: {}
+
+  images/python: {}
+
+  images/ubuntu: {}
+
+  images/universal: {}
+
   packages/sandbox:
     dependencies:
       '@vercel/sandbox':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - examples/*
+  - images/*
   - packages/*
 
 catalog:


### PR DESCRIPTION
Add Dockerfiles for Vercel Managed Images.

These are not being published in CI at this point.

This PR is not merging to main, it is merging to `public-images` to be prepped before merging to main.

All images have been tested on a real sandbox.

Sizes of each VHS image:

arch: 339MB
node: 102MB
python: 81MB
ubuntu: 40MB
universal: 646MB
