### PR TITLE
fix(sandbox): use invoked app name in help examples

### DIFF
--- a/.changeset/help-examples-app-name.md
+++ b/.changeset/help-examples-app-name.md
@@ -1,0 +1,5 @@
+---
+"sandbox": patch
+---
+
+Use the invoked app name in help examples so `vercel sandbox --help` shows `vercel sandbox ...` commands instead of the standalone `sandbox ...` form, which is not on PATH for Vercel CLI users.

--- a/packages/sandbox/src/app.ts
+++ b/packages/sandbox/src/app.ts
@@ -17,9 +17,10 @@ import { snapshots } from "./commands/snapshots";
 import { sessions } from "./commands/sessions";
 import { config } from "./commands/config";
 
-export const app = (opts?: { withoutAuth?: boolean; appName?: string }) =>
-  subcommands({
-    name: opts?.appName ?? "sandbox",
+export const app = (opts?: { withoutAuth?: boolean; appName?: string }) => {
+  const appName = opts?.appName ?? "sandbox";
+  return subcommands({
+    name: appName,
     description: "Interfacing with Vercel Sandbox",
     version,
     cmds: {
@@ -45,15 +46,16 @@ export const app = (opts?: { withoutAuth?: boolean; appName?: string }) =>
     examples: [
       {
         description: "Create a sandbox and start a shell",
-        command: "sandbox sh",
+        command: `${appName} sh`,
       },
       {
         description: "Run a command in a new sandbox",
-        command: `sandbox run -- node -e "console.log('hello')"`,
+        command: `${appName} run -- node -e "console.log('hello')"`,
       },
       {
         description: "Execute command in an existing sandbox",
-        command: `sandbox exec <name> -- npm test`,
+        command: `${appName} exec <name> -- npm test`,
       },
     ],
   });
+};


### PR DESCRIPTION
## Problem

The CLI can run under two names: standalone `sandbox`, or embedded in the Vercel CLI as `vercel sandbox` (the embedding passes `appName: 'vercel sandbox'` to `createApp`). The usage line respects that name, but the top-level help examples are hardcoded to the standalone form. So `vercel sandbox --help` prints:

```
EXAMPLES:

  Create a sandbox and start a shell
  $ sandbox sh
```

For Vercel CLI users there is no `sandbox` binary on PATH, so copy-pasting the CLI's own examples fails with `zsh: command not found: sandbox`. Hit this today on a fresh first run (Vercel CLI 56.2.0).

## Fix

Build the example commands from the same `appName` the usage line already uses. Standalone output is unchanged.

Verified against the built package:

- `createApp({ appName: "vercel sandbox" })` help now shows `$ vercel sandbox sh` etc.
- `createApp({ appName: "sandbox" })` output is identical to before.

## Not covered here

Subcommand-level examples (`create.ts`, `fork.ts`) and runtime hints (`format-error.ts`, `snapshot.ts`, `args/sandbox-name.ts`, `logout.ts`, `cp.ts`) also hardcode `sandbox ...`. Those strings are built at module import time, before `createApp` receives the name, so fixing them needs a small refactor (shared accessor or command factories). Happy to follow up with that if you want it.