### PR TITLE
feat(sdk): respect `retry-after` for up to 20s

### DIFF
--- a/.changeset/plain-groups-fall.md
+++ b/.changeset/plain-groups-fall.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Respect `Retry-After` when the value is up to 20 seconds. `Retry-After` values greater than 20 seconds will throw back the response to the client.

--- a/packages/vercel-sandbox/src/api-client/with-retry.test.ts
+++ b/packages/vercel-sandbox/src/api-client/with-retry.test.ts
@@ -23,12 +23,10 @@ describe("withRetry", () => {
     expectRetryTimes(requestTimes);
   });
 
-  it("uses normal backoff for 429 responses", async () => {
+  it("does not retry 429 responses with retry-after over 20 seconds", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
-    const requestTimes: number[] = [];
     const rawFetch = vi.fn(async () => {
-      requestTimes.push(Date.now());
       return new Response(null, {
         status: 429,
         headers: { "Retry-After": "60" },
@@ -39,17 +37,56 @@ describe("withRetry", () => {
     await vi.runAllTimersAsync();
 
     await expect(responsePromise).resolves.toMatchObject({ status: 429 });
+    expect(rawFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits and retries 429 responses with retry-after of 20 seconds", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const requestTimes: number[] = [];
+    const rawFetch = vi.fn(async () => {
+      requestTimes.push(Date.now());
+      return new Response(null, {
+        status: 429,
+        headers: { "Retry-After": "20" },
+      });
+    });
+
+    const responsePromise = withRetry(rawFetch)("https://example.com");
+    await vi.runAllTimersAsync();
+
+    await expect(responsePromise).resolves.toMatchObject({ status: 429 });
     expect(rawFetch).toHaveBeenCalledTimes(3);
-    expectRetryTimes(requestTimes);
+    expectRetryTimes(requestTimes, 20_000);
+  });
+
+  it("aborts while waiting to retry", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const rawFetch = vi.fn(async () => {
+      return new Response(null, {
+        status: 429,
+        headers: { "Retry-After": "20" },
+      });
+    });
+
+    const responsePromise = withRetry(rawFetch)("https://example.com", {
+      signal: controller.signal,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    controller.abort();
+
+    await expect(responsePromise).rejects.toMatchObject({ name: "AbortError" });
+    expect(rawFetch).toHaveBeenCalledTimes(1);
   });
 });
 
-function expectRetryTimes(requestTimes: number[]) {
+function expectRetryTimes(requestTimes: number[], retryAfter = 0) {
   expect(requestTimes[0]).toBe(0);
-  expect(requestTimes[1]).toBeGreaterThanOrEqual(400);
-  expect(requestTimes[1]).toBeLessThanOrEqual(800);
+  expect(requestTimes[1]).toBeGreaterThanOrEqual(retryAfter + 400);
+  expect(requestTimes[1]).toBeLessThanOrEqual(retryAfter + 800);
 
   const secondDelay = requestTimes[2] - requestTimes[1];
-  expect(secondDelay).toBeGreaterThanOrEqual(800);
-  expect(secondDelay).toBeLessThanOrEqual(1600);
+  expect(secondDelay).toBeGreaterThanOrEqual(retryAfter + 800);
+  expect(secondDelay).toBeLessThanOrEqual(retryAfter + 1600);
 }

--- a/packages/vercel-sandbox/src/api-client/with-retry.ts
+++ b/packages/vercel-sandbox/src/api-client/with-retry.ts
@@ -45,7 +45,7 @@ export function withRetry<T extends RequestInit>(
     }
 
     try {
-      return (await retry(async (bail) => {
+      return (await retry(async (bail, attempt) => {
         try {
           if (opts.signal?.aborted) {
             return bail(opts.signal.reason || new Error("Request aborted"));
@@ -53,6 +53,20 @@ export function withRetry<T extends RequestInit>(
           const response = await rawFetch(url, opts);
 
           if (response.status === 429) {
+            const retryAfter = Number(response.headers.get("Retry-After"));
+
+            // Bail if the retry-after is in more than 20 seconds, as we don't
+            // want to wait for that long before returning to the client.
+            if (retryAfter > 20) {
+              return bail(new APIError(response));
+            }
+
+            const hasRetriesRemaining =
+              retryOpts.forever || attempt <= retryOpts.retries;
+            if (retryAfter > 0 && hasRetriesRemaining) {
+              await waitForRetry(retryAfter * 1000, opts.signal);
+            }
+
             throw new APIError(response);
           }
 
@@ -98,6 +112,26 @@ export function withRetry<T extends RequestInit>(
       throw error;
     }
   };
+}
+
+async function waitForRetry(delay: number, signal?: AbortSignal | null) {
+  if (signal?.aborted) {
+    throw signal.reason || new Error("Request aborted");
+  }
+
+  await new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(signal?.reason || new Error("Request aborted"));
+    };
+
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve(null);
+    }, delay);
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 function isAbortError(error: unknown): error is Error {


### PR DESCRIPTION
Follow-up to https://github.com/vercel/sandbox/pull/254: removing the `retry-after` logic made us always go through the 2 retries (with backoff) if a client keeps hitting a rate limit

This PR adds back the `retry-after` logic and bails if it's more than 20s, while taking into account any `AbortSignal` passed in. It does keep the fewer retries (only 2)