### PR TITLE
Expose Secure Compute network selection

### DIFF
--- a/.changeset/public-secure-compute-network.md
+++ b/.changeset/public-secure-compute-network.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": minor
+---
+
+Add a public `networkId` option for selecting or opting out of Secure Compute per sandbox.

--- a/packages/vercel-sandbox/src/api-client/api-client.test.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.test.ts
@@ -1281,6 +1281,94 @@ describe("APIClient", () => {
       const body = JSON.parse(opts.body);
       expect(body).not.toHaveProperty("keepLastSnapshots");
     });
+
+    it("forwards the Secure Compute network override", async () => {
+      mockFetch.mockResolvedValue(sandboxResponse());
+
+      await client.createSandbox({
+        projectId: "proj_123",
+        networkId: "network_123",
+      });
+
+      const [, opts] = mockFetch.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body.networkId).toBe("network_123");
+    });
+
+    it("forwards null to opt out of the project Secure Compute default", async () => {
+      mockFetch.mockResolvedValue(sandboxResponse());
+
+      await client.createSandbox({
+        projectId: "proj_123",
+        networkId: null,
+      });
+
+      const [, opts] = mockFetch.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body.networkId).toBeNull();
+    });
+  });
+
+  describe("forkSandbox", () => {
+    let client: APIClient;
+    let mockFetch: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockFetch = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            sandbox: {
+              name: "forked-sandbox",
+              persistent: true,
+              region: "iad1",
+              vcpus: 1,
+              memory: 2048,
+              runtime: "node24",
+              timeout: 300000,
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+              status: "running",
+              currentSessionId: "sbx_123",
+            },
+            session: {
+              id: "sbx_123",
+              memory: 2048,
+              vcpus: 1,
+              region: "iad1",
+              runtime: "node24",
+              timeout: 300000,
+              status: "running",
+              requestedAt: Date.now(),
+              createdAt: Date.now(),
+              cwd: "/",
+              updatedAt: Date.now(),
+            },
+            routes: [],
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+      );
+      client = new APIClient({
+        teamId: "team_123",
+        token: "1234",
+        fetch: mockFetch,
+      });
+    });
+
+    it.each([
+      ["an explicit override", "network_123"],
+      ["an explicit opt-out", null],
+    ])("forwards %s", async (_description, networkId) => {
+      await client.forkSandbox({
+        sourceSandbox: "source-sandbox",
+        projectId: "proj_123",
+        networkId,
+      });
+
+      const [, opts] = mockFetch.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body).toHaveProperty("networkId", networkId);
+    });
   });
 
   describe("readFile", () => {

--- a/packages/vercel-sandbox/src/api-client/api-client.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.ts
@@ -172,6 +172,7 @@ export class APIClient extends BaseClient {
       runtime?: RUNTIMES | (string & {});
       image?: string;
       networkPolicy?: NetworkPolicy;
+      networkId?: string | null;
       env?: Record<string, string>;
       tags?: Record<string, string>;
       snapshotExpiration?: number;
@@ -201,6 +202,7 @@ export class APIClient extends BaseClient {
           networkPolicy: params.networkPolicy
             ? toAPINetworkPolicy(params.networkPolicy)
             : undefined,
+          networkId: params.networkId,
           env: params.env,
           tags: params.tags,
           snapshotExpiration: params.snapshotExpiration,
@@ -223,6 +225,7 @@ export class APIClient extends BaseClient {
       persistent?: boolean;
       image?: string;
       networkPolicy?: NetworkPolicy;
+      networkId?: string | null;
       env?: Record<string, string>;
       tags?: Record<string, string>;
       snapshotExpiration?: number;
@@ -252,6 +255,7 @@ export class APIClient extends BaseClient {
             networkPolicy: params.networkPolicy
               ? toAPINetworkPolicy(params.networkPolicy)
               : undefined,
+            networkId: params.networkId,
             env: params.env,
             tags: params.tags,
             snapshotExpiration: params.snapshotExpiration,

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -89,6 +89,13 @@ export interface BaseCreateSandboxParams {
    */
   networkPolicy?: NetworkPolicy;
   /**
+   * The Secure Compute network ID to attach to this sandbox.
+   *
+   * Omit this field to use the project's Sandbox default. Set it to `null` to
+   * create the sandbox without Secure Compute.
+   */
+  networkId?: string | null;
+  /**
    * Default environment variables for the sandbox.
    * These are inherited by all commands unless overridden with
    * the `env` option in `runCommand`.
@@ -703,6 +710,7 @@ export class Sandbox implements ExecutionContext {
       runtime: params?.runtime,
       image: params?.image,
       networkPolicy: params?.networkPolicy,
+      networkId: params?.networkId,
       env: params?.env,
       tags: params?.tags,
       snapshotExpiration: params?.snapshotExpiration,
@@ -771,6 +779,7 @@ export class Sandbox implements ExecutionContext {
       resources: params.resources,
       image: params.image,
       networkPolicy: params.networkPolicy,
+      networkId: params.networkId,
       env: params.env,
       tags: params.tags,
       snapshotExpiration: params.snapshotExpiration,


### PR DESCRIPTION
## What changed

- adds public `networkId?: string | null` to Sandbox create and fork
- forwards explicit network IDs to the API
- forwards `null` to opt out of a project default
- documents omitted values as inheriting the project default

## Validation

- 279 tests passed
- package typecheck passed

## Dependency

Release after https://github.com/vercel/api/pull/83259 is deployed.