### PR TITLE
chore: replace prettier with oxfmt and enforce format:check in CI

### DIFF
--- a/.changeset/oxfmt-formatting.md
+++ b/.changeset/oxfmt-formatting.md
@@ -1,0 +1,7 @@
+---
+"@vercel/sandbox-mock": patch
+"@vercel/sandbox": patch
+"sandbox": patch
+---
+
+Format all JavaScript and TypeScript sources with [oxfmt](https://oxc.rs/docs/guide/usage/formatter) and enforce `pnpm run format:check` in CI, so pull requests no longer carry whitespace-only churn. No runtime behaviour changes.

--- a/.changeset/oxfmt-formatting.md
+++ b/.changeset/oxfmt-formatting.md
@@ -4,4 +4,4 @@
 "sandbox": patch
 ---
 
-Format all JavaScript and TypeScript sources with [oxfmt](https://oxc.rs/docs/guide/usage/formatter) and enforce `pnpm run format:check` in CI, so pull requests no longer carry whitespace-only churn. No runtime behaviour changes.
+Replace Prettier with [oxfmt](https://oxc.rs/docs/guide/usage/formatter) as the repo's only formatter, and enforce `pnpm run format:check` in CI so pull requests no longer carry whitespace-only churn. No runtime behaviour changes.

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,34 @@
+name: Format
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  format:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.16.0"
+          cache: "pnpm"
+
+      - run: pnpm install
+        shell: bash
+
+      - name: Check formatting
+        run: pnpm run format:check

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "printWidth": 80,
+  "ignorePatterns": [
+    "**/dist/**",
+    "**/build/**",
+    "**/out/**",
+    "**/.next/**",
+    "**/.turbo/**",
+    "**/.vercel/**",
+    "**/*.json",
+    "**/*.jsonc",
+    "**/*.json5",
+    "**/*.md",
+    "**/*.mdx",
+    "**/*.yml",
+    "**/*.yaml",
+    "**/*.css"
+  ]
+}

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,20 +1,13 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "printWidth": 80,
+  "sortPackageJson": false,
   "ignorePatterns": [
     "**/dist/**",
     "**/build/**",
     "**/out/**",
     "**/.next/**",
     "**/.turbo/**",
-    "**/.vercel/**",
-    "**/*.json",
-    "**/*.jsonc",
-    "**/*.json5",
-    "**/*.md",
-    "**/*.mdx",
-    "**/*.yml",
-    "**/*.yaml",
-    "**/*.css"
+    "**/.vercel/**"
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,18 @@
 # Contributing
 
+## Formatting
+
+JavaScript and TypeScript are formatted with [oxfmt](https://oxc.rs/docs/guide/usage/formatter),
+configured in [`.oxfmtrc.json`](./.oxfmtrc.json). JSON and Markdown are still
+formatted with Prettier.
+
+- `pnpm run format` formats every JS/TS file in the repo.
+- `pnpm run format:check` reports files that are not formatted. CI runs this on
+  every pull request, so unformatted code fails the build.
+
+A `pre-commit` hook runs oxfmt over staged JS/TS files, so in practice you
+rarely need to run either command by hand.
+
 ## Running the tests
 
 NOTE: Running the tests creates actual sandboxes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,16 +2,17 @@
 
 ## Formatting
 
-JavaScript and TypeScript are formatted with [oxfmt](https://oxc.rs/docs/guide/usage/formatter),
-configured in [`.oxfmtrc.json`](./.oxfmtrc.json). JSON and Markdown are still
-formatted with Prettier.
+Everything is formatted with [oxfmt](https://oxc.rs/docs/guide/usage/formatter),
+configured in [`.oxfmtrc.json`](./.oxfmtrc.json). That covers JavaScript,
+TypeScript, JSON, Markdown, YAML and CSS — oxfmt skips any file type it does
+not understand.
 
-- `pnpm run format` formats every JS/TS file in the repo.
+- `pnpm run format` formats the whole repo.
 - `pnpm run format:check` reports files that are not formatted. CI runs this on
   every pull request, so unformatted code fails the build.
 
-A `pre-commit` hook runs oxfmt over staged JS/TS files, so in practice you
-rarely need to run either command by hand.
+A `pre-commit` hook runs oxfmt over staged files, so in practice you rarely
+need to run either command by hand.
 
 ## Running the tests
 

--- a/examples/ai-example/components/ui/badge.tsx
+++ b/examples/ai-example/components/ui/badge.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
   "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
@@ -22,8 +22,8 @@ const badgeVariants = cva(
     defaultVariants: {
       variant: "default",
     },
-  }
-)
+  },
+);
 
 function Badge({
   className,
@@ -32,7 +32,7 @@ function Badge({
   ...props
 }: React.ComponentProps<"span"> &
   VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : "span"
+  const Comp = asChild ? Slot : "span";
 
   return (
     <Comp
@@ -40,7 +40,7 @@ function Badge({
       className={cn(badgeVariants({ variant }), className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Badge, badgeVariants }
+export { Badge, badgeVariants };

--- a/examples/ai-example/components/ui/button.tsx
+++ b/examples/ai-example/components/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -32,8 +32,8 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
-)
+  },
+);
 
 function Button({
   className,
@@ -43,9 +43,9 @@ function Button({
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot : "button"
+  const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
@@ -53,7 +53,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/examples/ai-example/components/ui/card.tsx
+++ b/examples/ai-example/components/ui/card.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -8,11 +8,11 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card"
       className={cn(
         "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -21,11 +21,11 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-header"
       className={cn(
         "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
@@ -35,7 +35,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("leading-none font-semibold", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
@@ -45,7 +45,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardAction({ className, ...props }: React.ComponentProps<"div">) {
@@ -54,11 +54,11 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-action"
       className={cn(
         "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
@@ -68,7 +68,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("px-6", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
@@ -78,7 +78,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -89,4 +89,4 @@ export {
   CardAction,
   CardDescription,
   CardContent,
-}
+};

--- a/examples/ai-example/components/ui/form.tsx
+++ b/examples/ai-example/components/ui/form.tsx
@@ -1,8 +1,8 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
-import { Slot } from "@radix-ui/react-slot"
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
 import {
   Controller,
   FormProvider,
@@ -11,23 +11,23 @@ import {
   type ControllerProps,
   type FieldPath,
   type FieldValues,
-} from "react-hook-form"
+} from "react-hook-form";
 
-import { cn } from "@/lib/utils"
-import { Label } from "@/components/ui/label"
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
 
-const Form = FormProvider
+const Form = FormProvider;
 
 type FormFieldContextValue<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 > = {
-  name: TName
-}
+  name: TName;
+};
 
 const FormFieldContext = React.createContext<FormFieldContextValue>(
-  {} as FormFieldContextValue
-)
+  {} as FormFieldContextValue,
+);
 
 const FormField = <
   TFieldValues extends FieldValues = FieldValues,
@@ -39,21 +39,21 @@ const FormField = <
     <FormFieldContext.Provider value={{ name: props.name }}>
       <Controller {...props} />
     </FormFieldContext.Provider>
-  )
-}
+  );
+};
 
 const useFormField = () => {
-  const fieldContext = React.useContext(FormFieldContext)
-  const itemContext = React.useContext(FormItemContext)
-  const { getFieldState } = useFormContext()
-  const formState = useFormState({ name: fieldContext.name })
-  const fieldState = getFieldState(fieldContext.name, formState)
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const { getFieldState } = useFormContext();
+  const formState = useFormState({ name: fieldContext.name });
+  const fieldState = getFieldState(fieldContext.name, formState);
 
   if (!fieldContext) {
-    throw new Error("useFormField should be used within <FormField>")
+    throw new Error("useFormField should be used within <FormField>");
   }
 
-  const { id } = itemContext
+  const { id } = itemContext;
 
   return {
     id,
@@ -62,19 +62,19 @@ const useFormField = () => {
     formDescriptionId: `${id}-form-item-description`,
     formMessageId: `${id}-form-item-message`,
     ...fieldState,
-  }
-}
+  };
+};
 
 type FormItemContextValue = {
-  id: string
-}
+  id: string;
+};
 
 const FormItemContext = React.createContext<FormItemContextValue>(
-  {} as FormItemContextValue
-)
+  {} as FormItemContextValue,
+);
 
 function FormItem({ className, ...props }: React.ComponentProps<"div">) {
-  const id = React.useId()
+  const id = React.useId();
 
   return (
     <FormItemContext.Provider value={{ id }}>
@@ -84,14 +84,14 @@ function FormItem({ className, ...props }: React.ComponentProps<"div">) {
         {...props}
       />
     </FormItemContext.Provider>
-  )
+  );
 }
 
 function FormLabel({
   className,
   ...props
 }: React.ComponentProps<typeof LabelPrimitive.Root>) {
-  const { error, formItemId } = useFormField()
+  const { error, formItemId } = useFormField();
 
   return (
     <Label
@@ -101,11 +101,12 @@ function FormLabel({
       htmlFor={formItemId}
       {...props}
     />
-  )
+  );
 }
 
 function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
-  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+  const { error, formItemId, formDescriptionId, formMessageId } =
+    useFormField();
 
   return (
     <Slot
@@ -119,11 +120,11 @@ function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
       aria-invalid={!!error}
       {...props}
     />
-  )
+  );
 }
 
 function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
-  const { formDescriptionId } = useFormField()
+  const { formDescriptionId } = useFormField();
 
   return (
     <p
@@ -132,15 +133,15 @@ function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
       className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
-  )
+  );
 }
 
 function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
-  const { error, formMessageId } = useFormField()
-  const body = error ? String(error?.message ?? "") : props.children
+  const { error, formMessageId } = useFormField();
+  const body = error ? String(error?.message ?? "") : props.children;
 
   if (!body) {
-    return null
+    return null;
   }
 
   return (
@@ -152,7 +153,7 @@ function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
     >
       {body}
     </p>
-  )
+  );
 }
 
 export {
@@ -164,4 +165,4 @@ export {
   FormDescription,
   FormMessage,
   FormField,
-}
+};

--- a/examples/ai-example/components/ui/input.tsx
+++ b/examples/ai-example/components/ui/input.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
@@ -11,11 +11,11 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
         "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Input }
+export { Input };

--- a/examples/ai-example/components/ui/label.tsx
+++ b/examples/ai-example/components/ui/label.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Label({
   className,
@@ -14,11 +14,11 @@ function Label({
       data-slot="label"
       className={cn(
         "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Label }
+export { Label };

--- a/examples/ai-example/components/ui/scroll-area.tsx
+++ b/examples/ai-example/components/ui/scroll-area.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+import * as React from "react";
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function ScrollArea({
   className,
@@ -25,7 +25,7 @@ function ScrollArea({
       <ScrollBar />
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
-  )
+  );
 }
 
 function ScrollBar({
@@ -43,7 +43,7 @@ function ScrollBar({
           "h-full w-2.5 border-l border-l-transparent",
         orientation === "horizontal" &&
           "h-2.5 flex-col border-t border-t-transparent",
-        className
+        className,
       )}
       {...props}
     >
@@ -52,7 +52,7 @@ function ScrollBar({
         className="bg-border relative flex-1 rounded-full"
       />
     </ScrollAreaPrimitive.ScrollAreaScrollbar>
-  )
+  );
 }
 
-export { ScrollArea, ScrollBar }
+export { ScrollArea, ScrollBar };

--- a/examples/ai-example/lib/utils.ts
+++ b/examples/ai-example/lib/utils.ts
@@ -1,6 +1,6 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }

--- a/examples/ai-example/next.config.ts
+++ b/examples/ai-example/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  /* config options here */
-};
+const nextConfig: NextConfig = {/* config options here */};
 
 export default nextConfig;

--- a/examples/charts-python/charts-python.ts
+++ b/examples/charts-python/charts-python.ts
@@ -1,7 +1,7 @@
-import { Sandbox } from '@vercel/sandbox';
-import { generateText } from 'ai';
-import { gateway } from '@ai-sdk/gateway';
-import * as fs from 'fs';
+import { Sandbox } from "@vercel/sandbox";
+import { generateText } from "ai";
+import { gateway } from "@ai-sdk/gateway";
+import * as fs from "fs";
 
 async function main() {
   const prompt = `Generate Python code to create a chart visualizing the average weather temperatures across the year in Berlin. 
@@ -15,59 +15,59 @@ Requirements:
 
 IMPORTANT: Return ONLY the raw Python code. Do NOT use markdown code blocks, backticks, or any formatting. Start directly with 'import' statements.`;
 
-  console.log('Generating chart code with AI Gateway...');
+  console.log("Generating chart code with AI Gateway...");
   const response = await generateText({
-    model: gateway('openai/gpt-5.6-sol'),
+    model: gateway("openai/gpt-5.6-sol"),
     prompt: prompt,
     temperature: 0.7,
   });
 
-  console.log('Creating sandbox...');
+  console.log("Creating sandbox...");
   const sandbox = await Sandbox.create({
     timeout: 300000,
-    image: "vercel/sandbox/python:3.14"
+    image: "vercel/sandbox/python:3.14",
   });
 
-  console.log('Installing Python packages with uv...');
+  console.log("Installing Python packages with uv...");
   await sandbox.runCommand({
-    cmd: 'uv',
-    args: ['pip', 'install', '--system', 'matplotlib', 'pandas', 'numpy'],
+    cmd: "uv",
+    args: ["pip", "install", "--system", "matplotlib", "pandas", "numpy"],
     sudo: true,
   });
 
   // Write the Python code to the sandbox
-  console.log('Writing and executing Python code...');
+  console.log("Writing and executing Python code...");
   await sandbox.writeFiles([
     {
-      path: 'generate_chart.py',
+      path: "generate_chart.py",
       content: Buffer.from(response.text),
     },
   ]);
 
   // Run the Python code
-  const result = await sandbox.runCommand('python', ['generate_chart.py']);
+  const result = await sandbox.runCommand("python", ["generate_chart.py"]);
 
   if (result.exitCode === 0) {
-    console.log('Chart generated successfully!');
+    console.log("Chart generated successfully!");
 
     // Read the generated image from the sandbox
-    const imageStream = await sandbox.readFile({ path: 'berlin_weather.png' });
+    const imageStream = await sandbox.readFile({ path: "berlin_weather.png" });
 
     if (imageStream) {
-      const writeStream = fs.createWriteStream('berlin_weather.png');
+      const writeStream = fs.createWriteStream("berlin_weather.png");
       imageStream.pipe(writeStream);
 
       await new Promise((resolve, reject) => {
-        writeStream.on('finish', () => {
-          console.log('Image saved as berlin_weather.png');
+        writeStream.on("finish", () => {
+          console.log("Image saved as berlin_weather.png");
           resolve(undefined);
         });
-        writeStream.on('error', reject);
+        writeStream.on("error", reject);
       });
     }
   } else {
-    console.log('Failed to generate chart');
-    console.log('Error:', await result.stderr());
+    console.log("Failed to generate chart");
+    console.log("Error:", await result.stderr());
   }
 
   await sandbox.stop();

--- a/examples/dev-server/dev-server.ts
+++ b/examples/dev-server/dev-server.ts
@@ -1,50 +1,50 @@
-import { Sandbox } from '@vercel/sandbox';
-import { setTimeout } from 'timers/promises';
-import { spawn } from 'child_process';
+import { Sandbox } from "@vercel/sandbox";
+import { setTimeout } from "timers/promises";
+import { spawn } from "child_process";
 
 async function main() {
-  console.log('Creating sandbox from Git repository...');
+  console.log("Creating sandbox from Git repository...");
   const sandbox = await Sandbox.create({
     source: {
-      url: 'https://github.com/vercel/sandbox-example-next.git',
-      type: 'git',
+      url: "https://github.com/vercel/sandbox-example-next.git",
+      type: "git",
     },
     timeout: 300000,
     ports: [3000],
   });
 
-  console.log('Installing dependencies...');
+  console.log("Installing dependencies...");
   const install = await sandbox.runCommand({
-    cmd: 'npm',
-    args: ['install', '--loglevel', 'info'],
-    cwd: 'sandbox-example-next',
+    cmd: "npm",
+    args: ["install", "--loglevel", "info"],
+    cwd: "sandbox-example-next",
     stderr: process.stderr,
     stdout: process.stdout,
   });
 
-  console.log('Dependencies installed successfully!\n');
+  console.log("Dependencies installed successfully!\n");
 
-  console.log('Starting the development server...');
+  console.log("Starting the development server...");
   const devServer = await sandbox.runCommand({
-    cmd: 'npm',
-    args: ['run', 'dev'],
-    cwd: 'sandbox-example-next',
+    cmd: "npm",
+    args: ["run", "dev"],
+    cwd: "sandbox-example-next",
     stderr: process.stderr,
     stdout: process.stdout,
     detached: true,
   });
 
   // Set up graceful shutdown
-  process.on('SIGINT', async () => {
-    console.log('Shutting down...');
+  process.on("SIGINT", async () => {
+    console.log("Shutting down...");
     await sandbox.stop();
     process.exit(0);
   });
 
   console.log(`   URL: ${sandbox.domain(3000)}`);
-  console.log('Waiting for server to start...');
+  console.log("Waiting for server to start...");
   await setTimeout(1000);
-  spawn('open', [sandbox.domain(3000)]);
+  spawn("open", [sandbox.domain(3000)]);
 }
 
 main().catch(console.error);

--- a/examples/filesystem-snapshots/filesystem-snapshots.ts
+++ b/examples/filesystem-snapshots/filesystem-snapshots.ts
@@ -1,25 +1,27 @@
-import { Sandbox,Snapshot } from '@vercel/sandbox';
+import { Sandbox, Snapshot } from "@vercel/sandbox";
 
 async function main() {
   // Create a new sandbox
-  console.log('Creating sandbox...');
+  console.log("Creating sandbox...");
   const sandbox = await Sandbox.create();
 
-  console.log('Sandbox created successfully!\n');
+  console.log("Sandbox created successfully!\n");
 
   // 1. Write a file to the sandbox filesystem
-  await sandbox.writeFiles([{
-    path: '/vercel/sandbox/hello-world',
-    content: Buffer.from('Hello World from Vercel Sandbox snapshots!'),
-  }]);
-  console.log('Wrote hello-world file to /vercel/sandbox/');
+  await sandbox.writeFiles([
+    {
+      path: "/vercel/sandbox/hello-world",
+      content: Buffer.from("Hello World from Vercel Sandbox snapshots!"),
+    },
+  ]);
+  console.log("Wrote hello-world file to /vercel/sandbox/");
 
   // 2. Take a filesystem snapshot
-  console.log('Taking filesystem snapshot...');
+  console.log("Taking filesystem snapshot...");
   const snapshot = await sandbox.snapshot();
-  console.log('Created snapshot successfully!\n');
+  console.log("Created snapshot successfully!\n");
 
-  console.log('Listing all snapshots:');
+  console.log("Listing all snapshots:");
   const { snapshots } = await Snapshot.list();
   for (const snapshot of snapshots) {
     console.log(`- ${snapshot.id}`);
@@ -28,15 +30,17 @@ async function main() {
   }
 
   // 3. Create a new sandbox from that snapshot
-  console.log('Creating new sandbox from snapshot...');
+  console.log("Creating new sandbox from snapshot...");
   const newSandbox = await Sandbox.create({
-    source: { type: 'snapshot', snapshotId: snapshot.snapshotId },
+    source: { type: "snapshot", snapshotId: snapshot.snapshotId },
   });
-  console.log('New sandbox created from snapshot successfully!\n');
+  console.log("New sandbox created from snapshot successfully!\n");
 
   // 4. Read the file from the new sandbox to verify its content
-  console.log('Reading hello-world file from new sandbox:');
-  const buffer = await newSandbox.readFile({ path: '/vercel/sandbox/hello-world' })
+  console.log("Reading hello-world file from new sandbox:");
+  const buffer = await newSandbox.readFile({
+    path: "/vercel/sandbox/hello-world",
+  });
   if (buffer) {
     for await (const chunk of buffer) {
       process.stdout.write(chunk);

--- a/examples/install-packages/install-packages.ts
+++ b/examples/install-packages/install-packages.ts
@@ -1,23 +1,23 @@
-import { Sandbox } from '@vercel/sandbox';
+import { Sandbox } from "@vercel/sandbox";
 
 async function main() {
   const sandbox = await Sandbox.create({
-    image: 'vercel/sandbox/arch',
+    image: "vercel/sandbox/arch",
   });
 
   // Install Go
-  console.log('Installing Go...');
+  console.log("Installing Go...");
   await sandbox.runCommand({
-    cmd: 'pacman',
-    args: ['-Sy', '--noconfirm', '--needed', 'go'],
+    cmd: "pacman",
+    args: ["-Sy", "--noconfirm", "--needed", "go"],
     sudo: true,
   });
 
   // Create a simple Hello World Go program
-  console.log('Creating Hello World Go program...');
+  console.log("Creating Hello World Go program...");
   await sandbox.writeFiles([
     {
-      path: 'hello.go',
+      path: "hello.go",
       content: Buffer.from(`package main
 
 import "fmt"
@@ -30,11 +30,11 @@ func main() {
   ]);
 
   // Run the Go program
-  console.log('Running Go program...');
-  const runResult = await sandbox.runCommand('go', ['run', 'hello.go']);
+  console.log("Running Go program...");
+  const runResult = await sandbox.runCommand("go", ["run", "hello.go"]);
   const programOutput = await runResult.stdout();
 
-  console.log('Output:', programOutput);
+  console.log("Output:", programOutput);
 
   await sandbox.stop();
 }

--- a/examples/private-repo/private-repo.ts
+++ b/examples/private-repo/private-repo.ts
@@ -1,26 +1,26 @@
-import { Sandbox } from '@vercel/sandbox';
-import ms from 'ms';
+import { Sandbox } from "@vercel/sandbox";
+import ms from "ms";
 
 async function main() {
   const sandbox = await Sandbox.create({
-    image: 'vercel/sandbox/arch',
+    image: "vercel/sandbox/arch",
     source: {
-      url: 'https://github.com/vercel/some-private-repo.git',
-      type: 'git',
+      url: "https://github.com/vercel/some-private-repo.git",
+      type: "git",
       // For GitHub, you can use a fine grained, classic personal access token or GitHub App installation access token
-      username: 'x-access-token',
+      username: "x-access-token",
       password: process.env.GIT_ACCESS_TOKEN!,
     },
-    timeout: ms('5m'),
+    timeout: ms("5m"),
     ports: [3000],
   });
 
   const ls = await sandbox.runCommand({
-    cmd: 'ls',
-    args: ['-la'],
-    cwd: 'some-private-repo',
+    cmd: "ls",
+    args: ["-la"],
+    cwd: "some-private-repo",
   });
-  console.log('Repository contents:');
+  console.log("Repository contents:");
   console.log(await ls.stdout());
 
   await sandbox.stop();

--- a/examples/sandbox-basics/sandbox-basics.ts
+++ b/examples/sandbox-basics/sandbox-basics.ts
@@ -1,9 +1,8 @@
-import { Sandbox } from '@vercel/sandbox';
+import { Sandbox } from "@vercel/sandbox";
 
 async function main() {
-
   // Create a new sandbox
-  console.log('Creating sandbox...');
+  console.log("Creating sandbox...");
   const sandbox = await Sandbox.create({
     timeout: 300000, // 5 minutes
   });
@@ -11,33 +10,33 @@ async function main() {
   console.log(`Sandbox ${sandbox.name} created successfully!\n`);
 
   // 1. Check current working directory
-  const pwdResult = await sandbox.runCommand('pwd');
+  const pwdResult = await sandbox.runCommand("pwd");
   console.log(`Current working directory: ${await pwdResult.stdout()}`);
 
   // 2. List contents of current directory
-  console.log('Directory Contents:');
-  const lsResult = await sandbox.runCommand('ls', ['-la']);
+  console.log("Directory Contents:");
+  const lsResult = await sandbox.runCommand("ls", ["-la"]);
   console.log(await lsResult.stdout());
 
   // 3. Check what's on PATH
-  console.log('PATH Environment Variable:');
-  const pathResult = await sandbox.runCommand('bash', ['-c', 'echo $PATH']);
+  console.log("PATH Environment Variable:");
+  const pathResult = await sandbox.runCommand("bash", ["-c", "echo $PATH"]);
   const pathValue = await pathResult.stdout();
   console.log(`PATH: ${pathValue}`);
-  
+
   // Display PATH in a more readable format
-  console.log('PATH directories:');
-  const pathDirs = pathValue.trim().split(':');
+  console.log("PATH directories:");
+  const pathDirs = pathValue.trim().split(":");
   pathDirs.forEach((dir, index) => {
     console.log(`  ${index + 1}. ${dir}`);
   });
 
   // 4. Check available commands/tools
-  console.log('Available Tools:');
-  const tools = ['node', 'npm', 'python3', 'git', 'curl', 'wget', 'bash', 'sh'];
-  
+  console.log("Available Tools:");
+  const tools = ["node", "npm", "python3", "git", "curl", "wget", "bash", "sh"];
+
   for (const tool of tools) {
-    const whichResult = await sandbox.runCommand('which', [tool]);
+    const whichResult = await sandbox.runCommand("which", [tool]);
     if (whichResult.exitCode === 0) {
       const toolPath = await whichResult.stdout();
       console.log(`  ✅ ${tool}: ${toolPath.trim()}`);
@@ -47,28 +46,31 @@ async function main() {
   }
 
   // 5. Check system information
-  console.log('System Information:');
-  const unameResult = await sandbox.runCommand('uname', ['-a']);
+  console.log("System Information:");
+  const unameResult = await sandbox.runCommand("uname", ["-a"]);
   console.log(`System: ${await unameResult.stdout()}`);
 
-  const whoamiResult = await sandbox.runCommand('whoami');
+  const whoamiResult = await sandbox.runCommand("whoami");
   console.log(`User: ${await whoamiResult.stdout()}`);
 
   // 6. Set and use environment variables
-  console.log('Environment Variables:');
-  
+  console.log("Environment Variables:");
+
   // Demonstrate environment variables using bash -c
   // Note: Environment variables don't persist between separate commands
-  const envTestResult = await sandbox.runCommand('bash', ['-c', 'export MY_GREETINGS="Hello from sandbox!" && export EXAMPLE_NUMBER=42 && echo "Greetings string: $MY_GREETINGS" && echo "Number variable: $EXAMPLE_NUMBER"']);
+  const envTestResult = await sandbox.runCommand("bash", [
+    "-c",
+    'export MY_GREETINGS="Hello from sandbox!" && export EXAMPLE_NUMBER=42 && echo "Greetings string: $MY_GREETINGS" && echo "Number variable: $EXAMPLE_NUMBER"',
+  ]);
   console.log(await envTestResult.stdout());
 
   // 7. Create a simple script and run it
-  console.log('Creating and Running a Script:');
-  
+  console.log("Creating and Running a Script:");
+
   // Write a simple bash script that sets and uses environment variables
   await sandbox.writeFiles([
     {
-      path: 'hello.sh',
+      path: "hello.sh",
       content: Buffer.from(`#!/bin/bash
 # Set environment variables within the script
 export MY_GREETINGS="Hello from a script in sandbox!"
@@ -84,19 +86,19 @@ echo "Number variable: $EXAMPLE_NUMBER"
   ]);
 
   // Make script executable
-  await sandbox.runCommand('chmod', ['+x', 'hello.sh']);
-  
+  await sandbox.runCommand("chmod", ["+x", "hello.sh"]);
+
   // Run the script
-  const scriptResult = await sandbox.runCommand('./hello.sh', ['arg1', 'arg2']);
+  const scriptResult = await sandbox.runCommand("./hello.sh", ["arg1", "arg2"]);
   console.log(await scriptResult.stdout());
 
   // 8. Demonstrate process management and signals
-  console.log('Process Management and Signals:');
-  
+  console.log("Process Management and Signals:");
+
   // Create a long-running process script
   await sandbox.writeFiles([
     {
-      path: 'long_process.sh',
+      path: "long_process.sh",
       content: Buffer.from(`#!/bin/bash
 echo "Starting long process (PID: $$)..."
 trap 'echo "Received SIGTERM, cleaning up..."; exit 0' TERM
@@ -111,82 +113,86 @@ echo "Process completed normally"
     },
   ]);
 
-  await sandbox.runCommand('chmod', ['+x', 'long_process.sh']);
-  
+  await sandbox.runCommand("chmod", ["+x", "long_process.sh"]);
+
   // Start the long process in detached mode
-  console.log('Starting long-running process in background...');
+  console.log("Starting long-running process in background...");
   const longProcess = await sandbox.runCommand({
-    cmd: './long_process.sh',
+    cmd: "./long_process.sh",
     detached: true,
   });
-  
+
   // Wait a bit to let it start
-  await new Promise(resolve => setTimeout(resolve, 3000));
-  
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+
   // Send a signal to terminate the process
-  console.log('Sending SIGTERM signal to process in background...');
-  await longProcess.kill('SIGTERM');
-  
+  console.log("Sending SIGTERM signal to process in background...");
+  await longProcess.kill("SIGTERM");
+
   // Wait for the process to complete
   const processResult = await longProcess.wait();
-  console.log('Process running in background output:');
+  console.log("Process running in background output:");
   console.log(await processResult.stdout());
 
   // 9. Working with files and directories
-  console.log('File and Directory Operations:');
-  
+  console.log("File and Directory Operations:");
+
   // Create a directory structure
-  await sandbox.runCommand('mkdir', ['-p', 'test/nested/deep']);
-  
+  await sandbox.runCommand("mkdir", ["-p", "test/nested/deep"]);
+
   // Create some files
   await sandbox.writeFiles([
     {
-      path: 'test/file1.txt',
-      content: Buffer.from('This is file 1'),
+      path: "test/file1.txt",
+      content: Buffer.from("This is file 1"),
     },
     {
-      path: 'test/nested/file2.txt',
-      content: Buffer.from('This is file 2 in nested directory'),
+      path: "test/nested/file2.txt",
+      content: Buffer.from("This is file 2 in nested directory"),
     },
   ]);
 
   // List the directory tree
-  const treeResult = await sandbox.runCommand('find', ['test', '-type', 'f']);
-  console.log('Created files:');
+  const treeResult = await sandbox.runCommand("find", ["test", "-type", "f"]);
+  console.log("Created files:");
   console.log(await treeResult.stdout());
 
   // 10. Stop the sandbox
-  console.log('Stopping the sandbox ...');
+  console.log("Stopping the sandbox ...");
   await sandbox.stop();
 
   // 11. Modify the sandbox configuration
-  await sandbox.update({ resources: { vcpus: 2 }});
+  await sandbox.update({ resources: { vcpus: 2 } });
 
   // 12. Resume the sandbox from where you left off
-  console.log('Resuming the sandbox with 2 vCPU');
+  console.log("Resuming the sandbox with 2 vCPU");
   const resumedSandbox = await Sandbox.get({ name: sandbox.name });
-  const treeResultAfterResume = await resumedSandbox.runCommand('find', ['test', '-type', 'f']);
-  console.log('Created files (after resuming the sandbox):');
+  const treeResultAfterResume = await resumedSandbox.runCommand("find", [
+    "test",
+    "-type",
+    "f",
+  ]);
+  console.log("Created files (after resuming the sandbox):");
   console.log(await treeResultAfterResume.stdout());
 
   // 13. Check resource usage
-  console.log('Resource Usage:');
-  
+  console.log("Resource Usage:");
+
   // Check disk usage
-  const dfResult = await resumedSandbox.runCommand('df', ['-h']);
-  console.log('Disk usage:');
+  const dfResult = await resumedSandbox.runCommand("df", ["-h"]);
+  console.log("Disk usage:");
   console.log(await dfResult.stdout());
-  
+
   // Check memory usage
-  const freeResult = await resumedSandbox.runCommand('free', ['-h']);
-  console.log('Memory usage:');
+  const freeResult = await resumedSandbox.runCommand("free", ["-h"]);
+  console.log("Memory usage:");
   console.log(await freeResult.stdout());
 
   // 14. Delete the sandbox
-  console.log('Deleting the sandbox ...');
+  console.log("Deleting the sandbox ...");
   await resumedSandbox.delete();
 
-  console.log('Sandbox basics completed!');
+  console.log("Sandbox basics completed!");
 }
 
-main().catch(console.error); 
+main().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@svitejs/changesets-changelog-github-compact": "0.1.1",
     "husky": "3.0.4",
     "lint-staged": "9.2.5",
+    "oxfmt": "0.62.0",
     "prettier": "3.5.3",
     "ts-node": "^10.9.2",
     "turbo": "2.8.10",
@@ -17,12 +18,14 @@
     "clean": "turbo clean && rm -rf ./node_modules",
     "build": "turbo run typecheck build",
     "test": "turbo run test",
+    "format": "oxfmt .",
+    "format:check": "oxfmt --check .",
     "version:prepare": "changeset version && turbo run version:bump && pnpm install --no-frozen-lockfile",
     "release": "changeset publish"
   },
   "lint-staged": {
-    "./{*,{packages,.github}/**/*}.{js,ts}": [
-      "prettier --write",
+    "*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}": [
+      "oxfmt",
       "git add"
     ],
     "*.{json,md}": [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "husky": "3.0.4",
     "lint-staged": "9.2.5",
     "oxfmt": "0.62.0",
-    "prettier": "3.5.3",
     "ts-node": "^10.9.2",
     "turbo": "2.8.10",
     "typedoc": "0.28.4",
@@ -24,12 +23,8 @@
     "release": "changeset publish"
   },
   "lint-staged": {
-    "*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}": [
+    "*": [
       "oxfmt",
-      "git add"
-    ],
-    "*.{json,md}": [
-      "prettier --write",
       "git add"
     ]
   },

--- a/packages/sandbox/example/page.tsx
+++ b/packages/sandbox/example/page.tsx
@@ -1,20 +1,23 @@
 export default function Home() {
   return (
     <div>
-    <div className="flex min-h-screen flex-col">
-      {/* Hero Section */}
-      <section className="space-y-6 pb-8 pt-10 md:pb-12 md:pt-20 lg:py-32">
-        <div className="flex max-w-[64rem] flex-col items-center gap-4 text-center">
-          <div className="rounded-full bg-muted px-4 py-1.5 text-sm font-medium">Introducing Vercel Sandbox</div>
-          <h1 className="text-4xl font-bold tracking-tighter sm:text-5xl md:text-6xl lg:text-7xl">
-            Run arbitrary code anywhere
-          </h1>
-          <p className="max-w-[42rem] leading-normal text-muted-foreground sm:text-xl sm:leading-8">
-            Vercel Sandbox is a serverless compute platform that lets you run arbitrary code globally.
-          </p>
-        </div>
-      </section>
+      <div className="flex min-h-screen flex-col">
+        {/* Hero Section */}
+        <section className="space-y-6 pb-8 pt-10 md:pb-12 md:pt-20 lg:py-32">
+          <div className="flex max-w-[64rem] flex-col items-center gap-4 text-center">
+            <div className="rounded-full bg-muted px-4 py-1.5 text-sm font-medium">
+              Introducing Vercel Sandbox
+            </div>
+            <h1 className="text-4xl font-bold tracking-tighter sm:text-5xl md:text-6xl lg:text-7xl">
+              Run arbitrary code anywhere
+            </h1>
+            <p className="max-w-[42rem] leading-normal text-muted-foreground sm:text-xl sm:leading-8">
+              Vercel Sandbox is a serverless compute platform that lets you run
+              arbitrary code globally.
+            </p>
+          </div>
+        </section>
+      </div>
     </div>
-    </div>
-  )
+  );
 }

--- a/packages/sandbox/src/args/network-policy.ts
+++ b/packages/sandbox/src/args/network-policy.ts
@@ -19,8 +19,7 @@ const networkPolicyMode = cmd.extendType(cmd.string, {
 
 export const networkPolicy = cmd.option({
   long: "network-policy",
-  description:
-    `Network policy mode: "allow-all" or "deny-all"
+  description: `Network policy mode: "allow-all" or "deny-all"
       - allow-all: sandbox can access any website/domain
       - deny-all: sandbox has no network access
     Omit this option and use --allowed-domain / --allowed-cidr / --denied-cidr for custom policies.`,
@@ -29,22 +28,19 @@ export const networkPolicy = cmd.option({
 
 export const allowedDomains = cmd.multioption({
   long: "allowed-domain",
-  description:
-    `Domain to allow traffic to (creates a custom network policy). Supports "*" for wildcards for a segment (e.g. '*.vercel.com', 'www.*.com'). If used as the first segment, will match any subdomain.`,
+  description: `Domain to allow traffic to (creates a custom network policy). Supports "*" for wildcards for a segment (e.g. '*.vercel.com', 'www.*.com'). If used as the first segment, will match any subdomain.`,
   type: cmd.array(cmd.string),
 });
 
 export const allowedCIDRs = cmd.multioption({
   long: "allowed-cidr",
-  description:
-    `CIDR to allow traffic to (creates a custom network policy). Takes precedence over 'allowed-domain'.`,
+  description: `CIDR to allow traffic to (creates a custom network policy). Takes precedence over 'allowed-domain'.`,
   type: cmd.array(cmd.string),
 });
 
 export const deniedCIDRs = cmd.multioption({
   long: "denied-cidr",
-  description:
-    `CIDR to deny traffic to (creates a custom network policy). Takes precedence over allowed domains/CIDRs.`,
+  description: `CIDR to deny traffic to (creates a custom network policy). Takes precedence over allowed domains/CIDRs.`,
   type: cmd.array(cmd.string),
 });
 

--- a/packages/sandbox/src/args/vcpus.ts
+++ b/packages/sandbox/src/args/vcpus.ts
@@ -4,9 +4,7 @@ export const vcpusType = cmd.extendType(cmd.number, {
   displayName: "COUNT",
   async from(n) {
     if (!Number.isInteger(n) || n < 1) {
-      throw new Error(
-        `Invalid vCPU count: ${n}. Must be a positive integer.`,
-      );
+      throw new Error(`Invalid vCPU count: ${n}. Must be a positive integer.`);
     }
     return n;
   },

--- a/packages/sandbox/src/client.ts
+++ b/packages/sandbox/src/client.ts
@@ -28,17 +28,16 @@ export const sandboxClient: Pick<
     ),
 };
 
-export const snapshotClient: Pick<
-  typeof Snapshot,
-  "get" | "list" | "tree"
-> = {
+export const snapshotClient: Pick<typeof Snapshot, "get" | "list" | "tree"> = {
   list: (params) =>
     withErrorHandling(() =>
       Snapshot.list({ fetch: fetchWithUserAgent, ...params }),
     ),
   get: (params) => withErrorHandling(() => Snapshot.get({ ...params })),
   tree: (params) =>
-    withErrorHandling(() => Snapshot.tree({ fetch: fetchWithUserAgent, ...params })),
+    withErrorHandling(() =>
+      Snapshot.tree({ fetch: fetchWithUserAgent, ...params }),
+    ),
 };
 
 const fetchWithUserAgent: typeof globalThis.fetch = (input, init) => {

--- a/packages/sandbox/src/commands/config.ts
+++ b/packages/sandbox/src/commands/config.ts
@@ -50,9 +50,7 @@ const vcpusCommand = cmd.command({
       spinner.stop();
 
       process.stderr.write(
-        "✅ Configuration updated for sandbox " +
-          chalk.cyan(name) +
-          "\n",
+        "✅ Configuration updated for sandbox " + chalk.cyan(name) + "\n",
       );
       process.stderr.write(
         chalk.dim("   ╰ ") + "vcpus: " + chalk.cyan(count) + "\n",
@@ -66,7 +64,8 @@ const vcpusCommand = cmd.command({
 
 const timeoutCommand = cmd.command({
   name: "timeout",
-  description: "Update the timeout of a sandbox (will be applied to all new sessions)",
+  description:
+    "Update the timeout of a sandbox (will be applied to all new sessions)",
   args: {
     sandbox: cmd.positional({
       type: sandboxName,
@@ -74,15 +73,12 @@ const timeoutCommand = cmd.command({
     }),
     duration: cmd.positional({
       type: Duration,
-      description: "The maximum duration a sandbox can run for. Example: 5m, 1h",
+      description:
+        "The maximum duration a sandbox can run for. Example: 5m, 1h",
     }),
     scope,
   },
-  async handler({
-    scope: { token, team, project },
-    sandbox: name,
-    duration,
-  }) {
+  async handler({ scope: { token, team, project }, sandbox: name, duration }) {
     const sandbox = await sandboxClient.get({
       name,
       projectId: project,
@@ -96,9 +92,7 @@ const timeoutCommand = cmd.command({
       spinner.stop();
 
       process.stderr.write(
-        "✅ Configuration updated for sandbox " +
-          chalk.cyan(name) +
-          "\n",
+        "✅ Configuration updated for sandbox " + chalk.cyan(name) + "\n",
       );
       process.stderr.write(
         chalk.dim("   ╰ ") + "timeout: " + chalk.cyan(duration) + "\n",
@@ -112,7 +106,8 @@ const timeoutCommand = cmd.command({
 
 const persistentCommand = cmd.command({
   name: "persistent",
-  description: "Enable or disable automatic restore of the filesystem between sessions",
+  description:
+    "Enable or disable automatic restore of the filesystem between sessions",
   args: {
     sandbox: cmd.positional({
       type: sandboxName,
@@ -120,15 +115,12 @@ const persistentCommand = cmd.command({
     }),
     value: cmd.positional({
       type: { ...cmd.oneOf(["true", "false"]), displayName: "true|false" },
-      description: "Enable or disable automatic restore of the filesystem between sessions",
+      description:
+        "Enable or disable automatic restore of the filesystem between sessions",
     }),
     scope,
   },
-  async handler({
-    scope: { token, team, project },
-    sandbox: name,
-    value,
-  }) {
+  async handler({ scope: { token, team, project }, sandbox: name, value }) {
     const sandbox = await sandboxClient.get({
       name,
       projectId: project,
@@ -142,9 +134,7 @@ const persistentCommand = cmd.command({
       spinner.stop();
 
       process.stderr.write(
-        "✅ Configuration updated for sandbox " +
-          chalk.cyan(name) +
-          "\n",
+        "✅ Configuration updated for sandbox " + chalk.cyan(name) + "\n",
       );
       process.stderr.write(
         chalk.dim("   ╰ ") + "persistent: " + chalk.cyan(value) + "\n",
@@ -166,15 +156,12 @@ const snapshotExpirationCommand = cmd.command({
     }),
     duration: cmd.positional({
       type: SnapshotExpiration,
-      description: 'Snapshot expiration duration (e.g. 7d, 30d) or "none" for no expiration',
+      description:
+        'Snapshot expiration duration (e.g. 7d, 30d) or "none" for no expiration',
     }),
     scope,
   },
-  async handler({
-    scope: { token, team, project },
-    sandbox: name,
-    duration,
-  }) {
+  async handler({ scope: { token, team, project }, sandbox: name, duration }) {
     const sandbox = await sandboxClient.get({
       name,
       projectId: project,
@@ -189,12 +176,13 @@ const snapshotExpirationCommand = cmd.command({
 
       const display = ms(duration) === 0 ? "none" : duration;
       process.stderr.write(
-        "✅ Configuration updated for sandbox " +
-          chalk.cyan(name) +
-          "\n",
+        "✅ Configuration updated for sandbox " + chalk.cyan(name) + "\n",
       );
       process.stderr.write(
-        chalk.dim("   ╰ ") + "snapshot-expiration: " + chalk.cyan(display) + "\n",
+        chalk.dim("   ╰ ") +
+          "snapshot-expiration: " +
+          chalk.cyan(display) +
+          "\n",
       );
     } catch (error) {
       spinner.stop();
@@ -231,11 +219,7 @@ const keepLastSnapshotsCommand = cmd.command({
     }),
     scope,
   },
-  async handler({
-    scope: { token, team, project },
-    sandbox: name,
-    count,
-  }) {
+  async handler({ scope: { token, team, project }, sandbox: name, count }) {
     const sandbox = await sandboxClient.get({
       name,
       projectId: project,
@@ -291,11 +275,7 @@ const keepLastSnapshotsForCommand = cmd.command({
     }),
     scope,
   },
-  async handler({
-    scope: { token, team, project },
-    sandbox: name,
-    duration,
-  }) {
+  async handler({ scope: { token, team, project }, sandbox: name, duration }) {
     const sandbox = await sandboxClient.get({
       name,
       projectId: project,
@@ -357,11 +337,7 @@ const deleteEvictedSnapshotsCommand = cmd.command({
     }),
     scope,
   },
-  async handler({
-    scope: { token, team, project },
-    sandbox: name,
-    value,
-  }) {
+  async handler({ scope: { token, team, project }, sandbox: name, value }) {
     const sandbox = await sandboxClient.get({
       name,
       projectId: project,
@@ -438,19 +414,17 @@ const currentSnapshotCommand = cmd.command({
       spinner.stop();
 
       process.stderr.write(
-        "✅ Configuration updated for sandbox " +
-          chalk.cyan(name) +
-          "\n",
+        "✅ Configuration updated for sandbox " + chalk.cyan(name) + "\n",
       );
       process.stderr.write(
-        chalk.dim("   ╰ ") + "current-snapshot: " + chalk.cyan(snapshotId) + "\n",
+        chalk.dim("   ╰ ") +
+          "current-snapshot: " +
+          chalk.cyan(snapshotId) +
+          "\n",
       );
     } catch (error) {
       spinner.stop();
-      if (
-        error instanceof APIError &&
-        error.response.status === 404
-      ) {
+      if (error instanceof APIError && error.response.status === 404) {
         throw new StyledError(
           `Snapshot '${snapshotId}' was not found or does not belong to this project.`,
           error,
@@ -534,18 +508,39 @@ const listCommand = cmd.command({
       });
     })();
 
-    const networkPolicy = typeof sandbox.networkPolicy === "string" ? sandbox.networkPolicy : "restricted";
-    const tagsDisplay = sandbox.tags && Object.keys(sandbox.tags).length > 0
-      ? Object.entries(sandbox.tags).map(([k, v]) => `${k}=${v}`).join(", ")
-      : "-";
+    const networkPolicy =
+      typeof sandbox.networkPolicy === "string"
+        ? sandbox.networkPolicy
+        : "restricted";
+    const tagsDisplay =
+      sandbox.tags && Object.keys(sandbox.tags).length > 0
+        ? Object.entries(sandbox.tags)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(", ")
+        : "-";
     const rows = [
       { field: "vCPUs", value: String(sandbox.vcpus ?? "-") },
-      { field: "Timeout", value: sandbox.timeout != null ? ms(sandbox.timeout, { long: true }) : "-" },
+      {
+        field: "Timeout",
+        value:
+          sandbox.timeout != null ? ms(sandbox.timeout, { long: true }) : "-",
+      },
       { field: "Persistent", value: String(sandbox.persistent) },
       { field: "Network policy", value: String(networkPolicy) },
       { field: "Ports", value: formatPorts(sandbox) },
-      { field: "Snapshot expiration", value: sandbox.snapshotExpiration != null && sandbox.snapshotExpiration > 0 ? ms(sandbox.snapshotExpiration, { long: true }) : sandbox.snapshotExpiration === 0 ? "none" : "-" },
-      { field: "Keep last snapshots", value: formatKeepLastSnapshots(sandbox.keepLastSnapshots) },
+      {
+        field: "Snapshot expiration",
+        value:
+          sandbox.snapshotExpiration != null && sandbox.snapshotExpiration > 0
+            ? ms(sandbox.snapshotExpiration, { long: true })
+            : sandbox.snapshotExpiration === 0
+              ? "none"
+              : "-",
+      },
+      {
+        field: "Keep last snapshots",
+        value: formatKeepLastSnapshots(sandbox.keepLastSnapshots),
+      },
       { field: "Current snapshot", value: sandbox.currentSnapshotId ?? "-" },
       { field: "Tags", value: tagsDisplay },
     ];
@@ -624,7 +619,8 @@ const networkPolicyCommand = cmd.command({
           chalk.cyan(sandbox.name) +
           "\n",
       );
-      const mode = typeof networkPolicy === "string" ? networkPolicy : "restricted";
+      const mode =
+        typeof networkPolicy === "string" ? networkPolicy : "restricted";
       process.stderr.write(
         chalk.dim("   ╰ ") + "mode: " + chalk.cyan(mode) + "\n",
       );
@@ -637,7 +633,8 @@ const networkPolicyCommand = cmd.command({
 
 const tagsCommand = cmd.command({
   name: "tags",
-  description: "Update the tags of a sandbox. Replaces all existing tags with the provided tags.",
+  description:
+    "Update the tags of a sandbox. Replaces all existing tags with the provided tags.",
   args: {
     sandbox: cmd.positional({
       type: sandboxName,
@@ -647,7 +644,8 @@ const tagsCommand = cmd.command({
       long: "tag",
       short: "t",
       type: ObjectFromKeyValue,
-      description: "Key-value tags to set (e.g. --tag env=staging). Omit to clear all tags.",
+      description:
+        "Key-value tags to set (e.g. --tag env=staging). Omit to clear all tags.",
     }),
     scope,
   },
@@ -677,7 +675,9 @@ const tagsCommand = cmd.command({
           const [k, v] = entries[i];
           const isLast = i === entries.length - 1;
           const prefix = isLast ? chalk.dim("   ╰ ") : chalk.dim("   │ ");
-          process.stderr.write(prefix + chalk.cyan(k) + "=" + chalk.cyan(v) + "\n");
+          process.stderr.write(
+            prefix + chalk.cyan(k) + "=" + chalk.cyan(v) + "\n",
+          );
         }
       }
     } catch (error) {

--- a/packages/sandbox/src/commands/cp.ts
+++ b/packages/sandbox/src/commands/cp.ts
@@ -23,7 +23,11 @@ export const parseLocalOrRemotePath = async (input: string) => {
         ].join("\n"),
       );
     }
-    return { type: "remote", sandboxName: await sandboxName.from(id), path } as const;
+    return {
+      type: "remote",
+      sandboxName: await sandboxName.from(id),
+      path,
+    } as const;
   }
 
   return { type: "local", path: input } as const;
@@ -51,7 +55,9 @@ export const cp = cmd.command({
     scope,
   },
   async handler({ scope, source, dest }) {
-    const spinner = ora({ text: `Reading source file (${source.path})...` }).start();
+    const spinner = ora({
+      text: `Reading source file (${source.path})...`,
+    }).start();
     let sourceFile: Buffer<ArrayBufferLike> | null = null;
 
     if (source.type === "local") {
@@ -60,7 +66,7 @@ export const cp = cmd.command({
           return null;
         }
         throw err;
-      })
+      });
     } else {
       const sandbox = await sandboxClient.get({
         name: source.sandboxName,

--- a/packages/sandbox/src/commands/login.ts
+++ b/packages/sandbox/src/commands/login.ts
@@ -117,10 +117,11 @@ export const login = cmd.command({
       const auth = getAuth();
       if (auth?.token) {
         try {
-          const { teamId, teamSlug, projectId, projectSlug } =
-            await inferScope({
+          const { teamId, teamSlug, projectId, projectSlug } = await inferScope(
+            {
               token: auth.token,
-            });
+            },
+          );
           process.stderr.write(
             chalk.dim("   │ ") +
               "team: " +

--- a/packages/sandbox/src/commands/snapshot.ts
+++ b/packages/sandbox/src/commands/snapshot.ts
@@ -20,7 +20,8 @@ export const args = {
   expiration: cmd.option({
     long: "expiration",
     type: cmd.optional(Duration),
-    description: "The expiration time of the snapshot. Use 0 for no expiration.",
+    description:
+      "The expiration time of the snapshot. Use 0 for no expiration.",
   }),
   sandbox: cmd.positional({
     type: sandboxName as cmd.Type<string, string | Sandbox>,

--- a/packages/sandbox/src/commands/snapshots.ts
+++ b/packages/sandbox/src/commands/snapshots.ts
@@ -8,7 +8,12 @@ import { sandboxName } from "../args/sandbox-name";
 import { snapshotId } from "../args/snapshot-id";
 import { sandboxClient, snapshotClient } from "../client";
 import { acquireRelease } from "../util/disposables";
-import { formatBytes, formatNextCursorHint, table, timeAgo } from "../util/output";
+import {
+  formatBytes,
+  formatNextCursorHint,
+  table,
+  timeAgo,
+} from "../util/output";
 import { renderSnapshotTree } from "../util/snapshot-tree";
 
 const list = cmd.command({
@@ -38,7 +43,13 @@ const list = cmd.command({
       type: cmd.optional(cmd.string),
     }),
   },
-  async handler({ scope: { token, team, project }, name, sortOrder, limit, cursor }) {
+  async handler({
+    scope: { token, team, project },
+    name,
+    sortOrder,
+    limit,
+    cursor,
+  }) {
     const { snapshots, pagination } = await (async () => {
       using _spinner = acquireRelease(
         () => ora("Fetching snapshots...").start(),
@@ -117,7 +128,12 @@ const get = cmd.command({
             color: (s) => SnapshotStatusColor.get(s.status) ?? chalk.reset,
           },
           CREATED: { value: (s) => timeAgo(s.createdAt) },
-          EXPIRATION: { value: (s) => s.status === 'deleted' ? chalk.gray.dim('deleted') : timeAgo(s.expiresAt) },
+          EXPIRATION: {
+            value: (s) =>
+              s.status === "deleted"
+                ? chalk.gray.dim("deleted")
+                : timeAgo(s.expiresAt),
+          },
           SIZE: { value: (s) => formatBytes(s.sizeBytes) },
           ["SOURCE SESSION"]: { value: (s) => s.sourceSessionId },
         },
@@ -190,8 +206,7 @@ const tree = cmd.command({
     }),
     limit: cmd.option({
       long: "limit",
-      description:
-        "Maximum number of snapshots per page (1–10, default 10).",
+      description: "Maximum number of snapshots per page (1–10, default 10).",
       type: cmd.optional(cmd.number),
     }),
     cursor: cmd.option({
@@ -209,17 +224,13 @@ const tree = cmd.command({
     cursor,
   }) {
     if (limit !== undefined && (limit < 1 || limit > 10)) {
-      console.error(
-        chalk.red("Error: --limit must be between 1 and 10."),
-      );
+      console.error(chalk.red("Error: --limit must be between 1 and 10."));
       process.exitCode = 1;
       return;
     }
 
     if (sortOrder !== undefined && !cursor) {
-      console.error(
-        chalk.red("Error: --sort-order requires --cursor."),
-      );
+      console.error(chalk.red("Error: --sort-order requires --cursor."));
       process.exitCode = 1;
       return;
     }

--- a/packages/sandbox/src/commands/stop.ts
+++ b/packages/sandbox/src/commands/stop.ts
@@ -38,7 +38,9 @@ function printTree(rows: Cell[][]) {
       .map((cell, i) => {
         if (!cell) return " ".repeat(widths[i]);
         const pad = widths[i] - cell.label.length - cell.value.length;
-        return cell.label + chalk.cyan(cell.value) + " ".repeat(Math.max(0, pad));
+        return (
+          cell.label + chalk.cyan(cell.value) + " ".repeat(Math.max(0, pad))
+        );
       })
       .join("  ")
       .trimEnd();
@@ -46,7 +48,11 @@ function printTree(rows: Cell[][]) {
   }
 }
 
-function printStopResult(name: string, sandbox: Sandbox, sessionSnapshot: StopResult) {
+function printStopResult(
+  name: string,
+  sandbox: Sandbox,
+  sessionSnapshot: StopResult,
+) {
   process.stderr.write(chalk.green("✔") + " Sandbox stopped.\n");
 
   const snapshot = sessionSnapshot.snapshot;
@@ -54,26 +60,50 @@ function printStopResult(name: string, sandbox: Sandbox, sessionSnapshot: StopRe
   const rows: Cell[][] = [
     [
       c("sandbox: ", name),
-      sandbox.totalActiveCpuDurationMs != null ? c("active cpu: ", formatRunDuration(sandbox.totalActiveCpuDurationMs)) : null,
+      sandbox.totalActiveCpuDurationMs != null
+        ? c("active cpu: ", formatRunDuration(sandbox.totalActiveCpuDurationMs))
+        : null,
       sandbox.memory != null ? c("mem: ", `${sandbox.memory} MB`) : null,
-      sandbox.totalDurationMs != null ? c("duration: ", formatRunDuration(sandbox.totalDurationMs)) : null,
-      sandbox.totalIngressBytes != null ? c("ingress: ", formatBytes(sandbox.totalIngressBytes)) : null,
-      sandbox.totalEgressBytes != null ? c("egress: ", formatBytes(sandbox.totalEgressBytes)) : null,
+      sandbox.totalDurationMs != null
+        ? c("duration: ", formatRunDuration(sandbox.totalDurationMs))
+        : null,
+      sandbox.totalIngressBytes != null
+        ? c("ingress: ", formatBytes(sandbox.totalIngressBytes))
+        : null,
+      sandbox.totalEgressBytes != null
+        ? c("egress: ", formatBytes(sandbox.totalEgressBytes))
+        : null,
     ],
     [
       c("session: ", sessionSnapshot.id),
-      sessionSnapshot.activeCpuDurationMs != null ? c("active cpu: ", formatRunDuration(sessionSnapshot.activeCpuDurationMs)) : null,
+      sessionSnapshot.activeCpuDurationMs != null
+        ? c(
+            "active cpu: ",
+            formatRunDuration(sessionSnapshot.activeCpuDurationMs),
+          )
+        : null,
       c("mem: ", `${sessionSnapshot.memory} MB`),
-      sessionSnapshot.duration != null ? c("duration: ", formatRunDuration(sessionSnapshot.duration)) : null,
-      sessionSnapshot.networkTransfer ? c("ingress: ", formatBytes(sessionSnapshot.networkTransfer.ingress)) : null,
-      sessionSnapshot.networkTransfer ? c("egress: ", formatBytes(sessionSnapshot.networkTransfer.egress)) : null,
+      sessionSnapshot.duration != null
+        ? c("duration: ", formatRunDuration(sessionSnapshot.duration))
+        : null,
+      sessionSnapshot.networkTransfer
+        ? c("ingress: ", formatBytes(sessionSnapshot.networkTransfer.ingress))
+        : null,
+      sessionSnapshot.networkTransfer
+        ? c("egress: ", formatBytes(sessionSnapshot.networkTransfer.egress))
+        : null,
     ],
     ...(snapshot
-      ? [[
-          c("snapshot: ", snapshot.id),
-          c("size: ", formatBytes(snapshot.sizeBytes)),
-          c("expires: ", snapshot.expiresAt ? timeAgo(snapshot.expiresAt) : "never"),
-        ]]
+      ? [
+          [
+            c("snapshot: ", snapshot.id),
+            c("size: ", formatBytes(snapshot.sizeBytes)),
+            c(
+              "expires: ",
+              snapshot.expiresAt ? timeAgo(snapshot.expiresAt) : "never",
+            ),
+          ],
+        ]
       : []),
   ];
 
@@ -94,12 +124,17 @@ export const stop = cmd.command({
     }),
     scope,
   },
-  async handler({ scope: { token, team, project }, sandboxName, sandboxNames }) {
+  async handler({
+    scope: { token, team, project },
+    sandboxName,
+    sandboxNames,
+  }) {
     const names = Array.from(new Set([sandboxName, ...sandboxNames]));
     const spinner = ora({
-      text: names.length === 1
-        ? `Stopping ${names[0]}`
-        : `Stopping ${names.length} sandboxes`,
+      text:
+        names.length === 1
+          ? `Stopping ${names[0]}`
+          : `Stopping ${names.length} sandboxes`,
       stream: process.stderr,
     }).start();
 

--- a/packages/sandbox/src/interactive-shell/interactive-shell.ts
+++ b/packages/sandbox/src/interactive-shell/interactive-shell.ts
@@ -3,7 +3,11 @@ import createDebugger from "debug";
 import { WebSocket } from "ws";
 import { printCommand } from "../util/print-command";
 import ora from "ora";
-import { acquireRelease, createAbortController, defer } from "../util/disposables";
+import {
+  acquireRelease,
+  createAbortController,
+  defer,
+} from "../util/disposables";
 import chalk from "chalk";
 import { extendSandboxTimeoutPeriodically } from "./extend-sandbox-timeout";
 
@@ -165,7 +169,9 @@ export async function startInteractiveShell(options: {
   process.removeListener("SIGWINCH", onResize);
   process.stdin.removeListener("data", onStdin);
 
-  console.error(chalk.dim(`\n╰▶ connection to ▲ ${options.sandbox.name} closed.`));
+  console.error(
+    chalk.dim(`\n╰▶ connection to ▲ ${options.sandbox.name} closed.`),
+  );
 }
 
 function toEnvArray(env: Record<string, string>): string[] {

--- a/packages/sandbox/src/util/format-error.test.ts
+++ b/packages/sandbox/src/util/format-error.test.ts
@@ -19,7 +19,10 @@ import { StyledError } from "../error";
 
 function makeApiError(status: number, json?: unknown): APIError<unknown> {
   return new APIError(
-    new Response("", { status, statusText: status === 400 ? "Bad Request" : "Error" }),
+    new Response("", {
+      status,
+      statusText: status === 400 ? "Bad Request" : "Error",
+    }),
     { json },
   );
 }
@@ -35,12 +38,12 @@ describe("isApiTimeoutError", () => {
   });
 
   it("detects undici connect/headers timeouts via cause.code", () => {
-    expect(isApiTimeoutError({ cause: { code: "UND_ERR_CONNECT_TIMEOUT" } })).toBe(
-      true,
-    );
-    expect(isApiTimeoutError({ cause: { code: "UND_ERR_HEADERS_TIMEOUT" } })).toBe(
-      true,
-    );
+    expect(
+      isApiTimeoutError({ cause: { code: "UND_ERR_CONNECT_TIMEOUT" } }),
+    ).toBe(true);
+    expect(
+      isApiTimeoutError({ cause: { code: "UND_ERR_HEADERS_TIMEOUT" } }),
+    ).toBe(true);
   });
 
   it("detects the `fetch failed` TypeError wrapper", () => {
@@ -51,9 +54,9 @@ describe("isApiTimeoutError", () => {
 
   it("returns false for unrelated errors and non-objects", () => {
     expect(isApiTimeoutError(new Error("boom"))).toBe(false);
-    expect(isApiTimeoutError({ name: "TypeError", message: "fetch failed" })).toBe(
-      false,
-    );
+    expect(
+      isApiTimeoutError({ name: "TypeError", message: "fetch failed" }),
+    ).toBe(false);
     expect(isApiTimeoutError(undefined)).toBe(false);
     expect(isApiTimeoutError("nope")).toBe(false);
   });

--- a/packages/sandbox/src/util/fresh-auth-retry.test.ts
+++ b/packages/sandbox/src/util/fresh-auth-retry.test.ts
@@ -11,9 +11,7 @@ vi.mock("../args/auth", () => ({
 const { withFreshAuthRetry } = await import("./fresh-auth-retry");
 
 function makeApiError(status: number): APIError<unknown> {
-  return new APIError(
-    new Response("", { status, statusText: "Unauthorized" }),
-  );
+  return new APIError(new Response("", { status, statusText: "Unauthorized" }));
 }
 
 function makeNotOk(statusCode: number): NotOk {

--- a/packages/sandbox/src/util/keep-last-snapshots.ts
+++ b/packages/sandbox/src/util/keep-last-snapshots.ts
@@ -31,8 +31,7 @@ export function buildKeepLastSnapshotsPayload(
 
   if (
     keepLastSnapshots === undefined &&
-    (keepLastSnapshotsFor !== undefined ||
-      deleteEvictedSnapshots !== undefined)
+    (keepLastSnapshotsFor !== undefined || deleteEvictedSnapshots !== undefined)
   ) {
     throw new Error(
       [

--- a/packages/sandbox/src/util/output.ts
+++ b/packages/sandbox/src/util/output.ts
@@ -26,7 +26,7 @@ export function formatBytes(bytes: number) {
 
 export function timeAgo(date: string | number | Date | undefined) {
   if (date === undefined) {
-    return '-';
+    return "-";
   }
 
   return formatDistanceStrict(date, new Date(), {
@@ -76,7 +76,7 @@ export function formatRunDuration(d: number): string {
   if (d < 1000) {
     return `${d}ms`;
   }
-  return `${d/1000}s`
+  return `${d / 1000}s`;
 }
 
 export function formatNextCursorHint(cursor: string): string {

--- a/packages/sandbox/src/util/snapshot-tree.ts
+++ b/packages/sandbox/src/util/snapshot-tree.ts
@@ -88,19 +88,14 @@ function renderSiblings(siblings: SnapshotData[], count: string): string[] {
   return lines;
 }
 
-export function renderSnapshotTree(
-  params: RenderSnapshotTreeParams,
-): string {
+export function renderSnapshotTree(params: RenderSnapshotTreeParams): string {
   const { ancestors, descendants } = params;
   const hideCurrent = params.hideCurrent === true;
   const currentSnapshotId = hideCurrent ? undefined : params.currentSnapshotId;
   const lines: string[] = [];
 
   // Helper: push a snapshot node with optional siblings and a trailing connector
-  const pushNode = (
-    node: TreeNode,
-    isCurrent: boolean,
-  ) => {
+  const pushNode = (node: TreeNode, isCurrent: boolean) => {
     lines.push("│");
     lines.push(
       renderNode(node.snapshot.id, node.snapshot.expiresAt, isCurrent),

--- a/packages/sandbox/test/args/auth.test.ts
+++ b/packages/sandbox/test/args/auth.test.ts
@@ -5,18 +5,21 @@ import {
   RefreshAccessTokenFailedError,
 } from "@vercel/oidc";
 
-const { mockGetAuth, mockGetVercelCliToken, mockGetVercelOidcToken, mockLogin } =
-  vi.hoisted(() => ({
-    mockGetAuth: vi.fn(),
-    mockGetVercelCliToken: vi.fn(),
-    mockGetVercelOidcToken: vi.fn(),
-    mockLogin: vi.fn(),
-  }));
+const {
+  mockGetAuth,
+  mockGetVercelCliToken,
+  mockGetVercelOidcToken,
+  mockLogin,
+} = vi.hoisted(() => ({
+  mockGetAuth: vi.fn(),
+  mockGetVercelCliToken: vi.fn(),
+  mockGetVercelOidcToken: vi.fn(),
+  mockLogin: vi.fn(),
+}));
 
 vi.mock("@vercel/oidc", async () => {
-  const actual = await vi.importActual<typeof import("@vercel/oidc")>(
-    "@vercel/oidc",
-  );
+  const actual =
+    await vi.importActual<typeof import("@vercel/oidc")>("@vercel/oidc");
   return {
     ...actual,
     getVercelToken: mockGetVercelCliToken,

--- a/packages/sandbox/test/commands/cp.test.ts
+++ b/packages/sandbox/test/commands/cp.test.ts
@@ -3,12 +3,12 @@ import { parseLocalOrRemotePath } from "../../src/commands/cp";
 
 describe("copy path parsing", () => {
   test("accepts non-existent local paths", async () => {
-    await expect(parseLocalOrRemotePath("./does-not-exist.txt")).resolves.toEqual(
-      {
-        type: "local",
-        path: "./does-not-exist.txt",
-      },
-    );
+    await expect(
+      parseLocalOrRemotePath("./does-not-exist.txt"),
+    ).resolves.toEqual({
+      type: "local",
+      path: "./does-not-exist.txt",
+    });
   });
 
   test("parses remote paths with a sandbox name", async () => {

--- a/packages/vercel-sandbox-mock/src/fork.test.ts
+++ b/packages/vercel-sandbox-mock/src/fork.test.ts
@@ -41,7 +41,9 @@ describe("Sandbox.fork", () => {
       expect(fork.snapshotExpiration).toBe(7 * DAY);
       expect(fork.keepLastSnapshots?.count).toBe(3);
 
-      const forkPorts = fork.routes.map((route) => route.port).sort((a, b) => a - b);
+      const forkPorts = fork.routes
+        .map((route) => route.port)
+        .sort((a, b) => a - b);
       expect(forkPorts).toEqual([3000, 8080]);
 
       expect(await readEnv(fork, "FORKED")).toBe("yes");

--- a/packages/vercel-sandbox-mock/src/handlers.test.ts
+++ b/packages/vercel-sandbox-mock/src/handlers.test.ts
@@ -41,7 +41,9 @@ describe("command()", () => {
     });
 
     test("throws when the command name cannot be extracted", () => {
-      expect(() => command(/(npm|pnpm) install/)).toThrow(/Cannot extract command name/);
+      expect(() => command(/(npm|pnpm) install/)).toThrow(
+        /Cannot extract command name/,
+      );
     });
   });
 
@@ -52,7 +54,10 @@ describe("command()", () => {
 
     test("static responses are returned as-is", async () => {
       const handler = command("fail", { stderr: "boom", exitCode: 2 });
-      expect(await handler.resolve("fail", [], ctx)).toEqual({ stderr: "boom", exitCode: 2 });
+      expect(await handler.resolve("fail", [], ctx)).toEqual({
+        stderr: "boom",
+        exitCode: 2,
+      });
     });
 
     test("function responses receive args and context", async () => {
@@ -87,7 +92,10 @@ describe("handlersToCustomCommands", () => {
       stderr: "",
       exitCode: 0,
     });
-    expect(await bash.exec("npm audit")).toMatchObject({ stdout: "generic\n", exitCode: 1 });
+    expect(await bash.exec("npm audit")).toMatchObject({
+      stdout: "generic\n",
+      exitCode: 1,
+    });
   });
 
   test("no matching pattern yields exit code 127", async () => {

--- a/packages/vercel-sandbox-mock/src/handlers.ts
+++ b/packages/vercel-sandbox-mock/src/handlers.ts
@@ -25,7 +25,11 @@ export type CommandMatcher = string | RegExp;
 export interface CommandHandler {
   commandNames: string[];
   matches(cmd: string, args: string[]): boolean;
-  resolve(cmd: string, args: string[], ctx: CommandHandlerContext): Promise<CommandResponse>;
+  resolve(
+    cmd: string,
+    args: string[],
+    ctx: CommandHandlerContext,
+  ): Promise<CommandResponse>;
 }
 
 type ResponseFn = (
@@ -133,7 +137,9 @@ function extractCommandName(regex: RegExp): string {
  * Convert an array of CommandHandlers to just-bash Command objects.
  * Groups handlers by command name and creates a defineCommand for each.
  */
-export function handlersToCustomCommands(handlers: CommandHandler[]): Command[] {
+export function handlersToCustomCommands(
+  handlers: CommandHandler[],
+): Command[] {
   // Group handlers by command name
   const handlersByName = new Map<string, CommandHandler[]>();
   for (const handler of handlers) {
@@ -154,7 +160,9 @@ export function handlersToCustomCommands(handlers: CommandHandler[]): Command[] 
         // Provide exec so handlers can delegate to just-bash
         const exec = ctx.exec
           ? async (execCmd: string, execArgs?: string[]) => {
-              const cmdLine = execArgs?.length ? [execCmd, ...execArgs].join(" ") : execCmd;
+              const cmdLine = execArgs?.length
+                ? [execCmd, ...execArgs].join(" ")
+                : execCmd;
               return ctx.exec!(cmdLine, { cwd: ctx.cwd });
             }
           : undefined;

--- a/packages/vercel-sandbox-mock/src/sandbox.test.ts
+++ b/packages/vercel-sandbox-mock/src/sandbox.test.ts
@@ -13,16 +13,24 @@ describe("Sandbox (real SDK over mock fetch)", () => {
   });
 
   test("get on an unknown name throws a 404 APIError", async () => {
-    await expect(Sandbox.get({ name: "does-not-exist" })).rejects.toMatchObject({
-      response: { status: 404 },
-    });
+    await expect(Sandbox.get({ name: "does-not-exist" })).rejects.toMatchObject(
+      {
+        response: { status: 404 },
+      },
+    );
   });
 
   test("getOrCreate runs onCreate exactly once for a name", async () => {
     const name = uniq();
     let created = 0;
-    const first = await Sandbox.getOrCreate({ name, onCreate: async () => void created++ });
-    const second = await Sandbox.getOrCreate({ name, onCreate: async () => void created++ });
+    const first = await Sandbox.getOrCreate({
+      name,
+      onCreate: async () => void created++,
+    });
+    const second = await Sandbox.getOrCreate({
+      name,
+      onCreate: async () => void created++,
+    });
     expect(created).toBe(1);
     expect(second.name).toBe(name);
     await first.delete();
@@ -60,14 +68,20 @@ describe("Sandbox (real SDK over mock fetch)", () => {
   test("update({ ports }) refreshes routes so domain() resolves", async () => {
     const sandbox = await Sandbox.create({ name: uniq() });
     await sandbox.update({ ports: [8080] });
-    expect(sandbox.domain(8080)).toBe(sandbox.routes.find((r) => r.port === 8080)?.url);
+    expect(sandbox.domain(8080)).toBe(
+      sandbox.routes.find((r) => r.port === 8080)?.url,
+    );
     expect(() => sandbox.domain(9999)).toThrow(/No route/);
     await sandbox.stop();
   });
 
   test("detached commands expose wait/logs/kill", async () => {
     const sandbox = await Sandbox.create({ name: uniq() });
-    const command = await sandbox.runCommand({ cmd: "echo", args: ["detached"], detached: true });
+    const command = await sandbox.runCommand({
+      cmd: "echo",
+      args: ["detached"],
+      detached: true,
+    });
     expect(typeof command.cmdId).toBe("string");
 
     const finished = await command.wait();

--- a/packages/vercel-sandbox-mock/src/sandbox.ts
+++ b/packages/vercel-sandbox-mock/src/sandbox.ts
@@ -15,7 +15,9 @@ type ListParams = Parameters<typeof RealSandbox.list>[0];
  * existing `Sandbox` code works unchanged.
  */
 export class Sandbox extends RealSandbox {
-  static override create(params?: CreateParams): ReturnType<typeof RealSandbox.create> {
+  static override create(
+    params?: CreateParams,
+  ): ReturnType<typeof RealSandbox.create> {
     return RealSandbox.create(withMockDefaults(params) as CreateParams);
   }
 
@@ -26,14 +28,20 @@ export class Sandbox extends RealSandbox {
   static override getOrCreate(
     params?: GetOrCreateParams,
   ): ReturnType<typeof RealSandbox.getOrCreate> {
-    return RealSandbox.getOrCreate(withMockDefaults(params) as GetOrCreateParams);
+    return RealSandbox.getOrCreate(
+      withMockDefaults(params) as GetOrCreateParams,
+    );
   }
 
-  static override fork(params: ForkParams): ReturnType<typeof RealSandbox.fork> {
+  static override fork(
+    params: ForkParams,
+  ): ReturnType<typeof RealSandbox.fork> {
     return RealSandbox.fork(withMockDefaults(params) as ForkParams);
   }
 
-  static override list(params?: ListParams): ReturnType<typeof RealSandbox.list> {
+  static override list(
+    params?: ListParams,
+  ): ReturnType<typeof RealSandbox.list> {
     return RealSandbox.list(withMockDefaults(params) as ListParams);
   }
 }

--- a/packages/vercel-sandbox-mock/src/server/executor.test.ts
+++ b/packages/vercel-sandbox-mock/src/server/executor.test.ts
@@ -27,8 +27,14 @@ describe("Executor", () => {
 
   test("honors cwd and env", async () => {
     const exec = await makeExecutor();
-    expect((await exec.run({ command: "pwd", args: [], cwd: "/tmp" })).stdout.trim()).toBe("/tmp");
-    const env = await exec.run({ command: "printenv", args: ["X"], env: { X: "y" } });
+    expect(
+      (await exec.run({ command: "pwd", args: [], cwd: "/tmp" })).stdout.trim(),
+    ).toBe("/tmp");
+    const env = await exec.run({
+      command: "printenv",
+      args: ["X"],
+      env: { X: "y" },
+    });
     expect(env.stdout.trim()).toBe("y");
   });
 
@@ -57,14 +63,20 @@ describe("Executor", () => {
 
     test("stat on a missing path fails with ENOENT-shaped stderr", async () => {
       const exec = await makeExecutor();
-      const stat = await exec.run({ command: "stat", args: ["-c", "%s", "/nope"] });
+      const stat = await exec.run({
+        command: "stat",
+        args: ["-c", "%s", "/nope"],
+      });
       expect(stat.exitCode).toBe(1);
       expect(stat.stderr).toContain("No such file or directory");
     });
 
     test("find -printf lists entries as name|type", async () => {
       const exec = await makeExecutor();
-      await exec.run({ command: "sh", args: ["-c", "mkdir -p /d/sub && printf x > /d/f"] });
+      await exec.run({
+        command: "sh",
+        args: ["-c", "mkdir -p /d/sub && printf x > /d/f"],
+      });
       const find = await exec.run({
         command: "find",
         args: ["/d", "-maxdepth", "1", "-mindepth", "1", "-printf", "%f|%y\\n"],
@@ -78,37 +90,72 @@ describe("Executor", () => {
       const exec = await makeExecutor();
       await exec.run({ command: "sh", args: ["-c", "printf abcd > /tmp/t"] });
       await exec.run({ command: "truncate", args: ["-s", "2", "/tmp/t"] });
-      expect((await exec.run({ command: "cat", args: ["/tmp/t"] })).stdout).toBe("ab");
+      expect(
+        (await exec.run({ command: "cat", args: ["/tmp/t"] })).stdout,
+      ).toBe("ab");
 
-      const a = (await exec.run({ command: "mktemp", args: ["-d", "/tmp/x-XXXXXX"] })).stdout.trim();
-      const b = (await exec.run({ command: "mktemp", args: ["-d", "/tmp/x-XXXXXX"] })).stdout.trim();
+      const a = (
+        await exec.run({ command: "mktemp", args: ["-d", "/tmp/x-XXXXXX"] })
+      ).stdout.trim();
+      const b = (
+        await exec.run({ command: "mktemp", args: ["-d", "/tmp/x-XXXXXX"] })
+      ).stdout.trim();
       expect(a).not.toBe(b);
 
       await exec.run({ command: "sh", args: ["-c", "ln -s /tmp/t /tmp/link"] });
-      expect((await exec.run({ command: "realpath", args: ["/tmp/link"] })).stdout.trim()).toBe(
-        "/tmp/t",
-      );
+      expect(
+        (
+          await exec.run({ command: "realpath", args: ["/tmp/link"] })
+        ).stdout.trim(),
+      ).toBe("/tmp/t");
 
-      expect((await exec.run({ command: "test", args: ["-e", "/tmp/t"] })).exitCode).toBe(0);
-      expect((await exec.run({ command: "test", args: ["-e", "/nope"] })).exitCode).toBe(1);
+      expect(
+        (await exec.run({ command: "test", args: ["-e", "/tmp/t"] })).exitCode,
+      ).toBe(0);
+      expect(
+        (await exec.run({ command: "test", args: ["-e", "/nope"] })).exitCode,
+      ).toBe(1);
     });
   });
 
   describe("user/group commands", () => {
     test("useradd creates a user with a home dir and matching primary group", async () => {
       const users = createUserState();
-      const exec = await Executor.create({ cwd: "/vercel/sandbox", users, customCommands: [] });
-      expect((await exec.run({ command: "useradd", args: ["-m", "-s", "/bin/bash", "alice"] })).exitCode).toBe(0);
+      const exec = await Executor.create({
+        cwd: "/vercel/sandbox",
+        users,
+        customCommands: [],
+      });
+      expect(
+        (
+          await exec.run({
+            command: "useradd",
+            args: ["-m", "-s", "/bin/bash", "alice"],
+          })
+        ).exitCode,
+      ).toBe(0);
       expect(users.users.has("alice")).toBe(true);
-      expect((await exec.run({ command: "test", args: ["-e", "/home/alice"] })).exitCode).toBe(0);
-      expect((await exec.run({ command: "id", args: ["-gn", "alice"] })).stdout.trim()).toBe("alice");
-      expect((await exec.run({ command: "id", args: ["-un"] })).stdout.trim()).toBe("vercel-sandbox");
+      expect(
+        (await exec.run({ command: "test", args: ["-e", "/home/alice"] }))
+          .exitCode,
+      ).toBe(0);
+      expect(
+        (
+          await exec.run({ command: "id", args: ["-gn", "alice"] })
+        ).stdout.trim(),
+      ).toBe("alice");
+      expect(
+        (await exec.run({ command: "id", args: ["-un"] })).stdout.trim(),
+      ).toBe("vercel-sandbox");
     });
 
     test("useradd twice fails", async () => {
       const exec = await makeExecutor();
       await exec.run({ command: "useradd", args: ["-m", "alice"] });
-      const second = await exec.run({ command: "useradd", args: ["-m", "alice"] });
+      const second = await exec.run({
+        command: "useradd",
+        args: ["-m", "alice"],
+      });
       expect(second.exitCode).not.toBe(0);
       expect(second.stderr).toContain("already exists");
     });
@@ -117,10 +164,22 @@ describe("Executor", () => {
       const exec = await makeExecutor();
       await exec.run({ command: "useradd", args: ["-m", "alice"] });
       await exec.run({ command: "groupadd", args: ["devs"] });
-      expect((await exec.run({ command: "usermod", args: ["-aG", "devs", "alice"] })).exitCode).toBe(0);
-      expect((await exec.run({ command: "gpasswd", args: ["-d", "alice", "devs"] })).exitCode).toBe(0);
-      expect((await exec.run({ command: "gpasswd", args: ["-d", "alice", "devs"] })).exitCode).not.toBe(0);
-      expect((await exec.run({ command: "usermod", args: ["-aG", "nope", "alice"] })).exitCode).not.toBe(0);
+      expect(
+        (await exec.run({ command: "usermod", args: ["-aG", "devs", "alice"] }))
+          .exitCode,
+      ).toBe(0);
+      expect(
+        (await exec.run({ command: "gpasswd", args: ["-d", "alice", "devs"] }))
+          .exitCode,
+      ).toBe(0);
+      expect(
+        (await exec.run({ command: "gpasswd", args: ["-d", "alice", "devs"] }))
+          .exitCode,
+      ).not.toBe(0);
+      expect(
+        (await exec.run({ command: "usermod", args: ["-aG", "nope", "alice"] }))
+          .exitCode,
+      ).not.toBe(0);
     });
   });
 });

--- a/packages/vercel-sandbox-mock/src/server/executor.ts
+++ b/packages/vercel-sandbox-mock/src/server/executor.ts
@@ -27,7 +27,10 @@ export interface RunArgs {
  * Strip the `sudo`/options prefix and run the inner argv; there is no real
  * privilege or identity change (just-bash always runs as root).
  */
-function unwrapSudo(command: string, args: string[]): { command: string; args: string[] } {
+function unwrapSudo(
+  command: string,
+  args: string[],
+): { command: string; args: string[] } {
   if (command !== "sudo") return { command, args };
   let i = 0;
   while (i < args.length) {
@@ -74,7 +77,10 @@ export class Executor {
     const inner = await JustBashSandbox.create({
       cwd: config.cwd,
       env: config.env,
-      customCommands: [...buildUserCommands(config.users), ...config.customCommands],
+      customCommands: [
+        ...buildUserCommands(config.users),
+        ...config.customCommands,
+      ],
     });
     // just-bash only seeds /bin, /usr, /dev, ... — create the standard
     // directories a real sandbox image ships with.
@@ -95,9 +101,18 @@ export class Executor {
 
     // Intercept the coreutils invocations the SDK's FileSystem makes with
     // GNU flags just-bash doesn't support; everything else runs in just-bash.
-    const intercepted = await tryFsCommand(this.fs, params.cwd ?? this.#cwd, command, args);
+    const intercepted = await tryFsCommand(
+      this.fs,
+      params.cwd ?? this.#cwd,
+      command,
+      args,
+    );
     if (intercepted) {
-      return { ...intercepted, startedAt, durationMs: Math.max(0, Date.now() - startedAt) };
+      return {
+        ...intercepted,
+        startedAt,
+        durationMs: Math.max(0, Date.now() - startedAt),
+      };
     }
 
     const result = await this.#inner.runCommand({

--- a/packages/vercel-sandbox-mock/src/server/fs-commands.test.ts
+++ b/packages/vercel-sandbox-mock/src/server/fs-commands.test.ts
@@ -20,14 +20,23 @@ describe("tryFsCommand", () => {
 
   test("resolves relative paths against cwd", async () => {
     const fs = await makeFs();
-    const result = await tryFsCommand(fs, "/dir", "stat", ["-c", "%s", "file.txt"]);
+    const result = await tryFsCommand(fs, "/dir", "stat", [
+      "-c",
+      "%s",
+      "file.txt",
+    ]);
     expect(result?.stdout).toBe("3\n");
   });
 
   describe("stat -c", () => {
     test("formats size and type bits for a regular file", async () => {
       const fs = await makeFs();
-      const result = await tryFsCommand(fs, "/", "stat", ["-L", "-c", "%s|%f", "/dir/file.txt"]);
+      const result = await tryFsCommand(fs, "/", "stat", [
+        "-L",
+        "-c",
+        "%s|%f",
+        "/dir/file.txt",
+      ]);
       expect(result?.exitCode).toBe(0);
       const [size, rawMode] = result!.stdout.trim().split("|");
       expect(Number(size)).toBe(3);
@@ -36,9 +45,18 @@ describe("tryFsCommand", () => {
 
     test("-L follows symlinks; without it the link itself is reported", async () => {
       const fs = await makeFs();
-      const followed = await tryFsCommand(fs, "/", "stat", ["-L", "-c", "%f", "/dir/link"]);
+      const followed = await tryFsCommand(fs, "/", "stat", [
+        "-L",
+        "-c",
+        "%f",
+        "/dir/link",
+      ]);
       expect(parseInt(followed!.stdout.trim(), 16) & 0o170000).toBe(0o100000);
-      const link = await tryFsCommand(fs, "/", "stat", ["-c", "%f", "/dir/link"]);
+      const link = await tryFsCommand(fs, "/", "stat", [
+        "-c",
+        "%f",
+        "/dir/link",
+      ]);
       expect(parseInt(link!.stdout.trim(), 16) & 0o170000).toBe(0o120000);
     });
 
@@ -66,13 +84,20 @@ describe("tryFsCommand", () => {
 
     test("empty directories produce empty stdout", async () => {
       const fs = await makeFs();
-      const result = await tryFsCommand(fs, "/", "find", ["/dir/sub", "-printf", "%f|%y\\n"]);
+      const result = await tryFsCommand(fs, "/", "find", [
+        "/dir/sub",
+        "-printf",
+        "%f|%y\\n",
+      ]);
       expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });
     });
 
     test("missing paths fail", async () => {
       const fs = await makeFs();
-      expect((await tryFsCommand(fs, "/", "find", ["/nope", "-printf", "%f\\n"]))?.exitCode).toBe(1);
+      expect(
+        (await tryFsCommand(fs, "/", "find", ["/nope", "-printf", "%f\\n"]))
+          ?.exitCode,
+      ).toBe(1);
     });
   });
 
@@ -90,8 +115,14 @@ describe("tryFsCommand", () => {
 
   test("mktemp replaces the XXXXXX suffix and creates the directory", async () => {
     const fs = await makeFs();
-    const a = (await tryFsCommand(fs, "/", "mktemp", ["-d", "/tmp/x-XXXXXX"]))!.stdout.trim();
-    const b = (await tryFsCommand(fs, "/", "mktemp", ["-d", "/tmp/x-XXXXXX"]))!.stdout.trim();
+    const a = (await tryFsCommand(fs, "/", "mktemp", [
+      "-d",
+      "/tmp/x-XXXXXX",
+    ]))!.stdout.trim();
+    const b = (await tryFsCommand(fs, "/", "mktemp", [
+      "-d",
+      "/tmp/x-XXXXXX",
+    ]))!.stdout.trim();
     expect(a).toMatch(/^\/tmp\/x-[0-9a-f]{6}$/);
     expect(a).not.toBe(b);
     expect(await fs.exists(a)).toBe(true);
@@ -99,15 +130,21 @@ describe("tryFsCommand", () => {
 
   test("realpath resolves symlinks and fails on missing paths", async () => {
     const fs = await makeFs();
-    expect((await tryFsCommand(fs, "/", "realpath", ["/dir/link"]))?.stdout).toBe(
-      "/dir/file.txt\n",
+    expect(
+      (await tryFsCommand(fs, "/", "realpath", ["/dir/link"]))?.stdout,
+    ).toBe("/dir/file.txt\n");
+    expect((await tryFsCommand(fs, "/", "realpath", ["/nope"]))?.exitCode).toBe(
+      1,
     );
-    expect((await tryFsCommand(fs, "/", "realpath", ["/nope"]))?.exitCode).toBe(1);
   });
 
   test("test -e reports existence via exit code", async () => {
     const fs = await makeFs();
-    expect((await tryFsCommand(fs, "/", "test", ["-e", "/dir/file.txt"]))?.exitCode).toBe(0);
-    expect((await tryFsCommand(fs, "/", "test", ["-e", "/nope"]))?.exitCode).toBe(1);
+    expect(
+      (await tryFsCommand(fs, "/", "test", ["-e", "/dir/file.txt"]))?.exitCode,
+    ).toBe(0);
+    expect(
+      (await tryFsCommand(fs, "/", "test", ["-e", "/nope"]))?.exitCode,
+    ).toBe(1);
   });
 });

--- a/packages/vercel-sandbox-mock/src/server/fs-commands.ts
+++ b/packages/vercel-sandbox-mock/src/server/fs-commands.ts
@@ -18,10 +18,20 @@ const enoent = (tool: string, path: string): CommandOutput => ({
 });
 
 function formatStat(
-  stats: { isDirectory: boolean; isSymbolicLink: boolean; mode: number; size: number; mtime: Date },
+  stats: {
+    isDirectory: boolean;
+    isSymbolicLink: boolean;
+    mode: number;
+    size: number;
+    mtime: Date;
+  },
   format: string,
 ): string {
-  const typeBits = stats.isDirectory ? S_IFDIR : stats.isSymbolicLink ? S_IFLNK : S_IFREG;
+  const typeBits = stats.isDirectory
+    ? S_IFDIR
+    : stats.isSymbolicLink
+      ? S_IFLNK
+      : S_IFREG;
   const rawMode = typeBits | (stats.mode & 0o7777);
   const seconds = Math.floor(stats.mtime.getTime() / 1000);
   const tokens: Record<string, string> = {
@@ -62,8 +72,14 @@ export async function tryFsCommand(
     const format = args[args.indexOf("-c") + 1];
     const follow = args.includes("-L");
     try {
-      const stats = follow ? await fs.stat(abs(last)) : await fs.lstat(abs(last));
-      return { stdout: `${formatStat(stats, format)}\n`, stderr: "", exitCode: 0 };
+      const stats = follow
+        ? await fs.stat(abs(last))
+        : await fs.lstat(abs(last));
+      return {
+        stdout: `${formatStat(stats, format)}\n`,
+        stderr: "",
+        exitCode: 0,
+      };
     } catch {
       return enoent("stat", last);
     }
@@ -80,9 +96,14 @@ export async function tryFsCommand(
             isSymbolicLink: false,
           }));
       const lines = entries.map(
-        (e) => `${e.name}|${e.isDirectory ? "d" : e.isSymbolicLink ? "l" : "f"}`,
+        (e) =>
+          `${e.name}|${e.isDirectory ? "d" : e.isSymbolicLink ? "l" : "f"}`,
       );
-      return { stdout: lines.length ? `${lines.join("\n")}\n` : "", stderr: "", exitCode: 0 };
+      return {
+        stdout: lines.length ? `${lines.join("\n")}\n` : "",
+        stderr: "",
+        exitCode: 0,
+      };
     } catch {
       return enoent("find", path);
     }
@@ -103,14 +124,21 @@ export async function tryFsCommand(
   }
 
   if (command === "mktemp") {
-    const dir = last.replace(/X{3,}$/, randomUUID().replace(/-/g, "").slice(0, 6));
+    const dir = last.replace(
+      /X{3,}$/,
+      randomUUID().replace(/-/g, "").slice(0, 6),
+    );
     await fs.mkdir(abs(dir), { recursive: true });
     return { stdout: `${dir}\n`, stderr: "", exitCode: 0 };
   }
 
   if (command === "realpath") {
     try {
-      return { stdout: `${await fs.realpath(abs(last))}\n`, stderr: "", exitCode: 0 };
+      return {
+        stdout: `${await fs.realpath(abs(last))}\n`,
+        stderr: "",
+        exitCode: 0,
+      };
     } catch {
       return enoent("realpath", last);
     }
@@ -118,7 +146,11 @@ export async function tryFsCommand(
 
   if (command === "test") {
     // Only `-e` (exists) is used by the SDK's FileSystem.
-    return { stdout: "", stderr: "", exitCode: (await fs.exists(abs(last))) ? 0 : 1 };
+    return {
+      stdout: "",
+      stderr: "",
+      exitCode: (await fs.exists(abs(last))) ? 0 : 1,
+    };
   }
 
   return null;

--- a/packages/vercel-sandbox-mock/src/server/http.ts
+++ b/packages/vercel-sandbox-mock/src/server/http.ts
@@ -25,6 +25,10 @@ export function empty(): Response {
  * ...). Statuses 404/410/422 are surfaced immediately (not retried); 429/5xx
  * would trigger the SDK's retry loop, so they are never returned here.
  */
-export function apiError(status: number, code: string, message: string): Response {
+export function apiError(
+  status: number,
+  code: string,
+  message: string,
+): Response {
   return json({ error: { code, message } }, status);
 }

--- a/packages/vercel-sandbox-mock/src/server/ndjson.test.ts
+++ b/packages/vercel-sandbox-mock/src/server/ndjson.test.ts
@@ -7,7 +7,10 @@ describe("ndjson", () => {
   });
 
   test("emits one JSON object per line", async () => {
-    const response = ndjson([{ command: { id: "c1" } }, { stream: "stdout", data: "hi" }]);
+    const response = ndjson([
+      { command: { id: "c1" } },
+      { stream: "stdout", data: "hi" },
+    ]);
     const text = await response.text();
     const lines = text.trim().split("\n");
     expect(lines).toHaveLength(2);

--- a/packages/vercel-sandbox-mock/src/server/snapshot-fs.test.ts
+++ b/packages/vercel-sandbox-mock/src/server/snapshot-fs.test.ts
@@ -4,7 +4,10 @@ import { captureFileSystem, restoreFileSystem } from "./snapshot-fs";
 
 async function seed(fs: InMemoryFs): Promise<void> {
   await fs.mkdir("/tree/nested", { recursive: true });
-  await fs.writeFile("/tree/nested/payload.bin", Buffer.from([0x00, 0xff, 0x80]));
+  await fs.writeFile(
+    "/tree/nested/payload.bin",
+    Buffer.from([0x00, 0xff, 0x80]),
+  );
   await fs.writeFile("/tree/run.sh", "#!/bin/sh\necho hi\n");
   await fs.chmod("/tree/run.sh", 0o755);
   await fs.symlink("nested/payload.bin", "/tree/link");
@@ -19,9 +22,9 @@ describe("captureFileSystem / restoreFileSystem", () => {
     const target = new InMemoryFs();
     await restoreFileSystem(entries, target);
 
-    expect(Buffer.from(await target.readFileBuffer("/tree/nested/payload.bin"))).toEqual(
-      Buffer.from([0x00, 0xff, 0x80]),
-    );
+    expect(
+      Buffer.from(await target.readFileBuffer("/tree/nested/payload.bin")),
+    ).toEqual(Buffer.from([0x00, 0xff, 0x80]));
     expect((await target.lstat("/tree/run.sh")).mode & 0o777).toBe(0o755);
     expect((await target.lstat("/tree/link")).isSymbolicLink).toBe(true);
     expect(await target.readlink("/tree/link")).toBe("nested/payload.bin");
@@ -44,7 +47,9 @@ describe("captureFileSystem / restoreFileSystem", () => {
     await target.symlink("elsewhere", "/tree/link");
     await restoreFileSystem(entries, target);
 
-    expect(await target.readFile("/tree/run.sh", "utf8")).toBe("#!/bin/sh\necho hi\n");
+    expect(await target.readFile("/tree/run.sh", "utf8")).toBe(
+      "#!/bin/sh\necho hi\n",
+    );
     expect(await target.readlink("/tree/link")).toBe("nested/payload.bin");
   });
 });

--- a/packages/vercel-sandbox-mock/src/server/snapshot-fs.ts
+++ b/packages/vercel-sandbox-mock/src/server/snapshot-fs.ts
@@ -6,14 +6,20 @@ import type { SnapshotFileEntry } from "./registry.js";
  * with modes preserved. Used to snapshot a session and to persist a sandbox's
  * disk across stop/resume.
  */
-export async function captureFileSystem(source: IFileSystem): Promise<SnapshotFileEntry[]> {
+export async function captureFileSystem(
+  source: IFileSystem,
+): Promise<SnapshotFileEntry[]> {
   const entries: SnapshotFileEntry[] = [];
   for (const path of source.getAllPaths().filter((p) => p !== "/")) {
     const stats = await source.lstat(path);
     if (stats.isDirectory) {
       entries.push({ path, mode: stats.mode, type: "directory" });
     } else if (stats.isSymbolicLink) {
-      entries.push({ path, type: "symlink", target: await source.readlink(path) });
+      entries.push({
+        path,
+        type: "symlink",
+        target: await source.readlink(path),
+      });
     } else {
       entries.push({
         path,
@@ -44,7 +50,8 @@ export async function restoreFileSystem(
   for (const entry of ordered) {
     if (entry.type === "directory") continue;
     if (entry.type === "symlink") {
-      if (targetPaths.has(entry.path)) await target.rm(entry.path, { force: true });
+      if (targetPaths.has(entry.path))
+        await target.rm(entry.path, { force: true });
       await target.symlink(entry.target, entry.path);
     } else {
       await target.writeFile(entry.path, entry.content);

--- a/packages/vercel-sandbox-mock/src/server/tar.test.ts
+++ b/packages/vercel-sandbox-mock/src/server/tar.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, test } from "vitest";
 import { pack } from "tar-stream";
 import { extractTarGz } from "./tar";
 
-function gzipTar(files: { name: string; content: Buffer; mode?: number }[]): Promise<Buffer> {
+function gzipTar(
+  files: { name: string; content: Buffer; mode?: number }[],
+): Promise<Buffer> {
   const p = pack();
   for (const f of files) p.entry({ name: f.name, mode: f.mode }, f.content);
   p.finalize();
@@ -20,19 +22,27 @@ describe("extractTarGz", () => {
   test("round-trips file names, content, and modes", async () => {
     const body = await gzipTar([
       { name: "tmp/a.txt", content: Buffer.from("hello") },
-      { name: "tmp/nested/b.bin", content: Buffer.from([0, 255, 128]), mode: 0o755 },
+      {
+        name: "tmp/nested/b.bin",
+        content: Buffer.from([0, 255, 128]),
+        mode: 0o755,
+      },
     ]);
     const entries = await extractTarGz(body);
     const byName = new Map(entries.map((e) => [e.name, e]));
 
     expect(byName.get("tmp/a.txt")?.content.toString()).toBe("hello");
-    expect([...(byName.get("tmp/nested/b.bin")?.content ?? [])]).toEqual([0, 255, 128]);
+    expect([...(byName.get("tmp/nested/b.bin")?.content ?? [])]).toEqual([
+      0, 255, 128,
+    ]);
     expect(byName.get("tmp/nested/b.bin")?.mode).toBe(0o755);
   });
 
   test("preserves binary content exactly", async () => {
     const content = Buffer.from([0x00, 0xff, 0xfe, 0x80, 0x41]);
-    const [entry] = await extractTarGz(await gzipTar([{ name: "bin", content }]));
+    const [entry] = await extractTarGz(
+      await gzipTar([{ name: "bin", content }]),
+    );
     expect(entry.content).toEqual(content);
   });
 });

--- a/packages/vercel-sandbox-mock/src/server/user-commands.ts
+++ b/packages/vercel-sandbox-mock/src/server/user-commands.ts
@@ -40,22 +40,28 @@ export function buildUserCommands(state: UserState): Command[] {
     return state.users.get(user)?.group;
   };
 
-  const id = defineCommand("id", async (args: string[]): Promise<ExecResult> => {
-    const flag = args.find((a) => a.startsWith("-")) ?? "";
-    const target = positionals(args, new Set())[0] ?? state.defaultUser;
-    if (!exists(target)) return fail(`id: ‘${target}’: no such user`);
-    if (flag.includes("g")) {
-      const group = primaryGroup(target);
-      return group ? ok(`${group}\n`) : fail(`id: ‘${target}’: no such user`);
-    }
-    // Default and `-u`: report the login name.
-    return ok(`${target}\n`);
-  });
+  const id = defineCommand(
+    "id",
+    async (args: string[]): Promise<ExecResult> => {
+      const flag = args.find((a) => a.startsWith("-")) ?? "";
+      const target = positionals(args, new Set())[0] ?? state.defaultUser;
+      if (!exists(target)) return fail(`id: ‘${target}’: no such user`);
+      if (flag.includes("g")) {
+        const group = primaryGroup(target);
+        return group ? ok(`${group}\n`) : fail(`id: ‘${target}’: no such user`);
+      }
+      // Default and `-u`: report the login name.
+      return ok(`${target}\n`);
+    },
+  );
 
   const useradd = defineCommand(
     "useradd",
     async (args: string[], ctx: CommandContext): Promise<ExecResult> => {
-      const username = positionals(args, new Set(["-s", "-g", "-G", "-u", "-d"]))[0];
+      const username = positionals(
+        args,
+        new Set(["-s", "-g", "-G", "-u", "-d"]),
+      )[0];
       if (!username) return fail("useradd: missing operand");
       if (state.users.has(username)) {
         return fail(`useradd: user '${username}' already exists`, 9);
@@ -70,45 +76,57 @@ export function buildUserCommands(state: UserState): Command[] {
     },
   );
 
-  const groupadd = defineCommand("groupadd", async (args: string[]): Promise<ExecResult> => {
-    const groupname = positionals(args, new Set(["-g"]))[0];
-    if (!groupname) return fail("groupadd: missing operand");
-    if (state.groups.has(groupname)) {
-      return fail(`groupadd: group '${groupname}' already exists`, 9);
-    }
-    state.groups.set(groupname, new Set());
-    return ok();
-  });
+  const groupadd = defineCommand(
+    "groupadd",
+    async (args: string[]): Promise<ExecResult> => {
+      const groupname = positionals(args, new Set(["-g"]))[0];
+      if (!groupname) return fail("groupadd: missing operand");
+      if (state.groups.has(groupname)) {
+        return fail(`groupadd: group '${groupname}' already exists`, 9);
+      }
+      state.groups.set(groupname, new Set());
+      return ok();
+    },
+  );
 
-  const usermod = defineCommand("usermod", async (args: string[]): Promise<ExecResult> => {
-    // usermod -aG <group> <user>
-    const rest = positionals(args, new Set());
-    const [groupname, username] = rest;
-    const members = groupname ? state.groups.get(groupname) : undefined;
-    if (!members) {
-      return fail(`usermod: group '${groupname}' does not exist`, 6);
-    }
-    if (!username || !exists(username)) {
-      return fail(`usermod: user '${username}' does not exist`, 6);
-    }
-    members.add(username);
-    return ok();
-  });
+  const usermod = defineCommand(
+    "usermod",
+    async (args: string[]): Promise<ExecResult> => {
+      // usermod -aG <group> <user>
+      const rest = positionals(args, new Set());
+      const [groupname, username] = rest;
+      const members = groupname ? state.groups.get(groupname) : undefined;
+      if (!members) {
+        return fail(`usermod: group '${groupname}' does not exist`, 6);
+      }
+      if (!username || !exists(username)) {
+        return fail(`usermod: user '${username}' does not exist`, 6);
+      }
+      members.add(username);
+      return ok();
+    },
+  );
 
-  const gpasswd = defineCommand("gpasswd", async (args: string[]): Promise<ExecResult> => {
-    // gpasswd -d <user> <group>
-    const rest = positionals(args, new Set());
-    const [username, groupname] = rest;
-    const members = groupname ? state.groups.get(groupname) : undefined;
-    if (!members) {
-      return fail(`gpasswd: group '${groupname}' does not exist`, 1);
-    }
-    if (!username || !members.has(username)) {
-      return fail(`gpasswd: user '${username}' is not a member of '${groupname}'`, 3);
-    }
-    members.delete(username);
-    return ok();
-  });
+  const gpasswd = defineCommand(
+    "gpasswd",
+    async (args: string[]): Promise<ExecResult> => {
+      // gpasswd -d <user> <group>
+      const rest = positionals(args, new Set());
+      const [username, groupname] = rest;
+      const members = groupname ? state.groups.get(groupname) : undefined;
+      if (!members) {
+        return fail(`gpasswd: group '${groupname}' does not exist`, 1);
+      }
+      if (!username || !members.has(username)) {
+        return fail(
+          `gpasswd: user '${username}' is not a member of '${groupname}'`,
+          3,
+        );
+      }
+      members.delete(username);
+      return ok();
+    },
+  );
 
   // just-bash has no real ownership; chown is accepted as a no-op so the SDK's
   // exitCode checks pass. `chmod` is provided natively by just-bash.

--- a/packages/vercel-sandbox-mock/src/setup.test.ts
+++ b/packages/vercel-sandbox-mock/src/setup.test.ts
@@ -5,7 +5,9 @@ import { command, setupSandbox } from "./index";
 describe("command stubbing", () => {
   // Baseline handlers registered once, MSW-style, so `resetHandlers` must
   // preserve them across tests.
-  const server = setupSandbox(command("npm install", { stdout: "installed\n" }));
+  const server = setupSandbox(
+    command("npm install", { stdout: "installed\n" }),
+  );
   afterEach(() => server.resetHandlers());
 
   test("a default handler overrides just-bash for a matching command", async () => {
@@ -18,13 +20,18 @@ describe("command stubbing", () => {
   test("use() registers a per-test handler that takes priority", async () => {
     server.use(command("deploy", { stdout: "deployed\n" }));
     const sandbox = await Sandbox.create();
-    expect(await (await sandbox.runCommand("deploy", [])).stdout()).toContain("deployed");
+    expect(await (await sandbox.runCommand("deploy", [])).stdout()).toContain(
+      "deployed",
+    );
     await sandbox.stop();
   });
 
   test("a regex handler can compute a response from args", async () => {
     server.use(
-      command(/^echo-json/, (args) => ({ stdout: JSON.stringify(args), exitCode: 0 })),
+      command(/^echo-json/, (args) => ({
+        stdout: JSON.stringify(args),
+        exitCode: 0,
+      })),
     );
     const sandbox = await Sandbox.create();
     const result = await sandbox.runCommand("echo-json", ["a", "b"]);
@@ -37,7 +44,9 @@ describe("command stubbing", () => {
     server.resetHandlers();
     const sandbox = await Sandbox.create();
     // The per-test override is gone, but the module-scope default persists.
-    expect(await (await sandbox.runCommand("npm", ["install"])).stdout()).toContain("installed");
+    expect(
+      await (await sandbox.runCommand("npm", ["install"])).stdout(),
+    ).toContain("installed");
     await sandbox.stop();
   });
 
@@ -47,7 +56,9 @@ describe("command stubbing", () => {
     const sandbox = await Sandbox.create();
     // With the override cleared and no baseline stub for `echo`, real
     // just-bash `echo` runs again.
-    expect(await (await sandbox.runCommand("echo", ["real"])).stdout()).toBe("real\n");
+    expect(await (await sandbox.runCommand("echo", ["real"])).stdout()).toBe(
+      "real\n",
+    );
     await sandbox.stop();
   });
 });

--- a/packages/vercel-sandbox-mock/src/snapshot.test.ts
+++ b/packages/vercel-sandbox-mock/src/snapshot.test.ts
@@ -11,12 +11,12 @@ describe("Snapshot (real SDK over mock fetch)", () => {
     await sandbox.fs.writeFile("/tmp/state.txt", "captured");
     const snapshot = await sandbox.snapshot();
 
-    expect((await sandbox.listSnapshots()).snapshots.map((s) => s.id)).toContain(
-      snapshot.snapshotId,
-    );
-    expect((await Snapshot.list({ name })).snapshots.map((s) => s.id)).toContain(
-      snapshot.snapshotId,
-    );
+    expect(
+      (await sandbox.listSnapshots()).snapshots.map((s) => s.id),
+    ).toContain(snapshot.snapshotId);
+    expect(
+      (await Snapshot.list({ name })).snapshots.map((s) => s.id),
+    ).toContain(snapshot.snapshotId);
 
     const got = await Snapshot.get({ snapshotId: snapshot.snapshotId });
     expect(got.sourceSessionId).toBe(snapshot.sourceSessionId);
@@ -29,7 +29,9 @@ describe("Snapshot (real SDK over mock fetch)", () => {
   });
 
   test("a sandbox created from a snapshot restores its filesystem", async () => {
-    const sandbox = await Sandbox.create({ name: `snap-src-${randomUUID().slice(0, 8)}` });
+    const sandbox = await Sandbox.create({
+      name: `snap-src-${randomUUID().slice(0, 8)}`,
+    });
     await sandbox.fs.writeFile("/tmp/seed.txt", "from-snapshot");
     const snapshot = await sandbox.snapshot();
 
@@ -37,7 +39,9 @@ describe("Snapshot (real SDK over mock fetch)", () => {
       name: `snap-dst-${randomUUID().slice(0, 8)}`,
       source: { type: "snapshot", snapshotId: snapshot.snapshotId },
     });
-    expect(await restored.fs.readFile("/tmp/seed.txt", "utf8")).toBe("from-snapshot");
+    expect(await restored.fs.readFile("/tmp/seed.txt", "utf8")).toBe(
+      "from-snapshot",
+    );
     await sandbox.delete();
     await restored.delete();
   });

--- a/packages/vercel-sandbox-mock/src/snapshot.ts
+++ b/packages/vercel-sandbox-mock/src/snapshot.ts
@@ -11,7 +11,9 @@ type TreeParams = Parameters<typeof RealSnapshot.tree>[0];
  * in-memory {@link MockServer}.
  */
 export class Snapshot extends RealSnapshot {
-  static override list(params?: ListParams): ReturnType<typeof RealSnapshot.list> {
+  static override list(
+    params?: ListParams,
+  ): ReturnType<typeof RealSnapshot.list> {
     return RealSnapshot.list(withMockDefaults(params) as ListParams);
   }
 
@@ -19,7 +21,9 @@ export class Snapshot extends RealSnapshot {
     return RealSnapshot.get(withMockDefaults(params) as GetParams);
   }
 
-  static override tree(params: TreeParams): ReturnType<typeof RealSnapshot.tree> {
+  static override tree(
+    params: TreeParams,
+  ): ReturnType<typeof RealSnapshot.tree> {
     return RealSnapshot.tree(withMockDefaults(params) as TreeParams);
   }
 }

--- a/packages/vercel-sandbox-mock/src/test-scenarios.ts
+++ b/packages/vercel-sandbox-mock/src/test-scenarios.ts
@@ -29,13 +29,23 @@ export async function expectForkToPreserveSnapshotFileSystem(
       name: `fork-target-${suffix}`,
     });
 
-    expect(await fork.fs.readFile("/tmp/tree/nested/payload.bin")).toEqual(binary);
+    expect(await fork.fs.readFile("/tmp/tree/nested/payload.bin")).toEqual(
+      binary,
+    );
     expect((await fork.fs.stat("/tmp/tree/run.sh")).mode & 0o777).toBe(0o755);
-    expect((await fork.fs.lstat("/tmp/tree/payload-link")).isSymbolicLink()).toBe(true);
-    expect(await fork.fs.readlink("/tmp/tree/payload-link")).toBe("nested/payload.bin");
+    expect(
+      (await fork.fs.lstat("/tmp/tree/payload-link")).isSymbolicLink(),
+    ).toBe(true);
+    expect(await fork.fs.readlink("/tmp/tree/payload-link")).toBe(
+      "nested/payload.bin",
+    );
     expect(await fork.fs.readFile("/tmp/tree/payload-link")).toEqual(binary);
     expect(await fork.fs.exists("/tmp/tree/after-snapshot.txt")).toBe(false);
   } finally {
-    await Promise.allSettled([fork?.delete(), snapshot?.delete(), source.delete()]);
+    await Promise.allSettled([
+      fork?.delete(),
+      snapshot?.delete(),
+      source.delete(),
+    ]);
   }
 }

--- a/packages/vercel-sandbox-mock/tests/command.test.ts
+++ b/packages/vercel-sandbox-mock/tests/command.test.ts
@@ -20,7 +20,10 @@ describe("Command (real SDK over mock fetch)", () => {
   });
 
   test("separates stdout and stderr", async () => {
-    const result = await sandbox.runCommand("sh", ["-c", "echo out; echo err >&2"]);
+    const result = await sandbox.runCommand("sh", [
+      "-c",
+      "echo out; echo err >&2",
+    ]);
     expect(await result.stdout()).toContain("out");
     expect(await result.stderr()).toContain("err");
     expect(await result.output()).toContain("out");
@@ -39,7 +42,11 @@ describe("Command (real SDK over mock fetch)", () => {
         cb();
       },
     });
-    await sandbox.runCommand({ cmd: "echo", args: ["piped"], stdout: writable });
+    await sandbox.runCommand({
+      cmd: "echo",
+      args: ["piped"],
+      stdout: writable,
+    });
     expect(chunks.join("")).toContain("piped");
   });
 });

--- a/packages/vercel-sandbox-mock/tests/filesystem.test.ts
+++ b/packages/vercel-sandbox-mock/tests/filesystem.test.ts
@@ -17,7 +17,9 @@ describe("FileSystem (real SDK over mock fetch)", () => {
     await sandbox.fs.mkdir(root, { recursive: true });
     await sandbox.fs.writeFile(`${root}/text.txt`, "héllo");
     expect(await sandbox.fs.readFile(`${root}/text.txt`, "utf8")).toBe("héllo");
-    expect(await sandbox.fs.readFile(`${root}/text.txt`)).toEqual(Buffer.from("héllo"));
+    expect(await sandbox.fs.readFile(`${root}/text.txt`)).toEqual(
+      Buffer.from("héllo"),
+    );
   });
 
   test("appendFile appends", async () => {
@@ -29,7 +31,9 @@ describe("FileSystem (real SDK over mock fetch)", () => {
   test("exists reflects presence; missing reads throw ENOENT", async () => {
     expect(await sandbox.fs.exists(`${root}/text.txt`)).toBe(true);
     expect(await sandbox.fs.exists(`${root}/missing`)).toBe(false);
-    await expect(sandbox.fs.readFile(`${root}/missing`)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(sandbox.fs.readFile(`${root}/missing`)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   test("rm recursive removes a tree", async () => {

--- a/packages/vercel-sandbox-mock/tests/sandbox-user.test.ts
+++ b/packages/vercel-sandbox-mock/tests/sandbox-user.test.ts
@@ -7,7 +7,9 @@ const userName = () => `u${randomUUID().slice(0, 8).replace(/-/g, "")}`;
 describe("SandboxUser (real SDK over mock fetch)", () => {
   let sandbox: Sandbox;
   beforeAll(async () => {
-    sandbox = await Sandbox.create({ name: `user-${randomUUID().slice(0, 8)}` });
+    sandbox = await Sandbox.create({
+      name: `user-${randomUUID().slice(0, 8)}`,
+    });
   });
   afterAll(async () => {
     await sandbox.stop();

--- a/packages/vercel-sandbox/src/api-client/api-error.ts
+++ b/packages/vercel-sandbox/src/api-client/api-error.ts
@@ -12,7 +12,7 @@ export class APIError<ErrorData> extends Error {
   public json?: ErrorData;
   public text?: string;
   public sandboxName?: string;
-  public sessionId?: string
+  public sessionId?: string;
 
   constructor(response: Response, options?: Options<ErrorData>) {
     super(response.statusText);

--- a/packages/vercel-sandbox/src/api-client/base-client.ts
+++ b/packages/vercel-sandbox/src/api-client/base-client.ts
@@ -102,7 +102,9 @@ function extractSessionId(url: string): string | undefined {
  * Excludes known sub-paths like /sessions/ and /snapshots/.
  */
 function extractSandboxName(url: string): string | undefined {
-  const match = url.match(/\/v2\/sandboxes\/(?!sessions(?:\/|$|\?))(?!snapshots(?:\/|$|\?))([^/?]+)/);
+  const match = url.match(
+    /\/v2\/sandboxes\/(?!sessions(?:\/|$|\?))(?!snapshots(?:\/|$|\?))([^/?]+)/,
+  );
   return match?.[1];
 }
 
@@ -127,7 +129,7 @@ export async function parse<Data, ErrorData>(
     return new APIError<ErrorData>(response, {
       message: `Can't read response text: ${String(err)}`,
       sessionId,
-      sandboxName
+      sandboxName,
     });
   });
 
@@ -144,7 +146,7 @@ export async function parse<Data, ErrorData>(
       message: `Can't parse JSON: ${String(error)}`,
       text,
       sessionId,
-      sandboxName
+      sandboxName,
     });
   }
 
@@ -154,7 +156,7 @@ export async function parse<Data, ErrorData>(
       json: json as ErrorData,
       text,
       sessionId,
-      sandboxName
+      sandboxName,
     });
   }
 
@@ -165,7 +167,7 @@ export async function parse<Data, ErrorData>(
       json: json as ErrorData,
       text,
       sessionId,
-      sandboxName
+      sandboxName,
     });
   }
 

--- a/packages/vercel-sandbox/src/auth/infer-scope.test.ts
+++ b/packages/vercel-sandbox/src/auth/infer-scope.test.ts
@@ -477,7 +477,8 @@ describe("inferScope", () => {
         if (endpoint.includes("teamId=team_blocked")) {
           throw new NotOk({
             statusCode: 402,
-            responseText: "RESOURCE_CREATION_BLOCKED: Your Team encountered an unknown problem.",
+            responseText:
+              "RESOURCE_CREATION_BLOCKED: Your Team encountered an unknown problem.",
           });
         }
         return {};

--- a/packages/vercel-sandbox/src/auth/project.ts
+++ b/packages/vercel-sandbox/src/auth/project.ts
@@ -42,7 +42,10 @@ const DEFAULT_PROJECT_NAME = "vercel-sandbox-default-project";
 
 /** Status codes that mean "this team can't be used, try the next one". */
 function isSkippableTeamError(e: unknown): boolean {
-  return e instanceof NotOk && (e.response.statusCode === 402 || e.response.statusCode === 403);
+  return (
+    e instanceof NotOk &&
+    (e.response.statusCode === 402 || e.response.statusCode === 403)
+  );
 }
 
 /**
@@ -124,9 +127,7 @@ export async function inferScope(opts: {
   let next: number | null = null;
   do {
     const endpoint: string =
-      next === null
-        ? "/v2/teams?limit=20"
-        : `/v2/teams?limit=20&until=${next}`;
+      next === null ? "/v2/teams?limit=20" : `/v2/teams?limit=20&until=${next}`;
     const page = await fetchApi({ token: opts.token, endpoint }).then(
       TeamsSchema.parse,
     );
@@ -142,7 +143,9 @@ export async function inferScope(opts: {
 
     const bestHobbyTeam =
       hobbyOwnerTeams.find((t) => t.slug === username) ??
-      hobbyOwnerTeams.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))[0];
+      hobbyOwnerTeams.sort(
+        (a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0),
+      )[0];
 
     if (bestHobbyTeam && bestHobbyTeam.id !== defaultTeamId) {
       try {

--- a/packages/vercel-sandbox/src/command.ts
+++ b/packages/vercel-sandbox/src/command.ts
@@ -1,8 +1,5 @@
 import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from "@workflow/serde";
-import {
-  APIClient,
-  type CommandData,
-} from "./api-client/index.js";
+import { APIClient, type CommandData } from "./api-client/index.js";
 import { getCredentials } from "./utils/get-credentials.js";
 import { resolveSignal, type Signal } from "./utils/resolveSignal.js";
 

--- a/packages/vercel-sandbox/src/index.ts
+++ b/packages/vercel-sandbox/src/index.ts
@@ -11,10 +11,7 @@ export {
   type NetworkTransformer,
 } from "./session.js";
 export type { SerializedSandbox } from "./sandbox.js";
-export {
-  SandboxUser,
-  SandboxUserAlreadyExistsError,
-} from "./sandbox-user.js";
+export { SandboxUser, SandboxUserAlreadyExistsError } from "./sandbox-user.js";
 export type { ExecutionContext } from "./execution-context.js";
 export { Snapshot } from "./snapshot.js";
 export type { SerializedSnapshot } from "./snapshot.js";

--- a/packages/vercel-sandbox/src/network-policy.ts
+++ b/packages/vercel-sandbox/src/network-policy.ts
@@ -14,16 +14,19 @@ export type NetworkTransformer = {
 /**
  * Defines how a request value is matched.
  */
-export type NetworkPolicyMatcher = {
-  /** Match the value exactly. */
-  exact?: string;
-} | {
-  /** Match values that start with the provided prefix. */
-  startsWith?: string;
-} | {
-  /** Match values against an RE2 regular expression. */
-  regex?: string;
-};
+export type NetworkPolicyMatcher =
+  | {
+      /** Match the value exactly. */
+      exact?: string;
+    }
+  | {
+      /** Match values that start with the provided prefix. */
+      startsWith?: string;
+    }
+  | {
+      /** Match values against an RE2 regular expression. */
+      regex?: string;
+    };
 
 /**
  * Matcher for key/value request entries such as headers and query parameters.

--- a/packages/vercel-sandbox/src/proxy.test.ts
+++ b/packages/vercel-sandbox/src/proxy.test.ts
@@ -112,7 +112,9 @@ describe("defineSandboxProxy", () => {
     const handler = vi.fn(() => new Response("ok"));
     const proxy = defineSandboxProxy(handler);
 
-    await proxy(makeProxyRequest({ url: "https://proxy.vercel.app/some/path" }));
+    await proxy(
+      makeProxyRequest({ url: "https://proxy.vercel.app/some/path" }),
+    );
 
     expect(jwtVerifyMock).toHaveBeenCalledWith(
       "token_123",

--- a/packages/vercel-sandbox/src/snapshot.ts
+++ b/packages/vercel-sandbox/src/snapshot.ts
@@ -202,8 +202,9 @@ export class Snapshot {
    * ```
    */
   static async tree(
-    params: { snapshotId: string } &
-      Partial<Parameters<APIClient["getSnapshotTree"]>[0]> &
+    params: { snapshotId: string } & Partial<
+      Parameters<APIClient["getSnapshotTree"]>[0]
+    > &
       Partial<Credentials> &
       WithFetchOptions,
   ) {

--- a/packages/vercel-sandbox/src/utils/network-policy.test.ts
+++ b/packages/vercel-sandbox/src/utils/network-policy.test.ts
@@ -413,7 +413,9 @@ describe("fromAPINetworkPolicy", () => {
             match: {
               method: ["POST"],
               path: { startsWith: "/v1/" },
-              headers: [{ key: { exact: "x-route" }, value: { exact: "proxy" } }],
+              headers: [
+                { key: { exact: "x-route" }, value: { exact: "proxy" } },
+              ],
             },
             forwardURL: "https://proxy.example.com",
           },
@@ -430,7 +432,9 @@ describe("fromAPINetworkPolicy", () => {
             match: {
               method: ["POST"],
               path: { startsWith: "/v1/" },
-              headers: [{ key: { exact: "x-route" }, value: { exact: "proxy" } }],
+              headers: [
+                { key: { exact: "x-route" }, value: { exact: "proxy" } },
+              ],
             },
             forwardURL: "https://proxy.example.com",
           },

--- a/packages/vercel-sandbox/src/utils/network-policy.ts
+++ b/packages/vercel-sandbox/src/utils/network-policy.ts
@@ -12,9 +12,7 @@ export function toAPINetworkPolicy(
   policy: NetworkPolicy,
 ): APIRequestNetworkPolicy {
   const apiPolicy =
-    policy === "allow-all" || policy === "deny-all"
-      ? { mode: policy }
-      : policy;
+    policy === "allow-all" || policy === "deny-all" ? { mode: policy } : policy;
 
   NetworkPolicyRequestValidator.parse(apiPolicy);
   return apiPolicy;
@@ -70,7 +68,10 @@ export function fromAPINetworkPolicy(
       allow[domain] = rulesByDomain.get(domain) ?? [];
     }
     // Include L7 rules for domains not in allowedDomains
-    for (const rule of [...(api.injectionRules ?? []), ...(api.forwardRules ?? [])]) {
+    for (const rule of [
+      ...(api.injectionRules ?? []),
+      ...(api.forwardRules ?? []),
+    ]) {
       if (!(rule.domain in allow)) {
         allow[rule.domain] = rulesByDomain.get(rule.domain) ?? [];
       }

--- a/packages/vercel-sandbox/src/utils/paginator.test.ts
+++ b/packages/vercel-sandbox/src/utils/paginator.test.ts
@@ -101,7 +101,11 @@ describe("attachPaginator", () => {
   });
 
   it("stops iteration when signal is aborted between pages", async () => {
-    const pages = makePages([[1, 2], [3, 4], [5, 6]]);
+    const pages = makePages([
+      [1, 2],
+      [3, 4],
+      [5, 6],
+    ]);
     const controller = new AbortController();
     const fetchNext = vi.fn(async (cursor: string) => {
       if (cursor === "cursor-2") controller.abort();

--- a/packages/vercel-sandbox/src/utils/paginator.ts
+++ b/packages/vercel-sandbox/src/utils/paginator.ts
@@ -5,18 +5,22 @@ type CursorPaginationMeta = {
 
 type HasPagination = { pagination: CursorPaginationMeta };
 
-type ItemOf<Page, Key extends keyof Page> = Page[Key] extends Array<infer Item>
-  ? Item
-  : never;
+type ItemOf<Page, Key extends keyof Page> =
+  Page[Key] extends Array<infer Item> ? Item : never;
 
-export type Paginator<Page extends HasPagination, Key extends keyof Page> =
-  Page &
-    AsyncIterable<ItemOf<Page, Key>> & {
-      pages(): AsyncIterable<Page>;
-      toArray(): Promise<ItemOf<Page, Key>[]>;
-    };
+export type Paginator<
+  Page extends HasPagination,
+  Key extends keyof Page,
+> = Page &
+  AsyncIterable<ItemOf<Page, Key>> & {
+    pages(): AsyncIterable<Page>;
+    toArray(): Promise<ItemOf<Page, Key>[]>;
+  };
 
-type AttachPaginatorOptions<Page extends HasPagination, Key extends keyof Page> = {
+type AttachPaginatorOptions<
+  Page extends HasPagination,
+  Key extends keyof Page,
+> = {
   itemsKey: Key;
   fetchNext: (cursor: string) => Promise<Page>;
   signal?: AbortSignal;

--- a/packages/vercel-sandbox/src/utils/validate-name.test.ts
+++ b/packages/vercel-sandbox/src/utils/validate-name.test.ts
@@ -23,7 +23,9 @@ describe("validateName", () => {
   });
 
   it("rejects names with an invalid regex", () => {
-    expect(() => validateName("INVALID_REGEX", "username")).toThrow("Invalid username");
+    expect(() => validateName("INVALID_REGEX", "username")).toThrow(
+      "Invalid username",
+    );
   });
 
   it("rejects names that do not start with a letter or underscore", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       lint-staged:
         specifier: 9.2.5
         version: 9.2.5
+      oxfmt:
+        specifier: 0.62.0
+        version: 0.62.0
       prettier:
         specifier: 3.5.3
         version: 3.5.3
@@ -1719,6 +1722,128 @@ packages:
 
   '@oxc-project/types@0.98.0':
     resolution: {integrity: sha512-Vzmd6FsqVuz5HQVcRC/hrx7Ujo3WEVeQP7C2UNP5uy1hUY4SQvMB+93jxkI1KRHz9a/6cni3glPOtvteN+zpsw==}
+
+  '@oxfmt/binding-android-arm-eabi@0.62.0':
+    resolution: {integrity: sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.62.0':
+    resolution: {integrity: sha512-WC3YQ7uS/KtDrjmqwBviwFKe9qeoi+eXx8aX1z/ffG23Md75myjrJaQqTuJvdOLPoa4EYTjDWH0dHXfwulCVog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.62.0':
+    resolution: {integrity: sha512-GM8Yf3LjjaR1I8PD0SfeoIlwhsh9GvSF+cQ8sf624Yxnjsyumn95aFzYfKJVefblfDIiOAnZ7QVm2sa21Er/0Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.62.0':
+    resolution: {integrity: sha512-d5THp7F8bCxLqNogEXDORRsQD6dosf3EyFtnXfBer6v+8tGdcWIjoDX9WaXrrF/26zOmL8qHpPTKCEvpBDmZkQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.62.0':
+    resolution: {integrity: sha512-1DnrtXGZooOZ0fHgAXZUaDQzBVh1CM2MNW4oBXyQ2aWKvCHjyljvT9fgBkOM0fEOb96X5eqtcfJ0YUVt9jj66g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.62.0':
+    resolution: {integrity: sha512-4pQDHOYRH+Huqe0StIaWyvk2CVl/aTaqSrbZpA3/pLS2xH24ME7lBgYprhQF2fRkHBzhGGGKliwxFsDdHwx59g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.62.0':
+    resolution: {integrity: sha512-X0jAaZJFMCVKhB6YyWVTQ/wN2DLsBcZKSMqTS76bF6riT+XZdtg2FPEdjDvdVbunO9cG+tWiVaEs4Zs38lxYog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.62.0':
+    resolution: {integrity: sha512-682Z8T5s8T5ATArYtsejKvbIfd8LEAXyyDkKkoZVq8HND7Vx8TYLlrDjDSeYfodMeVwHOgkj13lJYR8cj6vUSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.62.0':
+    resolution: {integrity: sha512-lk25fAl7KWaLWVJcW0CHEXB7QlQZtx5eDkjpaGMK0hzXTjUe0Wmlu8IKuFHoviSOcEJedRTs4VE/506VqGxGew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.62.0':
+    resolution: {integrity: sha512-SFyNqHQLwySceWNLhiSldx7wPXRAzP0L0WcW9GegP3uWrpZGJiZlQO85NbHAFPEfxR9PhZ9qSnZryEh7+v+4Gw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.62.0':
+    resolution: {integrity: sha512-KYj55C1ywJfHo6+aKDuEmUtVEdJALsC5GwayDGsI6FGz2GxFqNr/mA8nxVsNbJzm7sE5MRqTQ9ziImSzhYXysA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.62.0':
+    resolution: {integrity: sha512-BhZDNo5GOU5nC378RhD0/XpvaEBHsH3HLgJp8YZX3A0InC7oivzA63HsRmiXFLtLSHAstEVrDf6fbC7Rs8Jh/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.62.0':
+    resolution: {integrity: sha512-UyAFmyHkgSgUJ/wOM4p3U8AC2yAFvRH5PNBs7TnK0fObTT/XSWcdr/lAzPSWaekHaZFaMeFZyk9n93Joq3J93A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.62.0':
+    resolution: {integrity: sha512-1iYMP0leytWazFubD/WnINJuIrzRPuoL1aWEJdlGezEzDbTxcd29R4r8IUzP2oWeKst5V02uMJgR2NILlPlG6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.62.0':
+    resolution: {integrity: sha512-4rA/URtJSTVNVAQz6Q8wf7SaRvOXVy+TizriT9hs/Y1XhLR/R+92uWKRQG8yFWRAIEBbFHJ6WevQcl/G9SXEfw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.62.0':
+    resolution: {integrity: sha512-mSZuFHU2ar1KLUjXpI2QBQcJ1VsOB3mOCgQXuXCpKs19dgh4u+OaovNfrWDfiJb+ihJ2+f7YFcaO9bS2dlTCXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.62.0':
+    resolution: {integrity: sha512-OfwuhkcjDlqC4EgDojtiV9mzpLqeB9KqTOWPOjLEYBVdDCVSxqW3qzp/xcIxsbtI0UgGCnKvAqYKyY25kf5JZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.62.0':
+    resolution: {integrity: sha512-P9uDDNFRzghO3X8QAzhkjKhK7JvtABsVn8UYtFX7uor12IAnwNt8nNIctvfWj1JkQU/kE+fmLRPiw7XlrIHsZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.62.0':
+    resolution: {integrity: sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@quansync/fs@0.1.5':
     resolution: {integrity: sha512-lNS9hL2aS2NZgNW7BBj+6EBl4rOf8l+tQ0eRY6JWCI8jI2kc53gSoqbjojU0OnAWhzoXiOjFyGsHcDGePB3lhA==}
@@ -4911,6 +5036,19 @@ packages:
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
+  oxfmt@0.62.0:
+    resolution: {integrity: sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
+
   p-cancelable@3.0.0:
     resolution: {integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==}
     engines: {node: '>=12.20'}
@@ -5736,6 +5874,10 @@ packages:
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
@@ -7397,6 +7539,63 @@ snapshots:
   '@oxc-project/runtime@0.96.0': {}
 
   '@oxc-project/types@0.98.0': {}
+
+  '@oxfmt/binding-android-arm-eabi@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.62.0':
+    optional: true
 
   '@quansync/fs@0.1.5':
     dependencies:
@@ -11144,6 +11343,30 @@ snapshots:
 
   outdent@0.5.0: {}
 
+  oxfmt@0.62.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.62.0
+      '@oxfmt/binding-android-arm64': 0.62.0
+      '@oxfmt/binding-darwin-arm64': 0.62.0
+      '@oxfmt/binding-darwin-x64': 0.62.0
+      '@oxfmt/binding-freebsd-x64': 0.62.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.62.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.62.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.62.0
+      '@oxfmt/binding-linux-arm64-musl': 0.62.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.62.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.62.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.62.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.62.0
+      '@oxfmt/binding-linux-x64-gnu': 0.62.0
+      '@oxfmt/binding-linux-x64-musl': 0.62.0
+      '@oxfmt/binding-openharmony-arm64': 0.62.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.62.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.62.0
+      '@oxfmt/binding-win32-x64-msvc': 0.62.0
+
   p-cancelable@3.0.0: {}
 
   p-filter@2.1.0:
@@ -12086,6 +12309,8 @@ snapshots:
       picomatch: 4.0.4
 
   tinypool@1.1.1: {}
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@2.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,15 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-catalogs:
-  default:
-    tsdown:
-      specifier: 0.16.6
-      version: 0.16.6
-    vitest:
-      specifier: 3.2.1
-      version: 3.2.1
-
 importers:
 
   .:
@@ -36,9 +27,6 @@ importers:
       oxfmt:
         specifier: 0.62.0
         version: 0.62.0
-      prettier:
-        specifier: 3.5.3
-        version: 3.5.3
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.3)(@types/node@24.10.1)(typescript@5.8.3)
@@ -5218,11 +5206,6 @@ packages:
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
-    hasBin: true
-
-  prettier@3.5.3:
-    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
-    engines: {node: '>=14'}
     hasBin: true
 
   prismjs@1.27.0:
@@ -11533,8 +11516,6 @@ snapshots:
     optional: true
 
   prettier@2.8.8: {}
-
-  prettier@3.5.3: {}
 
   prismjs@1.27.0: {}
 


### PR DESCRIPTION
## Problem

The repo has no formatting gate. Prettier is wired into a `pre-commit` hook, but nothing verifies formatting in CI, so files drift out of shape and PRs end up carrying whitespace-only churn alongside real changes. 68 committed JS/TS files were already not formatted.

## Change

Replace Prettier with [oxfmt](https://oxc.rs/docs/guide/usage/formatter) (the oxc formatter) as the repo's only formatter, and fail CI when anything isn't formatted.

- **`.oxfmtrc.json`** — oxfmt covers every file type it understands: JS, TS, JSON, Markdown, YAML, CSS. `ignorePatterns` only excludes build output (`dist`, `.next`, `.turbo`, …); oxfmt already skips lockfiles, dot-directories and file types it doesn't handle (binaries, SVG). 289 files are covered.
- **Prettier removed** — the `prettier` devDependency is gone, along with its lint-staged entry and the CONTRIBUTING reference. The only `prettier` left in the lockfile is 2.8.8, vendored inside `@changesets/write`.
- **Scripts** — `pnpm run format` and `pnpm run format:check` at the root.
- **CI** — a new `Format` workflow runs `pnpm run format:check` on every pull request and on pushes to `main`. It's a separate job from `Publish` so formatting feedback is fast and a format failure can't wedge a release.
- **lint-staged** — collapsed to a single `*` group running `oxfmt`. Since oxfmt no-ops on unsupported files, the glob doesn't need to enumerate extensions, and one group removes the concurrent `git add` race the two groups had.
- **Reformat** — the 68 JS/TS files that weren't already formatted.

## Two config choices worth a look

**`printWidth: 80`** rather than oxfmt's default of `100`. 80 matches the repo's existing Prettier-formatted style; 100 would have reflowed ~123 files (−1200 net lines) instead of 68. Easy to flip later as its own PR.

**`sortPackageJson: false`** — this defaults to `true` and reorders `package.json` keys *and* sorts dependency lists. That's a source transformation rather than formatting, it's not something Prettier ever did, and it would make the changesets release PR fail the format check whenever it rewrote a manifest. Left off deliberately.

## Notes on the diff

The bulk of this PR is the mechanical JS/TS reformat. The reviewable part is `.oxfmtrc.json`, `package.json`, `.github/workflows/format.yml`, and `CONTRIBUTING.md`.

Most reformatted hunks are cases where oxfmt follows Prettier 3.6+'s ternary and type-parameter formatting while the repo is on Prettier 3.5.3 — plus a handful of lines that simply exceeded 80 columns and were never formatted at all. Dropping Prettier cost **zero** extra churn: every JSON, Markdown, YAML and CSS file in the repo already matched oxfmt's output.

## Verification

- `pnpm run format:check` — clean, 289 files
- `git diff --check` — clean
- `pnpm run build` (typecheck + build, 8 tasks) — passing
- `packages/vercel-sandbox-mock` tests — 195 passed, 86 skipped
- lint-staged exercised against staged `.ts`, `.json`, `.md` and `.yaml` (all formatted) and a binary `.ico` (untouched)

The `@vercel/sandbox` and `sandbox` test suites hit the real API and weren't run locally.