### PR TITLE
feat(images): track managed image packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,7 +13,7 @@
   "ignore": ["*-example"],
   "privatePackages": {
     "version": true,
-    "tag": false
+    "tag": true
   },
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,6 +11,10 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": ["*-example"],
+  "privatePackages": {
+    "version": true,
+    "tag": false
+  },
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }

--- a/.changeset/track-sandbox-images.md
+++ b/.changeset/track-sandbox-images.md
@@ -1,0 +1,4 @@
+---
+---
+
+Track private Sandbox image packages with Changesets at version 1.0.0.

--- a/.changeset/track-sandbox-images.md
+++ b/.changeset/track-sandbox-images.md
@@ -1,4 +1,9 @@
 ---
+"@vercel-managed-images/arch": major
+"@vercel-managed-images/node": major
+"@vercel-managed-images/python": major
+"@vercel-managed-images/ubuntu": major
+"@vercel-managed-images/universal": major
 ---
 
-Track private Sandbox image packages with Changesets at version 1.0.0.
+Release the Vercel Managed Images packages at version 1.0.0.

--- a/images/arch/CHANGELOG.md
+++ b/images/arch/CHANGELOG.md
@@ -1,4 +1,4 @@
-# sandbox-image-arch
+# @vercel-managed-images/arch
 
 ## 0.1.0
 

--- a/images/arch/package.json
+++ b/images/arch/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@vercel-managed-images/arch",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "private": true
 }

--- a/images/arch/package.json
+++ b/images/arch/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sandbox-image-arch",
-  "version": "0.1.0",
+  "name": "@vercel-managed-images/arch",
+  "version": "1.0.0",
   "private": true
 }

--- a/images/node/CHANGELOG.md
+++ b/images/node/CHANGELOG.md
@@ -1,4 +1,4 @@
-# sandbox-image-node
+# @vercel-managed-images/node
 
 ## 0.1.0
 

--- a/images/node/package.json
+++ b/images/node/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@vercel-managed-images/node",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "private": true
 }

--- a/images/node/package.json
+++ b/images/node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sandbox-image-node",
-  "version": "0.1.0",
+  "name": "@vercel-managed-images/node",
+  "version": "1.0.0",
   "private": true
 }

--- a/images/python/CHANGELOG.md
+++ b/images/python/CHANGELOG.md
@@ -1,4 +1,4 @@
-# sandbox-image-python
+# @vercel-managed-images/python
 
 ## 0.1.0
 

--- a/images/python/package.json
+++ b/images/python/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sandbox-image-python",
-  "version": "0.1.0",
+  "name": "@vercel-managed-images/python",
+  "version": "1.0.0",
   "private": true
 }

--- a/images/python/package.json
+++ b/images/python/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@vercel-managed-images/python",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "private": true
 }

--- a/images/ubuntu/CHANGELOG.md
+++ b/images/ubuntu/CHANGELOG.md
@@ -1,4 +1,4 @@
-# sandbox-image-ubuntu
+# @vercel-managed-images/ubuntu
 
 ## 0.1.0
 

--- a/images/ubuntu/package.json
+++ b/images/ubuntu/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@vercel-managed-images/ubuntu",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "private": true
 }

--- a/images/ubuntu/package.json
+++ b/images/ubuntu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sandbox-image-ubuntu",
-  "version": "0.1.0",
+  "name": "@vercel-managed-images/ubuntu",
+  "version": "1.0.0",
   "private": true
 }

--- a/images/universal/CHANGELOG.md
+++ b/images/universal/CHANGELOG.md
@@ -1,4 +1,4 @@
-# sandbox-image-universal
+# @vercel-managed-images/universal
 
 ## 0.1.0
 

--- a/images/universal/package.json
+++ b/images/universal/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@vercel-managed-images/universal",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "private": true
 }

--- a/images/universal/package.json
+++ b/images/universal/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sandbox-image-universal",
-  "version": "0.1.0",
+  "name": "@vercel-managed-images/universal",
+  "version": "1.0.0",
   "private": true
 }


### PR DESCRIPTION
## Summary

- rename image workspace packages under the `@vercel-managed-images` scope
- set each managed image package to version `1.0.0`
- enable Changesets version tracking for private packages
- update image changelog headings to match the scoped package names

## Verification

- `changeset status`
- `prettier --check .changeset/config.json .changeset/track-sandbox-images.md images/*/package.json images/*/CHANGELOG.md`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)