### PR TITLE
fix(images): pin exact Node versions

### DIFF
--- a/.changeset/bright-nodes-build.md
+++ b/.changeset/bright-nodes-build.md
@@ -1,0 +1,5 @@
+---
+"sandbox-image-node": patch
+---
+
+Pin exact Node.js versions during builds and publish exact-version image tags alongside the major-version tags.

--- a/images/docker-bake.hcl
+++ b/images/docker-bake.hcl
@@ -40,7 +40,10 @@ target "node" {
   name     = "node-${node.major}"
   inherits = ["_common"]
   context  = "node"
-  tags     = ["${REGISTRY}/node:${node.major}"]
+  tags = [
+    "${REGISTRY}/node:${node.major}",
+    "${REGISTRY}/node:${node.version}",
+  ]
 
   contexts = {
     base = "target:ubuntu"

--- a/images/docker-bake.hcl
+++ b/images/docker-bake.hcl
@@ -21,20 +21,33 @@ target "ubuntu" {
 
 target "node" {
   matrix = {
-    major = ["22", "24", "26"]
+    node = [
+      {
+        major   = "22"
+        version = "22.23.2"
+      },
+      {
+        major   = "24"
+        version = "24.19.0"
+      },
+      {
+        major   = "26"
+        version = "26.7.0"
+      },
+    ]
   }
 
-  name     = "node-${major}"
+  name     = "node-${node.major}"
   inherits = ["_common"]
   context  = "node"
-  tags     = ["${REGISTRY}/node:${major}"]
+  tags     = ["${REGISTRY}/node:${node.major}"]
 
   contexts = {
     base = "target:ubuntu"
   }
 
   args = {
-    NODE_MAJOR = major
+    NODE_VERSION = node.version
   }
 }
 

--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -7,11 +7,9 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl libarchive-tools && \
     rm -rf /var/lib/apt/lists/*
 
-ARG NODE_MAJOR
-RUN tarball="$(curl -fsSL "https://nodejs.org/dist/latest-v${NODE_MAJOR}.x/SHASUMS256.txt" \
-      | grep -oE 'node-v[0-9]+\.[0-9]+\.[0-9]+-linux-x64\.tar\.xz' | head -n1)" && \
-    mkdir -p /opt/node && \
-    curl -fsSL "https://nodejs.org/dist/latest-v${NODE_MAJOR}.x/${tarball}" \
+ARG NODE_VERSION
+RUN mkdir -p /opt/node && \
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
       | bsdtar -xJ --strip-components=1 -C /opt/node && \
     rm -f /opt/node/CHANGELOG.md /opt/node/LICENSE /opt/node/README.md
 

--- a/images/node/README.md
+++ b/images/node/README.md
@@ -2,16 +2,15 @@
 
 `vercel/sandbox/node:22` | `vercel/sandbox/node:24` | `vercel/sandbox/node:26`
 
-Node.js on top of the [ubuntu](../ubuntu) base image. Each tag pins a major version
-and installs the latest release of that line at build time, so tags roll
-forward with rebuilds.
+Node.js on top of the [ubuntu](../ubuntu) base image. Each tag pins a major version,
+with the exact release supplied to the build through `NODE_VERSION`.
 
 Runs as the default `ubuntu` user (uid 1000) with passwordless sudo.
 
 ## Packages
 
-- Node.js (latest release of the tag's major line), with `npm`, `npx` and
-  `corepack`
+- Node.js 22.23.2, 24.19.0, or 26.7.0 (depending on the image tag), with
+  `npm`, `npx` and `corepack`
 - `pnpm` 11
 - `git`
 - `libatomic1`


### PR DESCRIPTION
## Summary

- replace the Node image’s major-only build argument with exact `NODE_VERSION` values
- pin current Node 22, 24, and 26 releases in the Docker Bake matrix
- publish both major-version and exact-version image tags
- document the exact releases used by each image tag
- add a patch changeset for `sandbox-image-node`

## Verification

- rendered `images/docker-bake.hcl` with Docker Buildx Bake
- asserted Node 22.23.2, 24.19.0, and 26.7.0 args and tags
- verified each pinned Linux x64 tarball exists upstream
- `pnpm exec changeset status`

## Stack

Base PR for #280, which adds nightly automatic upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)