### PR TITLE
fix(sdk): lazy-load auth path dependency

### DIFF
--- a/.changeset/lazy-load-xdg-paths.md
+++ b/.changeset/lazy-load-xdg-paths.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Load CLI auth path discovery only when accessing the local auth configuration.

--- a/packages/vercel-sandbox/src/auth/file.ts
+++ b/packages/vercel-sandbox/src/auth/file.ts
@@ -1,9 +1,11 @@
 import path from "node:path";
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import { homedir } from "node:os";
-import XDGAppPaths from "xdg-app-paths";
 import { z } from "zod";
 import { json } from "./zod.js";
+
+type XDGAppPathsFactory = typeof import("xdg-app-paths");
 
 const ZodDate = z.number().transform((seconds) => new Date(seconds * 1000));
 
@@ -38,6 +40,8 @@ const getGlobalPathConfig = (): string => {
     return process.env.VERCEL_AUTH_CONFIG_DIR;
   }
 
+  const require = createRequire(import.meta.url);
+  const XDGAppPaths = require("xdg-app-paths") as XDGAppPathsFactory;
   const vercelDirectories = XDGAppPaths("com.vercel.cli").dataDirs();
 
   const possibleConfigPaths = [


### PR DESCRIPTION
## Summary

- lazy-load `xdg-app-paths` when Sandbox accesses local CLI auth
- preserve existing auth config path resolution
- apply the same import-safety fix in Sandbox defensively

## Production context

The observed Vade production failure originated from the separate `@vercel/cli-config` dependency path:

```text
@workflow/core
  → @vercel/functions
  → @vercel/oidc
  → @vercel/cli-config
  → xdg-app-paths@5.1.0
```

- [vercel/agents#2646](https://github.com/vercel/agents/pull/2646) removed the existing consumer-side patch; the subsequent Vade production deployment failed during page-data collection with `path.parse(undefined)`
- [vercel/agents#2649](https://github.com/vercel/agents/pull/2649) restored the lazy-import patch; the Vade production build and hosted deployment completed successfully
- [vercel/vercel-internal#177](https://github.com/vercel/vercel-internal/pull/177) applies the upstream fix in `@vercel/cli-config`

Sandbox was not the dependency responsible for that deployment failure. However, Sandbox independently depends on `xdg-app-paths@5.1.0` and eagerly imports it from its auth module, exposing the same import-time failure mode. This PR applies the equivalent fix here as a defensive measure in case Sandbox is evaluated in the same kind of entrypoint-less server build runtime.

## Root cause

`xdg-app-paths@5.1.0` constructs its default export at module load and calls `path.parse(require.main?.filename ?? process.argv[0])`. A server build worker with neither value can therefore fail while importing Sandbox, before Sandbox auth is used.

## Fix

Resolve `xdg-app-paths` inside `getGlobalPathConfig()` so the import-time side effect runs only when local CLI auth is accessed.
