### PR TITLE
feat(sandbox): open the account's login shell on connect

### DIFF
--- a/.changeset/eighty-donkeys-shave.md
+++ b/.changeset/eighty-donkeys-shave.md
@@ -1,0 +1,7 @@
+---
+"sandbox": minor
+---
+
+Interactive sessions started without a command (`sandbox connect`/`ssh`/`shell`, `sandbox create --connect`, `sandbox fork --connect`, `sandbox sh`) now open the shell the sandbox account declares in its passwd entry, as a login shell, instead of a hardcoded `sh`. An image that gives its user zsh — or installs the usual shell somewhere else — gets the shell the account actually configures, with its profile sourced.
+
+Adding `--sudo` opens the target account's login shell the same way (`sudo --login`), which starts in that account's home directory rather than `--workdir`. Explicit commands (`sandbox exec`, `sandbox run`) are unchanged.

--- a/packages/sandbox/src/commands/connect.ts
+++ b/packages/sandbox/src/commands/connect.ts
@@ -8,11 +8,11 @@ export const connect = cmd.command({
   description: "Start an interactive shell in an existing sandbox",
   args: omit(Exec.args, "command", "args", "interactive", "tty"),
   async handler(args) {
-    return Exec.exec.handler({
-      command: "sh",
+    return Exec.execute({
+      // No command: the sandbox opens the account's configured shell.
+      command: undefined,
       args: [],
       interactive: true,
-      tty: true,
       ...args,
     });
   },

--- a/packages/sandbox/src/commands/create.ts
+++ b/packages/sandbox/src/commands/create.ts
@@ -186,16 +186,16 @@ export const create = cmd.command({
     }
 
     if (connect) {
-      await Exec.exec.handler({
+      await Exec.execute({
         scope,
         asSudo: false,
         args: [],
         cwd: undefined,
         skipExtendingTimeout: false,
         envVars: {},
-        command: "sh",
+        // No command: the sandbox opens the account's configured shell.
+        command: undefined,
         interactive: true,
-        tty: true,
         sandbox,
         timeout: undefined,
       });

--- a/packages/sandbox/src/commands/exec.ts
+++ b/packages/sandbox/src/commands/exec.ts
@@ -1,5 +1,6 @@
 import { Sandbox } from "@vercel/sandbox";
 import * as cmd from "cmd-ts";
+import type { ParsingInto } from "cmd-ts/dist/esm/argparser";
 import ms from "ms";
 import { sandboxName } from "../args/sandbox-name";
 import { isatty } from "node:tty";
@@ -81,75 +82,102 @@ export const args = {
   scope,
 } as const;
 
-export const exec = cmd.command({
-  name: "exec",
-  description: "Execute a command in an existing sandbox",
+/**
+ * What {@link execute} runs with: the `exec` command's own arguments, except
+ * that `command` is optional. The commands that only ever open a shell
+ * (`connect`, `create --connect`, `fork --connect`) leave it out so the
+ * sandbox spawns the account's configured shell as a login shell instead of a
+ * path the CLI guessed.
+ */
+export type ExecuteOptions = Omit<
+  { [K in keyof typeof args]: ParsingInto<(typeof args)[K]> },
+  "command" | "tty"
+> & { command?: string };
+
+/**
+ * Runs a command in a sandbox, interactively or not. Omitting `command`
+ * requires `interactive`; the session then opens the account's login shell.
+ */
+export async function execute({
+  command,
+  cwd,
   args,
-  async handler({
-    command,
-    cwd,
-    args,
-    asSudo,
-    sandbox: sandboxName,
-    scope: { token, team, project },
-    interactive,
-    envVars,
-    skipExtendingTimeout,
-    timeout,
-  }) {
-    if (interactive && timeout) {
+  asSudo,
+  sandbox: sandboxName,
+  scope: { token, team, project },
+  interactive,
+  envVars,
+  skipExtendingTimeout,
+  timeout,
+}: ExecuteOptions) {
+  if (interactive && timeout) {
+    throw new Error(
+      [
+        "--timeout cannot be combined with --interactive.",
+        `${chalk.bold("hint:")} Remove one of the two flags. Interactive sessions do not enforce a command timeout.`,
+      ].join("\n"),
+    );
+  }
+
+  const sandbox =
+    typeof sandboxName !== "string"
+      ? sandboxName
+      : await sandboxClient.get({
+          name: sandboxName,
+          projectId: project,
+          teamId: team,
+          token,
+          // Resume up front so the sandbox is already running by the time the
+          // interactive-shell setup runs its parallel steps.
+          resume: true,
+          __includeSystemRoutes: true,
+        });
+
+  if (!interactive) {
+    if (command === undefined) {
       throw new Error(
         [
-          "--timeout cannot be combined with --interactive.",
-          `${chalk.bold("hint:")} Remove one of the two flags. Interactive sessions do not enforce a command timeout.`,
+          "A command is required unless the session is interactive.",
+          `${chalk.bold("hint:")} Only interactive sessions can fall back to the sandbox's login shell.`,
         ].join("\n"),
       );
     }
 
-    const sandbox =
-      typeof sandboxName !== "string"
-        ? sandboxName
-        : await sandboxClient.get({
-            name: sandboxName,
-            projectId: project,
-            teamId: team,
-            token,
-            // Resume up front so the sandbox is already running by the time the
-            // interactive-shell setup runs its parallel steps.
-            resume: true,
-            __includeSystemRoutes: true,
-          });
+    console.error(printCommand(command, args));
+    const result = await sandbox.runCommand({
+      cmd: command,
+      args,
+      stderr: process.stderr,
+      stdout: process.stdout,
+      sudo: asSudo,
+      cwd,
+      env: envVars,
+      timeoutMs: timeout ? ms(timeout) : undefined,
+    });
 
-    if (!interactive) {
-      console.error(printCommand(command, args));
-      const result = await sandbox.runCommand({
-        cmd: command,
-        args,
-        stderr: process.stderr,
-        stdout: process.stdout,
-        sudo: asSudo,
-        cwd,
-        env: envVars,
-        timeoutMs: timeout ? ms(timeout) : undefined,
-      });
-
-      // Exit code 137 (128 + SIGKILL) is how a `--timeout` kill surfaces.
-      if (timeout && result.exitCode === 137) {
-        console.error(
-          `${chalk.yellow("Command was killed (SIGKILL, exit code 137)")}.`,
-        );
-      }
-
-      process.exitCode = result.exitCode;
-    } else {
-      await startInteractiveShell({
-        sandbox,
-        cwd,
-        execution: [command, ...args],
-        envVars,
-        sudo: asSudo,
-        skipExtendingTimeout,
-      });
+    // Exit code 137 (128 + SIGKILL) is how a `--timeout` kill surfaces.
+    if (timeout && result.exitCode === 137) {
+      console.error(
+        `${chalk.yellow("Command was killed (SIGKILL, exit code 137)")}.`,
+      );
     }
-  },
+
+    process.exitCode = result.exitCode;
+  } else {
+    await startInteractiveShell({
+      sandbox,
+      cwd,
+      execution: command === undefined ? undefined : [command, ...args],
+      envVars,
+      sudo: asSudo,
+      skipExtendingTimeout,
+    });
+  }
+}
+
+export const exec = cmd.command({
+  name: "exec",
+  description: "Execute a command in an existing sandbox",
+  args,
+  handler: execute,
 });

--- a/packages/sandbox/src/commands/fork.ts
+++ b/packages/sandbox/src/commands/fork.ts
@@ -173,16 +173,16 @@ export const fork = cmd.command({
     }
 
     if (connect) {
-      await Exec.exec.handler({
+      await Exec.execute({
         scope,
         asSudo: false,
         args: [],
         cwd: undefined,
         skipExtendingTimeout: false,
         envVars: {},
-        command: "sh",
+        // No command: the sandbox opens the account's configured shell.
+        command: undefined,
         interactive: true,
-        tty: true,
         sandbox,
         timeout: undefined,
       });

--- a/packages/sandbox/src/commands/run.ts
+++ b/packages/sandbox/src/commands/run.ts
@@ -68,7 +68,7 @@ export const run = cmd.command({
     }
 
     try {
-      await Exec.exec.handler({ ...rest, sandbox, timeout: undefined });
+      await Exec.execute({ ...rest, sandbox, timeout: undefined });
     } finally {
       if (removeAfterUse) {
         await sandbox.delete();

--- a/packages/sandbox/src/interactive-shell/interactive-shell.ts
+++ b/packages/sandbox/src/interactive-shell/interactive-shell.ts
@@ -3,7 +3,11 @@ import createDebugger from "debug";
 import { WebSocket } from "ws";
 import { printCommand } from "../util/print-command";
 import ora from "ora";
-import { acquireRelease, createAbortController, defer } from "../util/disposables";
+import {
+  acquireRelease,
+  createAbortController,
+  defer,
+} from "../util/disposables";
 import chalk from "chalk";
 import { extendSandboxTimeoutPeriodically } from "./extend-sandbox-timeout";
 
@@ -33,13 +37,71 @@ const TERM = "xterm-256color";
 const PS1 = `▲ \x01\x1b[2m\x02$PWD/\x01\x1b[0m\x02 `;
 
 /**
+ * The flag that turns a shell into a login shell, so it sources the account's
+ * profile (`~/.profile`, `~/.bash_profile`, ...) the way a real login does.
+ * Spelled out in full because that is the form bash, zsh, fish and `sudo` all
+ * accept. Shells that only take `-l` would have to be special-cased where the
+ * shell is actually known, which is the sandbox, not here.
+ */
+const LOGIN = "--login";
+
+/**
+ * What the interactive server should spawn, as it goes over the wire.
+ */
+export interface InteractiveExecution {
+  /**
+   * The executable to spawn. The empty string asks the sandbox to spawn the
+   * shell the account declares in the passwd database.
+   */
+  command: string;
+  args: string[];
+}
+
+/**
+ * Resolves the process an interactive session starts.
+ *
+ * With no explicit command the session should open a shell, but which shell
+ * that is belongs to the sandbox: an image can give its user zsh, or install
+ * the usual one somewhere else, and the client has no business guessing a path
+ * that happens to exist in every image. Sending an empty command asks the
+ * sandbox to resolve the account's shell from its passwd entry, and `--login`
+ * makes it a login shell so the account's profile is sourced.
+ *
+ * `sudo --login` (`sudo -i`) is the same contract for the target account: sudo
+ * spawns the shell root's passwd entry declares, as a login shell. Because
+ * that starts in root's home directory, `--workdir` does not survive the
+ * combination of `--sudo` and an implicit shell.
+ *
+ * An explicit command is passed through untouched.
+ */
+export function resolveExecution(options: {
+  execution?: [string, ...string[]];
+  sudo: boolean;
+}): InteractiveExecution {
+  const { execution, sudo } = options;
+
+  if (!execution) {
+    return sudo
+      ? { command: "sudo", args: [LOGIN] }
+      : { command: "", args: [LOGIN] };
+  }
+
+  const [command, ...args] = execution;
+  return sudo
+    ? { command: "sudo", args: [command, ...args] }
+    : { command, args };
+}
+
+/**
  * Starts an interactive shell session with a sandbox. The API hands us a
  * WebSocket URL and token, and we tunnel stdin/stdout over it.
+ *
+ * Omitting `execution` opens the account's configured shell as a login shell.
  */
 export async function startInteractiveShell(options: {
   sandbox: Sandbox;
   cwd?: string;
-  execution: [string, ...string[]];
+  execution?: [string, ...string[]];
   envVars: Record<string, string>;
   sudo: boolean;
   skipExtendingTimeout: boolean;
@@ -71,10 +133,7 @@ export async function startInteractiveShell(options: {
   progress.text = "Opening interactive session...";
   const { url, token } = await options.sandbox.openInteractive();
 
-  const [command, ...args] = options.execution;
-  const execution: [string, ...string[]] = options.sudo
-    ? ["sudo", command, ...args]
-    : [command, ...args];
+  const execution = resolveExecution(options);
 
   progress.text = "Connecting...";
   const client = new WebSocket(`${url}?token=${encodeURIComponent(token)}`);
@@ -95,8 +154,8 @@ export async function startInteractiveShell(options: {
   client.send(
     JSON.stringify({
       type: "start",
-      command: execution[0],
-      args: execution.slice(1),
+      command: execution.command,
+      args: execution.args,
       env: toEnvArray({ TERM, PS1, ...options.envVars }),
       cwd: options.cwd ?? options.sandbox.cwd,
       cols: process.stdout.columns,
@@ -154,7 +213,11 @@ export async function startInteractiveShell(options: {
   };
   process.on("SIGWINCH", onResize);
 
-  console.error(printCommand(options.execution[0], options.execution.slice(1)));
+  // Nothing to echo for an implicit shell: the sandbox picks the executable,
+  // so printing a guess here would name a process that never ran.
+  if (execution.command) {
+    console.error(printCommand(execution.command, execution.args));
+  }
 
   await new Promise<void>((resolve, reject) => {
     client.once("close", () => resolve());
@@ -165,7 +228,9 @@ export async function startInteractiveShell(options: {
   process.removeListener("SIGWINCH", onResize);
   process.stdin.removeListener("data", onStdin);
 
-  console.error(chalk.dim(`\n╰▶ connection to ▲ ${options.sandbox.name} closed.`));
+  console.error(
+    chalk.dim(`\n╰▶ connection to ▲ ${options.sandbox.name} closed.`),
+  );
 }
 
 function toEnvArray(env: Record<string, string>): string[] {

--- a/packages/sandbox/test/commands/connect.test.ts
+++ b/packages/sandbox/test/commands/connect.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import * as cmd from "cmd-ts";
+
+const { mockGet, mockCreate, mockFork, mockStartInteractiveShell } = vi.hoisted(
+  () => ({
+    mockGet: vi.fn(),
+    mockCreate: vi.fn(),
+    mockFork: vi.fn(),
+    mockStartInteractiveShell: vi.fn(),
+  }),
+);
+
+vi.mock("../../src/client", () => ({
+  sandboxClient: {
+    get: mockGet,
+    create: mockCreate,
+    fork: mockFork,
+    list: vi.fn(),
+  },
+  snapshotClient: { get: vi.fn(), list: vi.fn(), tree: vi.fn() },
+}));
+
+vi.mock("../../src/interactive-shell/interactive-shell", () => ({
+  startInteractiveShell: mockStartInteractiveShell,
+}));
+
+vi.mock("@vercel/oidc", () => ({
+  getVercelOidcToken: vi.fn(),
+  getVercelToken: vi.fn(),
+}));
+
+vi.mock("../../src/commands/login", () => ({
+  login: { handler: vi.fn() },
+}));
+
+const fakeSandbox = {
+  name: "my-sandbox",
+  interactivePort: 8443,
+  routes: [{ url: "https://example.com", subdomain: "sbx", port: 8443 }],
+};
+
+const scopeArgs = ["--scope=team", "--project=proj"];
+
+describe("connecting to a sandbox", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(fakeSandbox);
+    mockCreate.mockResolvedValue(fakeSandbox);
+    mockFork.mockResolvedValue(fakeSandbox);
+    process.env.VERCEL_AUTH_TOKEN = "tok";
+  });
+
+  test("`connect` leaves the command to the sandbox", async () => {
+    const { connect } = await import("../../src/commands/connect.ts");
+    await cmd.run(connect, ["my-sandbox", ...scopeArgs]);
+
+    expect(mockStartInteractiveShell).toHaveBeenCalledTimes(1);
+    expect(mockStartInteractiveShell.mock.calls[0][0]).toMatchObject({
+      sandbox: fakeSandbox,
+      execution: undefined,
+      sudo: false,
+    });
+  });
+
+  test("`connect --sudo` still leaves the command to the sandbox", async () => {
+    const { connect } = await import("../../src/commands/connect.ts");
+    await cmd.run(connect, ["my-sandbox", "--sudo", ...scopeArgs]);
+
+    expect(mockStartInteractiveShell.mock.calls[0][0]).toMatchObject({
+      execution: undefined,
+      sudo: true,
+    });
+  });
+
+  test("`create --connect` leaves the command to the sandbox", async () => {
+    const { create } = await import("../../src/commands/create.ts");
+    await cmd.run(create, ["--connect", "--silent", ...scopeArgs]);
+
+    expect(mockStartInteractiveShell).toHaveBeenCalledTimes(1);
+    expect(mockStartInteractiveShell.mock.calls[0][0]).toMatchObject({
+      sandbox: fakeSandbox,
+      execution: undefined,
+    });
+  });
+
+  test("`fork --connect` leaves the command to the sandbox", async () => {
+    const { fork } = await import("../../src/commands/fork.ts");
+    await cmd.run(fork, ["my-source", "--connect", "--silent", ...scopeArgs]);
+
+    expect(mockStartInteractiveShell).toHaveBeenCalledTimes(1);
+    expect(mockStartInteractiveShell.mock.calls[0][0]).toMatchObject({
+      sandbox: fakeSandbox,
+      execution: undefined,
+    });
+  });
+
+  // `--interactive` refuses to parse without a TTY, so this drives the shared
+  // entry point the `exec` command hands its parsed arguments to.
+  test("`exec --interactive` keeps running the command it was given", async () => {
+    const { execute } = await import("../../src/commands/exec.ts");
+    await execute({
+      sandbox: "my-sandbox",
+      command: "npm",
+      args: ["test"],
+      asSudo: false,
+      interactive: true,
+      skipExtendingTimeout: false,
+      cwd: undefined,
+      envVars: {},
+      timeout: undefined,
+      scope: { token: "tok", team: "team", project: "proj" },
+    });
+
+    expect(mockStartInteractiveShell.mock.calls[0][0]).toMatchObject({
+      execution: ["npm", "test"],
+    });
+  });
+});

--- a/packages/sandbox/test/interactive-shell/interactive-shell.test.ts
+++ b/packages/sandbox/test/interactive-shell/interactive-shell.test.ts
@@ -1,0 +1,132 @@
+import { describe, test, expect, vi, afterEach } from "vitest";
+import type { AddressInfo } from "node:net";
+import { WebSocketServer } from "ws";
+import type { Sandbox } from "@vercel/sandbox";
+import {
+  resolveExecution,
+  startInteractiveShell,
+} from "../../src/interactive-shell/interactive-shell";
+
+describe("resolveExecution", () => {
+  test("asks the sandbox for the account's login shell when no command is given", () => {
+    expect(resolveExecution({ execution: undefined, sudo: false })).toEqual({
+      // Empty: the sandbox resolves the shell from the account's passwd entry.
+      command: "",
+      args: ["--login"],
+    });
+  });
+
+  test("asks sudo for the target account's login shell", () => {
+    expect(resolveExecution({ execution: undefined, sudo: true })).toEqual({
+      command: "sudo",
+      args: ["--login"],
+    });
+  });
+
+  test("passes an explicit command through untouched", () => {
+    expect(
+      resolveExecution({ execution: ["npm", "test", "--", "-w"], sudo: false }),
+    ).toEqual({ command: "npm", args: ["test", "--", "-w"] });
+  });
+
+  test("keeps an explicit command under sudo", () => {
+    expect(
+      resolveExecution({ execution: ["npm", "test"], sudo: true }),
+    ).toEqual({ command: "sudo", args: ["npm", "test"] });
+  });
+});
+
+/**
+ * Runs an interactive session against a local WebSocket server and returns the
+ * `start` control frame the client sent, which is the contract the sandbox's
+ * interactive server reads.
+ */
+async function captureStartFrame(options: {
+  execution?: [string, ...string[]];
+  sudo?: boolean;
+}) {
+  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await new Promise((resolve) => server.once("listening", resolve));
+  const { port } = server.address() as AddressInfo;
+
+  const start = new Promise<Record<string, unknown>>((resolve, reject) => {
+    server.once("connection", (socket) => {
+      socket.once("message", (data: Buffer) => {
+        try {
+          resolve(JSON.parse(data.toString()));
+        } catch (err) {
+          reject(err);
+        }
+        // Ending the session lets startInteractiveShell resolve.
+        socket.close();
+      });
+    });
+  });
+
+  const sandbox = {
+    name: "my-sandbox",
+    cwd: "/vercel/sandbox",
+    openInteractive: async () => ({
+      url: `ws://127.0.0.1:${port}`,
+      token: "session-token",
+    }),
+  } as unknown as Sandbox;
+
+  try {
+    await startInteractiveShell({
+      sandbox,
+      envVars: { FOO: "bar" },
+      sudo: options.sudo ?? false,
+      execution: options.execution,
+      skipExtendingTimeout: true,
+    });
+    return await start;
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+describe("startInteractiveShell", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("starts the account's login shell when no command is given", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const frame = await captureStartFrame({});
+
+    expect(frame).toMatchObject({
+      type: "start",
+      command: "",
+      args: ["--login"],
+      cwd: "/vercel/sandbox",
+    });
+    expect(frame.env).toEqual(
+      expect.arrayContaining(["TERM=xterm-256color", "FOO=bar"]),
+    );
+  });
+
+  test("starts an explicit command instead of a shell", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const frame = await captureStartFrame({ execution: ["npm", "test"] });
+
+    expect(frame).toMatchObject({
+      type: "start",
+      command: "npm",
+      args: ["test"],
+    });
+  });
+
+  test("echoes an explicit command but not the shell the sandbox picks", async () => {
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await captureStartFrame({ execution: ["npm", "test"] });
+    expect(stderr.mock.calls.flat().join("\n")).toContain("npm test");
+
+    stderr.mockClear();
+    await captureStartFrame({});
+    expect(stderr.mock.calls.flat().join("\n")).not.toContain("--login");
+  });
+});


### PR DESCRIPTION
## What

`sandbox connect` (and `ssh`/`shell`), `sandbox create --connect`, `sandbox fork --connect` and `sandbox sh` all hardcoded `sh` as the executable of the interactive session. [vercel/api#85167](https://github.com/vercel/api/pull/85167) teaches sandbox-init to resolve the account's shell from its passwd entry when the `start` frame carries no command — but the CLI always names one, so that path never ran.

The commands that only ever open a shell now send **no command** and `--login`, so the session spawns `<the account's shell> --login`: the shell the image's user actually declares, as a login shell, with its profile sourced. Commands the user typed are still sent verbatim.

Wire-level, the `start` frame goes from `{command: "sh", args: []}` to `{command: "", args: ["--login"]}`.

- `resolveExecution()` in `interactive-shell.ts` is now the single place that decides what a session spawns, and `startInteractiveShell`'s `execution` is optional.
- `exec.ts` exposes `execute()` — the `exec` command's handler, with `command` optional — so `connect`/`create`/`fork` can ask for a shell instead of fabricating an argv. Most of that file's diff is de-indentation from moving the handler body into a named function.
- With `--sudo` the same request becomes `sudo --login` (`sudo -i`), which is sudo's own version of this feature: the target account's passwd shell, as a login shell. It starts in that account's home directory, so `--workdir` no longer survives the `--sudo` + implicit-shell combination. Explicit commands under `--sudo` are unchanged.
- Nothing is echoed as `$ …` for an implicit shell anymore: the sandbox picks the executable, so the CLI would only be printing a guess.

## api-side coordination

No changes to #85167 are needed. Its empty-command path passes `Arguments` through to `exec.Command` verbatim, so the client-supplied `--login` lands on the resolved shell — verified against `sandboxinit/service/interactive.go` and the controller's `wsControl` bridge on `sandbox-shell-from-passwd`, neither of which rejects an empty `command`.

The dependency runs one way: **this PR should land after #85167 is deployed.** Against an older sandbox-init, an empty command reaches `exec.Command("", "--login")` and the session fails to start.

`--login` is spelled out because that is the form bash, zsh, fish and sudo all accept. If we ever need to support a shell that only takes `-l`, that translation belongs next to the passwd lookup in sandbox-init, where the shell is actually known — not in the CLI.

## Testing

`pnpm test` and `pnpm typecheck` in `packages/sandbox`. New coverage:

- `test/interactive-shell/interactive-shell.test.ts` — `resolveExecution` over the four combinations (implicit/explicit command × sudo), plus sessions driven against a real local WebSocket server asserting the `start` frame that goes over the wire, and that only an explicit command is echoed.
- `test/commands/connect.test.ts` — `connect`, `connect --sudo`, `create --connect` and `fork --connect` reach `startInteractiveShell` with no execution; `exec --interactive` still carries the command it was given. Verified these fail against the old `command: "sh"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)