### PR TITLE
[sandbox-sdk] surface the server's error message in APIError.message

### DIFF
--- a/.changeset/api-error-server-message.md
+++ b/.changeset/api-error-server-message.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Surface the server's error message in `APIError.message`. Failed API requests previously reported only `Status code 400 is not ok`, hiding the actionable detail (e.g. ``Invalid request: `ports` should NOT have more than 15 items.``) in `error.json`. The message now includes it directly.

--- a/packages/vercel-sandbox/src/api-client/api-client.test.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.test.ts
@@ -340,6 +340,48 @@ describe("APIClient", () => {
       }
     });
 
+    it("surfaces the server's error message in APIError.message", async () => {
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: "bad_request",
+              message:
+                "Invalid request: `ports` should NOT have more than 15 items.",
+            },
+          }),
+          {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      );
+
+      try {
+        await client.runCommand({
+          sessionId: "sbx_123",
+          command: "echo",
+          args: ["hello"],
+          env: {},
+          sudo: false,
+          wait: true,
+        });
+        expect.fail("Expected APIError to be thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(APIError);
+        expect(err.message).toBe(
+          "Status code 400 is not ok: Invalid request: `ports` should NOT have more than 15 items.",
+        );
+        expect(err.json).toEqual({
+          error: {
+            code: "bad_request",
+            message:
+              "Invalid request: `ports` should NOT have more than 15 items.",
+          },
+        });
+      }
+    });
+
     it("throws abort error (not Zod error) when signal aborts before stream finishes", async () => {
       const commandData = {
         command: {

--- a/packages/vercel-sandbox/src/api-client/base-client.ts
+++ b/packages/vercel-sandbox/src/api-client/base-client.ts
@@ -1,6 +1,6 @@
 import type { Options as RetryOptions } from "async-retry";
 import { APIError } from "./api-error.js";
-import { ZodType } from "zod";
+import { z, ZodType } from "zod";
 import { array } from "../utils/array.js";
 import { withRetry, type RequestOptions } from "./with-retry.js";
 import { Agent } from "undici";
@@ -107,6 +107,26 @@ function extractSandboxName(url: string): string | undefined {
 }
 
 /**
+ * The error body shape returned by the Sandbox API. Mirrors the shape the
+ * CLI's formatApiError parses.
+ */
+const ErrorResponseBody = z.object({
+  error: z.object({
+    message: z.string(),
+  }),
+});
+
+/**
+ * Extract the server-provided error message from an error response body so
+ * it can be surfaced in APIError.message. Returns undefined for any other
+ * body shape.
+ */
+function extractServerMessage(json: unknown): string | undefined {
+  const parsed = ErrorResponseBody.safeParse(json);
+  return parsed.success ? parsed.data.error.message : undefined;
+}
+
+/**
  * Allows to read the response text and parse it as JSON casting to the given
  * type. If the response is not ok or cannot be parsed it will return error.
  *
@@ -149,8 +169,11 @@ export async function parse<Data, ErrorData>(
   }
 
   if (!response.ok) {
+    const serverMessage = extractServerMessage(json);
     return new APIError<ErrorData>(response, {
-      message: `Status code ${response.status} is not ok`,
+      message: serverMessage
+        ? `Status code ${response.status} is not ok: ${serverMessage}`
+        : `Status code ${response.status} is not ok`,
       json: json as ErrorData,
       text,
       sessionId,


### PR DESCRIPTION
## Problem

When an API request fails, the SDK throws an `APIError` whose `.message` is only:

```
Status code 400 is not ok
```

The server actually returns a precise explanation — `"Invalid request: \`tags\` should NOT have more than 5 properties."` — but it lands only on `err.json` / `err.text`, which nothing reads by default. `err.message` is what shows in stack traces, loggers, and what coding agents read in their loops, so the actionable detail is effectively hidden. The CLI already works around this: `formatApiError` in `packages/sandbox` zod-parses `err.json` to recover the same message. This moves that extraction into the SDK itself.

## Fix

In `parse()` (`base-client.ts`), when the response is not ok, extract `error.message` from the parsed body (same shape the CLI parses) and append it:

**Before**
```
Status code 400 is not ok
```

**After**
```
Status code 400 is not ok: Invalid request: `tags` should NOT have more than 5 properties.
```

Bodies without that shape (e.g. `{ error: "gone" }`) keep the previous message unchanged.

## Verification

- Unit: new test asserting the enriched message; all 42 tests in `api-client.test.ts` pass.
- `pnpm typecheck` clean, `pnpm build` clean.
- Live against the production API (local build, 6-tags create): observed exactly the **After** message above; 404 cases (`Image not found.`, `Snapshot not found.`) also verified to carry the server text in `err.json`.

Changeset included (patch).