### PR TITLE
[sandbox-docs] correct ports JSDoc limit from 4 to 15

### DIFF
--- a/.changeset/ports-jsdoc-limit.md
+++ b/.changeset/ports-jsdoc-limit.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Correct the `ports` option JSDoc: the limit is 15 ports (matching the docs and API validation), not 4.

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -69,7 +69,7 @@ export interface BaseCreateSandboxParams {
     | { type: "tarball"; url: string };
   /**
    * Array of port numbers to expose from the sandbox. Sandboxes can
-   * expose up to 4 ports.
+   * expose up to 15 ports.
    */
   ports?: number[];
   /**


### PR DESCRIPTION
The JSDoc on `CreateSandboxParams.ports` says sandboxes "can expose up to 4 ports". The actual limit is 15:

- Docs: [sdk-reference](https://vercel.com/docs/sandbox/sdk-reference), `Sandbox.create` parameters table — "Ports to expose for `sandbox.domain()`. Up to 15."
- API validation: a 16-port create is rejected with `"Invalid request: \`ports\` should NOT have more than 15 items."`
- Live behavior: a 5-port create succeeds with all 5 ports routed (verified 2026-08-11).

Since this comment is what IDEs show on hover/autocomplete, developers currently design around a 4-port constraint that was lifted. One-line comment fix + changeset (patch) so the corrected `.d.ts` ships.

Note: while verifying the boundary we found that a create with exactly 15 ports currently fails with an HTTP 500 after ~14s (14 works, 16 is cleanly rejected) — reported separately, as that's server-side and doesn't change what the intended documented limit is.