### PR TITLE
[sandbox-docs] correct resume JSDoc default from true to false

### DIFF
--- a/.changeset/resume-jsdoc-default.md
+++ b/.changeset/resume-jsdoc-default.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Correct the `resume` option JSDoc on `Sandbox.get` and `Sandbox.getOrCreate`: the default is `false` (the client omits the param and the API defaults to not resuming), not `true`. A stopped sandbox still auto-resumes on the first SDK call that needs a running session.

--- a/.changeset/resume-jsdoc-default.md
+++ b/.changeset/resume-jsdoc-default.md
@@ -2,4 +2,4 @@
 "@vercel/sandbox": patch
 ---
 
-Correct the `resume` option JSDoc on `Sandbox.get` and `Sandbox.getOrCreate`: the default is `false` (the client omits the param and the API defaults to not resuming), not `true`. A stopped sandbox still auto-resumes on the first SDK call that needs a running session.
+Correct the `resume` option JSDoc on `Sandbox.get` and `Sandbox.getOrCreate`: the default is `false` (the client omits the param and the API defaults to not resuming), not `true`. A stopped persistent sandbox still auto-resumes on the first SDK call that needs a running session.

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -225,8 +225,8 @@ interface GetSandboxParams {
   name: string;
   /**
    * Whether to resume an existing session immediately. Defaults to false;
-   * the sandbox still auto-resumes on the first SDK call that needs a
-   * running session (such as `runCommand`).
+   * a persistent sandbox still auto-resumes on the first SDK call that
+   * needs a running session (such as `runCommand`).
    */
   resume?: boolean;
   /**
@@ -248,8 +248,8 @@ interface GetSandboxParams {
 type GetOrCreateSandboxParams = CreateSandboxParams & {
   /**
    * Whether to resume an existing session immediately. Defaults to false;
-   * the sandbox still auto-resumes on the first SDK call that needs a
-   * running session (such as `runCommand`).
+   * a persistent sandbox still auto-resumes on the first SDK call that
+   * needs a running session (such as `runCommand`).
    */
   resume?: boolean;
   /**

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -224,7 +224,9 @@ interface GetSandboxParams {
    */
   name: string;
   /**
-   * Whether to resume an existing session. Defaults to true.
+   * Whether to resume an existing session immediately. Defaults to false;
+   * the sandbox still auto-resumes on the first SDK call that needs a
+   * running session (such as `runCommand`).
    */
   resume?: boolean;
   /**
@@ -245,7 +247,9 @@ interface GetSandboxParams {
  */
 type GetOrCreateSandboxParams = CreateSandboxParams & {
   /**
-   * Whether to resume an existing session. Defaults to true.
+   * Whether to resume an existing session immediately. Defaults to false;
+   * the sandbox still auto-resumes on the first SDK call that needs a
+   * running session (such as `runCommand`).
    */
   resume?: boolean;
   /**


### PR DESCRIPTION
## Problem

The `resume` option JSDoc on both `GetSandboxParams` and `GetOrCreateSandboxParams` says "Defaults to true". The shipped behavior is the opposite:

- The client serializer only sends the param when set (`api-client.ts` `getSandbox`: `if (params.resume !== void 0) query.resume = String(params.resume)`), so the API default wins — and the API does not resume by default.
- Live-verified (2026-08-11, SDK 3.0.0): on a stopped sandbox, `Sandbox.get({ name })` → status stays `stopped`; `Sandbox.get({ name, resume: true })` → `running`; `Sandbox.getOrCreate({ name })` → `stopped`.
- The [persistent sandboxes docs](https://vercel.com/docs/sandbox/concepts/persistent-sandboxes) agree: "getOrCreate retrieves the sandbox but does not resume it" by default.

Since IDEs surface this JSDoc on hover, users currently expect `get` to boot the sandbox when it doesn't (it only resumes lazily on the first SDK call that needs a running session).

## Fix

Correct the comment in both places and mention the lazy auto-resume so the corrected default doesn't read as "stopped forever". Changeset (patch) included so the fixed `.d.ts` ships.

Note: the [sdk-reference](https://vercel.com/docs/sandbox/sdk-reference) `resume` row also says "Defaults to `true`" — that docs-page fix is going separately.