### PR TITLE
[sandbox-sdk] expose structured API error codes

### DIFF
--- a/.changeset/curly-cats-expose-api-errors.md
+++ b/.changeset/curly-cats-expose-api-errors.md
@@ -2,4 +2,4 @@
 "@vercel/sandbox": patch
 ---
 
-Expose structured API error codes and server messages on `APIError` instances.
+Expose structured API error codes on `APIError` instances.

--- a/.changeset/curly-cats-expose-api-errors.md
+++ b/.changeset/curly-cats-expose-api-errors.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Expose structured API error codes and server messages on `APIError` instances.

--- a/packages/vercel-sandbox/src/api-client/api-client.test.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.test.ts
@@ -130,7 +130,6 @@ describe("APIClient", () => {
         expect(error).toMatchObject({
           message: "Status code 400 is not ok",
           code: "sandbox_already_exists",
-          serverMessage: "A sandbox with this name already exists.",
         });
       }
     });

--- a/packages/vercel-sandbox/src/api-client/api-client.test.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.test.ts
@@ -103,6 +103,38 @@ describe("APIClient", () => {
       }
     });
 
+    it("exposes structured API error fields without changing the error message", async () => {
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: "sandbox_already_exists",
+              message: "A sandbox with this name already exists.",
+            },
+          }),
+          {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      );
+
+      const logs = client.getLogs({ sessionId: "sbx_123", cmdId: "cmd_456" });
+
+      try {
+        for await (const _ of logs) {
+        }
+        expect.fail("Expected APIError to be thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(APIError);
+        expect(error).toMatchObject({
+          message: "Status code 400 is not ok",
+          code: "sandbox_already_exists",
+          serverMessage: "A sandbox with this name already exists.",
+        });
+      }
+    });
+
     it("throws APIError when response body is null", async () => {
       mockFetch.mockResolvedValue(
         new Response(null, {

--- a/packages/vercel-sandbox/src/api-client/api-error.ts
+++ b/packages/vercel-sandbox/src/api-client/api-error.ts
@@ -11,8 +11,12 @@ export class APIError<ErrorData> extends Error {
   public message: string;
   public json?: ErrorData;
   public text?: string;
+  /** Stable API error code when the response uses Vercel's standard error envelope. */
+  public code?: string;
+  /** API-provided error message when the response uses Vercel's standard error envelope. */
+  public serverMessage?: string;
   public sandboxName?: string;
-  public sessionId?: string
+  public sessionId?: string;
 
   constructor(response: Response, options?: Options<ErrorData>) {
     super(response.statusText);
@@ -24,9 +28,33 @@ export class APIError<ErrorData> extends Error {
     this.message = options?.message ?? "";
     this.json = options?.json;
     this.text = options?.text;
+    const apiError = getStandardAPIError(options?.json);
+    this.code = apiError?.code;
+    this.serverMessage = apiError?.message;
     this.sandboxName = options?.sandboxName;
     this.sessionId = options?.sessionId;
   }
+}
+
+function getStandardAPIError(value: unknown):
+  | {
+      code: string;
+      message: string;
+    }
+  | undefined {
+  if (typeof value !== "object" || value === null || !("error" in value)) {
+    return undefined;
+  }
+
+  const error = value.error;
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+
+  const { code, message } = error as Record<string, unknown>;
+  return typeof code === "string" && typeof message === "string"
+    ? { code, message }
+    : undefined;
 }
 
 /**

--- a/packages/vercel-sandbox/src/api-client/api-error.ts
+++ b/packages/vercel-sandbox/src/api-client/api-error.ts
@@ -13,8 +13,6 @@ export class APIError<ErrorData> extends Error {
   public text?: string;
   /** Stable API error code when the response uses Vercel's standard error envelope. */
   public code?: string;
-  /** API-provided error message when the response uses Vercel's standard error envelope. */
-  public serverMessage?: string;
   public sandboxName?: string;
   public sessionId?: string;
 
@@ -28,20 +26,13 @@ export class APIError<ErrorData> extends Error {
     this.message = options?.message ?? "";
     this.json = options?.json;
     this.text = options?.text;
-    const apiError = getStandardAPIError(options?.json);
-    this.code = apiError?.code;
-    this.serverMessage = apiError?.message;
+    this.code = getStandardAPIErrorCode(options?.json);
     this.sandboxName = options?.sandboxName;
     this.sessionId = options?.sessionId;
   }
 }
 
-function getStandardAPIError(value: unknown):
-  | {
-      code: string;
-      message: string;
-    }
-  | undefined {
+function getStandardAPIErrorCode(value: unknown): string | undefined {
   if (typeof value !== "object" || value === null || !("error" in value)) {
     return undefined;
   }
@@ -51,10 +42,8 @@ function getStandardAPIError(value: unknown):
     return undefined;
   }
 
-  const { code, message } = error as Record<string, unknown>;
-  return typeof code === "string" && typeof message === "string"
-    ? { code, message }
-    : undefined;
+  const { code } = error as Record<string, unknown>;
+  return typeof code === "string" ? code : undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

```ts
error.code === "sandbox_already_exists"
```

- Expose the standard API envelope's `error.code` directly on `APIError`.
- Preserve the existing `APIError.message`, `json`, `text`, and class contract.
- Complement #291, which owns surfacing the server-provided error message.

## Impact

- SDK consumers can classify provider errors without parsing internal response JSON or matching prose.

## Validation

- Verified structured and unstructured API response envelopes retain their existing behavior.
