### PR TITLE
[sandbox-cli] end create and fork output with a connect hint

### DIFF
--- a/.changeset/cli-connect-hint.md
+++ b/.changeset/cli-connect-hint.md
@@ -1,0 +1,5 @@
+---
+"sandbox": patch
+---
+
+`create` and `fork` output now ends with a connect hint (`connect with: sandbox ssh <name>`), so a fresh sandbox never leaves you without a next step. Composing commands like `run` suppress it.

--- a/packages/sandbox/src/commands/create.ts
+++ b/packages/sandbox/src/commands/create.ts
@@ -82,29 +82,35 @@ export const create = cmd.command({
       command: `sandbox run --network-policy=none --connect`,
     },
   ],
-  async handler({
-    name,
-    nonPersistent,
-    ports,
-    scope,
-    runtime,
-    image,
-    timeout,
-    vcpus,
-    silent,
-    snapshot,
-    connect,
-    envVars,
-    tags,
-    snapshotExpiration,
-    keepLastSnapshots,
-    keepLastSnapshotsFor,
-    deleteEvictedSnapshots,
-    networkPolicy: networkPolicyMode,
-    allowedDomains,
-    allowedCIDRs,
-    deniedCIDRs,
-  }) {
+  async handler(input) {
+    const {
+      name,
+      nonPersistent,
+      ports,
+      scope,
+      runtime,
+      image,
+      timeout,
+      vcpus,
+      silent,
+      snapshot,
+      connect,
+      envVars,
+      tags,
+      snapshotExpiration,
+      keepLastSnapshots,
+      keepLastSnapshotsFor,
+      deleteEvictedSnapshots,
+      networkPolicy: networkPolicyMode,
+      allowedDomains,
+      allowedCIDRs,
+      deniedCIDRs,
+    } = input;
+    // Internal flag for composing commands (e.g. `run`) that create a sandbox
+    // as a step rather than as the outcome, where a connect hint would mislead.
+    const { __printConnectHint = true } = input as {
+      __printConnectHint?: boolean;
+    };
     if (runtime !== undefined && image !== undefined) {
       throw new Error("--runtime and --image cannot be used together.");
     }
@@ -182,7 +188,12 @@ export const create = cmd.command({
     }
 
     if (!silent) {
-      printSandboxSummary({ sandbox, scope, action: "created" });
+      printSandboxSummary({
+        sandbox,
+        scope,
+        action: "created",
+        connectHint: !connect && __printConnectHint,
+      });
     }
 
     if (connect) {

--- a/packages/sandbox/src/commands/fork.ts
+++ b/packages/sandbox/src/commands/fork.ts
@@ -169,6 +169,7 @@ export const fork = cmd.command({
         sandbox,
         scope,
         action: `forked from ${chalk.cyan(source)}`,
+        connectHint: !connect,
       });
     }
 

--- a/packages/sandbox/src/commands/run.ts
+++ b/packages/sandbox/src/commands/run.ts
@@ -55,7 +55,8 @@ export const run = cmd.command({
           sandbox = await Create.create.handler({
             ...rest,
             nonPersistent: rest.nonPersistent || removeAfterUse,
-          });
+            __printConnectHint: false,
+          } as Parameters<typeof Create.create.handler>[0]);
         } else {
           throw error;
         }
@@ -64,7 +65,8 @@ export const run = cmd.command({
       sandbox = await Create.create.handler({
         ...rest,
         nonPersistent: rest.nonPersistent || removeAfterUse,
-      });
+        __printConnectHint: false,
+      } as Parameters<typeof Create.create.handler>[0]);
     }
 
     try {

--- a/packages/sandbox/src/util/print-sandbox-summary.ts
+++ b/packages/sandbox/src/util/print-sandbox-summary.ts
@@ -22,8 +22,10 @@ export function printSandboxSummary(opts: {
   sandbox: Sandbox;
   scope: Scope;
   action: string;
+  /** Append a "connect with" hint so the output never ends at a dead end. */
+  connectHint?: boolean;
 }) {
-  const { sandbox, scope, action } = opts;
+  const { sandbox, scope, action, connectHint } = opts;
   const teamDisplay = scope.teamSlug ?? scope.team;
   const projectDisplay = scope.projectSlug ?? scope.project;
   const routes = sandbox.routes.filter(
@@ -38,6 +40,9 @@ export function printSandboxSummary(opts: {
     chalk.dim("   │ ") + "team: " + chalk.cyan(teamDisplay) + "\n",
   );
 
+  // With a connect hint, the hint becomes the closing "╰" line.
+  const close = (last: boolean) => chalk.dim(last && !connectHint ? "   ╰ " : "   │ ");
+
   if (hasPorts) {
     process.stderr.write(
       chalk.dim("   │ ") + "project: " + chalk.cyan(projectDisplay) + "\n",
@@ -46,14 +51,22 @@ export function printSandboxSummary(opts: {
     for (let i = 0; i < routes.length; i++) {
       const route = routes[i];
       const isLast = i === routes.length - 1;
-      const prefix = isLast ? chalk.dim("   ╰ ") : chalk.dim("   │ ");
       process.stderr.write(
-        prefix + "• " + route.port + " -> " + chalk.cyan(route.url) + "\n",
+        close(isLast) + "• " + route.port + " -> " + chalk.cyan(route.url) + "\n",
       );
     }
   } else {
     process.stderr.write(
-      chalk.dim("   ╰ ") + "project: " + chalk.cyan(projectDisplay) + "\n",
+      close(true) + "project: " + chalk.cyan(projectDisplay) + "\n",
+    );
+  }
+
+  if (connectHint) {
+    process.stderr.write(
+      chalk.dim("   ╰ ") +
+        "connect with: " +
+        chalk.cyan(`sandbox ssh ${sandbox.name}`) +
+        "\n",
     );
   }
 }


### PR DESCRIPTION
First of four PRs splitting #295 per change (review feedback: one changelog entry per change, stacked).

## What

`create` and `fork` close their summary with `╰ connect with: sandbox ssh <name>`. Composing commands (`run`) suppress it via an internal `__printConnectHint` flag; `--connect` and `sh` don't print it since you're already inside.

## Why

New-user friction audit (Aug 10-12): `create` succeeds and returns to the local prompt with no next step; users type `sh` and land in their LOCAL macOS shell believing they're in the VM. Output should never end at a dead end.

## Changelog entry (changeset included)

> `create` and `fork` output now ends with a connect hint (`connect with: sandbox ssh <name>`), so a fresh sandbox never leaves you without a next step.

## Verification

- `pnpm typecheck` clean (packages/sandbox)
- Stack: #295 carried the combined change live-tested; this slice is the summary/flag plumbing only. The staleness PR stacks on this branch.