### PR TITLE
[sandbox-cli] print an update notice when the CLI is stale

### DIFF
--- a/.changeset/cli-staleness-notice.md
+++ b/.changeset/cli-staleness-notice.md
@@ -2,4 +2,4 @@
 "sandbox": patch
 ---
 
-`create`, `sh`, and `run` check for a newer published CLI concurrently with sandbox creation (time-boxed, zero added latency) and print an update notice when the install is stale. Disable with `SANDBOX_SKIP_VERSION_CHECK=1`.
+`create`, `sh`, and `run` check for a newer published CLI and print an update notice when the install is behind. The result is cached to a file and refreshed at most once per hour; when a lookup does run it happens concurrently with sandbox creation and is aborted as the command finishes, so it never adds latency or delays exit. Disable with `SANDBOX_SKIP_VERSION_CHECK=1`.

--- a/.changeset/cli-staleness-notice.md
+++ b/.changeset/cli-staleness-notice.md
@@ -1,0 +1,5 @@
+---
+"sandbox": patch
+---
+
+`create`, `sh`, and `run` check for a newer published CLI concurrently with sandbox creation (time-boxed, zero added latency) and print an update notice when the install is stale. Disable with `SANDBOX_SKIP_VERSION_CHECK=1`.

--- a/packages/sandbox/src/commands/create.ts
+++ b/packages/sandbox/src/commands/create.ts
@@ -16,6 +16,7 @@ import { buildNetworkPolicy } from "../util/network-policy";
 import { ObjectFromKeyValue } from "../args/key-value-pair";
 import { buildKeepLastSnapshotsPayload } from "../util/keep-last-snapshots";
 import { printSandboxSummary } from "../util/print-sandbox-summary";
+import { startLatestVersionCheck } from "../util/check-latest-version";
 
 export const args = {
   name: cmd.option({
@@ -115,6 +116,10 @@ export const create = cmd.command({
       throw new Error("--runtime and --image cannot be used together.");
     }
 
+    // Look up the latest published CLI version while the creation request is
+    // in flight, so stale installs learn they're behind at no latency cost.
+    const versionCheck = silent ? undefined : startLatestVersionCheck();
+
     const networkPolicy = buildNetworkPolicy({
       networkPolicy: networkPolicyMode,
       allowedDomains,
@@ -194,6 +199,7 @@ export const create = cmd.command({
         action: "created",
         connectHint: !connect && __printConnectHint,
       });
+      versionCheck?.report();
     }
 
     if (connect) {

--- a/packages/sandbox/src/util/check-latest-version.test.ts
+++ b/packages/sandbox/src/util/check-latest-version.test.ts
@@ -23,3 +23,116 @@ describe("isOutdated", () => {
     expect(isOutdated("4.0.0", "not-a-version")).toBe(false);
   });
 });
+
+import { vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import Path from "node:path";
+import { startLatestVersionCheck } from "./check-latest-version";
+
+describe("startLatestVersionCheck", () => {
+  let dir: string;
+  let cachePath: string;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(Path.join(tmpdir(), "sandbox-version-"));
+    cachePath = Path.join(dir, "latest-version.json");
+    stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function output(): string {
+    return stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+  }
+
+  it("serves a fresh cache without touching the registry", () => {
+    writeFileSync(
+      cachePath,
+      JSON.stringify({ latest: "9.9.9", checkedAt: Date.now() }),
+    );
+    const fetchImpl = vi.fn();
+    const check = startLatestVersionCheck({
+      cachePath,
+      fetchImpl,
+      currentVersion: "4.0.0",
+    });
+    check.report();
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(output()).toContain("9.9.9");
+  });
+
+  it("refreshes a stale cache and persists the result", async () => {
+    writeFileSync(
+      cachePath,
+      JSON.stringify({ latest: "4.0.1", checkedAt: Date.now() - 2 * 60 * 60 * 1000 }),
+    );
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ version: "9.9.9" }), { status: 200 }),
+    );
+    startLatestVersionCheck({
+      cachePath,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      currentVersion: "4.0.0",
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    await vi.waitFor(() => {
+      const cache = JSON.parse(readFileSync(cachePath, "utf8"));
+      expect(cache.latest).toBe("9.9.9");
+    });
+  });
+
+  it("report() aborts an in-flight registry request", () => {
+    let seenSignal: AbortSignal | undefined;
+    const fetchImpl = vi.fn((_url: unknown, init?: RequestInit) => {
+      seenSignal = init?.signal ?? undefined;
+      return new Promise<Response>(() => {
+        // Never resolves: simulates a hung registry.
+      });
+    });
+    const check = startLatestVersionCheck({
+      cachePath,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      currentVersion: "4.0.0",
+    });
+    expect(seenSignal?.aborted).toBe(false);
+    check.report();
+    expect(seenSignal?.aborted).toBe(true);
+  });
+
+  it("treats a corrupt cache file as missing", () => {
+    writeFileSync(cachePath, "not json{{{");
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ version: "9.9.9" }), { status: 200 }),
+    );
+    startLatestVersionCheck({
+      cachePath,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      currentVersion: "4.0.0",
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("does nothing when SANDBOX_SKIP_VERSION_CHECK is set", () => {
+    vi.stubEnv("SANDBOX_SKIP_VERSION_CHECK", "1");
+    try {
+      const fetchImpl = vi.fn();
+      const check = startLatestVersionCheck({
+        cachePath,
+        fetchImpl,
+        currentVersion: "4.0.0",
+      });
+      check.report();
+      expect(fetchImpl).not.toHaveBeenCalled();
+      expect(output()).toBe("");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+});

--- a/packages/sandbox/src/util/check-latest-version.test.ts
+++ b/packages/sandbox/src/util/check-latest-version.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { isOutdated } from "./check-latest-version";
+
+describe("isOutdated", () => {
+  it("flags older majors, minors and patches", () => {
+    expect(isOutdated("3.5.2", "4.0.0")).toBe(true);
+    expect(isOutdated("4.0.0", "4.1.0")).toBe(true);
+    expect(isOutdated("4.1.0", "4.1.1")).toBe(true);
+  });
+
+  it("does not flag equal or newer versions", () => {
+    expect(isOutdated("4.0.0", "4.0.0")).toBe(false);
+    expect(isOutdated("4.1.0", "4.0.9")).toBe(false);
+    expect(isOutdated("5.0.0", "4.9.9")).toBe(false);
+  });
+
+  it("opts out for prerelease versions on either side", () => {
+    expect(isOutdated("4.1.0-beta.0", "4.1.0")).toBe(false);
+    expect(isOutdated("4.0.0", "4.1.0-beta.0")).toBe(false);
+  });
+
+  it("opts out when a segment is not numeric", () => {
+    expect(isOutdated("4.0.0", "not-a-version")).toBe(false);
+  });
+});

--- a/packages/sandbox/src/util/check-latest-version.test.ts
+++ b/packages/sandbox/src/util/check-latest-version.test.ts
@@ -24,7 +24,7 @@ describe("isOutdated", () => {
   });
 });
 
-import { vi, beforeEach, afterEach } from "vitest";
+import { vi, beforeEach, afterEach, type MockInstance } from "vitest";
 import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import Path from "node:path";
@@ -33,7 +33,7 @@ import { startLatestVersionCheck } from "./check-latest-version";
 describe("startLatestVersionCheck", () => {
   let dir: string;
   let cachePath: string;
-  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: MockInstance<typeof process.stderr.write>;
 
   beforeEach(() => {
     dir = mkdtempSync(Path.join(tmpdir(), "sandbox-version-"));

--- a/packages/sandbox/src/util/check-latest-version.ts
+++ b/packages/sandbox/src/util/check-latest-version.ts
@@ -1,46 +1,133 @@
 import chalk from "chalk";
+import xdgAppPaths from "xdg-app-paths";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import Path from "node:path";
 import { version } from "../pkg";
 
 const REGISTRY_URL = "https://registry.npmjs.org/sandbox/latest";
 
+/**
+ * Re-check the registry at most once per hour; the cache file answers in
+ * between, so most commands never touch the network. Mirrors the Vercel
+ * CLI's caching approach (XDG cache file + refresh interval), without the
+ * detached worker process it uses.
+ */
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Budget for a registry round trip when one does run. `report()` aborts an
+ * in-flight request anyway, so this only bounds how long a slow registry has
+ * to answer before the notice is skipped for this run.
+ */
+const FETCH_TIMEOUT_MS = 1000;
+
+interface VersionCache {
+  latest: string;
+  checkedAt: number;
+}
+
 export interface VersionCheck {
   /**
-   * Print a stderr notice when a newer release is already known.
-   * Synchronous and non-blocking: if the registry hasn't answered yet,
-   * nothing is printed.
+   * Print a stderr notice when a newer release is known (from the cache or
+   * from a lookup that finished in time), and abort any still-in-flight
+   * registry request so it can never keep the process alive after the
+   * command is done.
    */
   report(): void;
 }
 
+/** Options exist for tests; production callers pass nothing. */
+export interface VersionCheckOptions {
+  cachePath?: string;
+  ttlMs?: number;
+  fetchImpl?: typeof fetch;
+  currentVersion?: string;
+}
+
+function defaultCachePath(): string {
+  return Path.join(xdgAppPaths("sandbox-cli").cache(), "latest-version.json");
+}
+
+function readCache(cachePath: string): VersionCache | undefined {
+  try {
+    const parsed = JSON.parse(readFileSync(cachePath, "utf8")) as VersionCache;
+    if (
+      typeof parsed.latest === "string" &&
+      typeof parsed.checkedAt === "number"
+    ) {
+      return parsed;
+    }
+  } catch {
+    // A missing or corrupt cache is the same as no cache.
+  }
+  return undefined;
+}
+
+function writeCache(cachePath: string, cache: VersionCache): void {
+  try {
+    mkdirSync(Path.dirname(cachePath), { recursive: true });
+    writeFileSync(cachePath, JSON.stringify(cache));
+  } catch {
+    // The cache is best-effort; the next run simply checks again.
+  }
+}
+
 /**
- * Start a latest-version lookup concurrently with the command's own network
- * work, so the check adds no latency of its own. Stale clients silently keep
- * old creation defaults (e.g. the base image), so surfacing "you're behind"
- * at creation time is the only signal that reaches globally-installed CLIs.
+ * Start a latest-version check. With a fresh cache this is synchronous and
+ * network-free; with a stale or missing cache it fires one registry lookup
+ * concurrently with the command's own network work, so it adds no latency.
+ * Stale clients silently keep old creation defaults (e.g. the base image),
+ * so surfacing "you're behind" at creation time is the only signal that
+ * reaches globally-installed CLIs.
  *
  * Set SANDBOX_SKIP_VERSION_CHECK=1 to disable (e.g. in CI).
  */
-export function startLatestVersionCheck(): VersionCheck {
-  let latest: string | undefined;
+export function startLatestVersionCheck(
+  opts: VersionCheckOptions = {},
+): VersionCheck {
+  if (process.env.SANDBOX_SKIP_VERSION_CHECK) {
+    return { report() {} };
+  }
 
-  if (!process.env.SANDBOX_SKIP_VERSION_CHECK) {
-    fetch(REGISTRY_URL, { signal: AbortSignal.timeout(1500) })
+  const cachePath = opts.cachePath ?? defaultCachePath();
+  const ttlMs = opts.ttlMs ?? CACHE_TTL_MS;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const current = opts.currentVersion ?? version;
+
+  const cached = readCache(cachePath);
+  let latest = cached?.latest;
+  let controller: AbortController | undefined;
+
+  const fresh = cached !== undefined && Date.now() - cached.checkedAt < ttlMs;
+  if (!fresh) {
+    controller = new AbortController();
+    const timeout = setTimeout(() => controller?.abort(), FETCH_TIMEOUT_MS);
+    timeout.unref?.();
+    fetchImpl(REGISTRY_URL, { signal: controller.signal })
       .then((res) => (res.ok ? res.json() : undefined))
       .then((json) => {
-        latest = (json as { version?: string } | undefined)?.version;
+        const fetched = (json as { version?: string } | undefined)?.version;
+        if (fetched) {
+          latest = fetched;
+          writeCache(cachePath, { latest: fetched, checkedAt: Date.now() });
+        }
       })
       .catch(() => {
         // Never let the version check interfere with the actual command.
-      });
+      })
+      .finally(() => clearTimeout(timeout));
   }
 
   return {
     report() {
-      if (latest && isOutdated(version, latest)) {
+      // Tear down an in-flight request first: a pending registry call must
+      // not keep the event loop alive after the command has finished.
+      controller?.abort();
+      if (latest && isOutdated(current, latest)) {
         process.stderr.write(
           chalk.yellow("⚠ ") +
             `A newer Sandbox CLI is available: ${chalk.cyan(latest)}` +
-            chalk.dim(` (you're on ${version})`) +
+            chalk.dim(` (you're on ${current})`) +
             "\n" +
             chalk.dim("   ╰ ") +
             "newer versions can change creation defaults like the base image. Update with " +

--- a/packages/sandbox/src/util/check-latest-version.ts
+++ b/packages/sandbox/src/util/check-latest-version.ts
@@ -1,0 +1,76 @@
+import chalk from "chalk";
+import { version } from "../pkg";
+
+const REGISTRY_URL = "https://registry.npmjs.org/sandbox/latest";
+
+export interface VersionCheck {
+  /**
+   * Print a stderr notice when a newer release is already known.
+   * Synchronous and non-blocking: if the registry hasn't answered yet,
+   * nothing is printed.
+   */
+  report(): void;
+}
+
+/**
+ * Start a latest-version lookup concurrently with the command's own network
+ * work, so the check adds no latency of its own. Stale clients silently keep
+ * old creation defaults (e.g. the base image), so surfacing "you're behind"
+ * at creation time is the only signal that reaches globally-installed CLIs.
+ *
+ * Set SANDBOX_SKIP_VERSION_CHECK=1 to disable (e.g. in CI).
+ */
+export function startLatestVersionCheck(): VersionCheck {
+  let latest: string | undefined;
+
+  if (!process.env.SANDBOX_SKIP_VERSION_CHECK) {
+    fetch(REGISTRY_URL, { signal: AbortSignal.timeout(1500) })
+      .then((res) => (res.ok ? res.json() : undefined))
+      .then((json) => {
+        latest = (json as { version?: string } | undefined)?.version;
+      })
+      .catch(() => {
+        // Never let the version check interfere with the actual command.
+      });
+  }
+
+  return {
+    report() {
+      if (latest && isOutdated(version, latest)) {
+        process.stderr.write(
+          chalk.yellow("⚠ ") +
+            `A newer Sandbox CLI is available: ${chalk.cyan(latest)}` +
+            chalk.dim(` (you're on ${version})`) +
+            "\n" +
+            chalk.dim("   ╰ ") +
+            "newer versions can change creation defaults like the base image. Update with " +
+            chalk.cyan("npm i -g sandbox@latest") +
+            "\n",
+        );
+      }
+    },
+  };
+}
+
+/**
+ * Minimal x.y.z comparison. Prerelease versions on either side opt out of
+ * the notice entirely rather than risking a wrong comparison.
+ */
+export function isOutdated(current: string, latest: string): boolean {
+  if (current.includes("-") || latest.includes("-")) {
+    return false;
+  }
+  const c = current.split(".").map(Number);
+  const l = latest.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const a = c[i] ?? 0;
+    const b = l[i] ?? 0;
+    if (Number.isNaN(a) || Number.isNaN(b)) {
+      return false;
+    }
+    if (b !== a) {
+      return b > a;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
Last of four PRs splitting #295 per change; #296, #298 and #299 are merged. Rebased onto main.

## What

`create`/`sh`/`run` print an update notice after the summary when the install is behind. Per review, the mechanism is now cache-first, modeled on the Vercel CLI's `package-updates` cache (minus its detached worker):

- The registry answer is cached to an XDG cache file (`sandbox-cli/latest-version.json`) and refreshed at most once per hour — most commands never touch the network.
- When a lookup does run, it fires concurrently with the creation request (1s budget), and `report()` aborts any still-in-flight request, so a slow registry can never keep the event loop alive or delay command exit.
- Prereleases opt out; disable with `SANDBOX_SKIP_VERSION_CHECK=1`. Failures are silent and best-effort.

## Why

Stale clients are the recurring VMI-rollout wound: globally-installed CLIs and npx caches silently boot the pre-VMI image with no coding agents (the default is chosen client-side). rauchg personally hit this. npx`@latest` copy discipline can't fix an existing global install — the CLI itself has to say it's behind.

## Changelog entry (changeset included)

> `create`, `sh`, and `run` check for a newer published CLI concurrently with sandbox creation and print an update notice when the install is stale. Disable with `SANDBOX_SKIP_VERSION_CHECK=1`.

## Verification

- check-latest-version unit tests: 9/9 pass (fresh-cache serves without fetch, stale cache refreshes and persists, report() aborts in-flight requests, corrupt cache treated as missing, env kill-switch)
- Live (2026-08-14, branch build, local version set behind): cold run fetched + wrote the cache file, warm run printed the notice from cache; both runs showed the notice — the cold-start race from the first revision is gone
- `pnpm build` (turbo `typecheck` + `build`): 8/8 tasks, exit 0. Note that `typecheck` dependsOn `^build`, so running `tsc` directly in the package without building the workspace SDK first reports unrelated errors.
- `pnpm test`: 4/4 tasks, 571 tests passed across the three packages
