### PR TITLE
[sandbox-cli] quiet lookup 404s with a sandbox ls hint

### DIFF
--- a/.changeset/cli-404-ls-hint.md
+++ b/.changeset/cli-404-ls-hint.md
@@ -1,0 +1,5 @@
+---
+"sandbox": patch
+---
+
+Sandbox-lookup 404 errors now suggest running `sandbox ls` to see your sandboxes instead of ending at a raw API error.

--- a/.changeset/cli-404-ls-hint.md
+++ b/.changeset/cli-404-ls-hint.md
@@ -2,4 +2,4 @@
 "sandbox": patch
 ---
 
-Sandbox-lookup 404 errors are now quiet and actionable: the error states the name was not found, the status code, and a closing hint to run `sandbox ls`. The request URL and response-buffer path move behind `DEBUG=sandbox:errors`.
+Sandbox-lookup 404 errors are now quiet and actionable: the error states the name was not found, the status code, and a closing hint to run `sandbox ls --all`. The request URL and response-buffer path move behind `DEBUG=sandbox:errors`.

--- a/.changeset/cli-404-ls-hint.md
+++ b/.changeset/cli-404-ls-hint.md
@@ -2,4 +2,4 @@
 "sandbox": patch
 ---
 
-Sandbox-lookup 404 errors now suggest running `sandbox ls` to see your sandboxes instead of ending at a raw API error.
+Sandbox-lookup 404 errors are now quiet and actionable: the error states the name was not found, the status code, and a closing hint to run `sandbox ls`. The request URL and response-buffer path move behind `DEBUG=sandbox:errors`.

--- a/packages/sandbox/src/util/format-error.test.ts
+++ b/packages/sandbox/src/util/format-error.test.ts
@@ -83,7 +83,7 @@ describe("formatApiError", () => {
       value: "https://vercel.com/api/v2/sandboxes/doesnotexist?teamId=t",
     });
     const styled = await formatApiError(apiError);
-    expect(styled.message).toContain("sandbox ls");
+    expect(styled.message).toContain("sandbox ls --all");
   });
 
   it("keeps lookup 404s quiet: no request url or buffer path by default", async () => {
@@ -113,7 +113,7 @@ describe("formatApiError", () => {
       const styled = await formatApiError(apiError);
       expect(styled.message).toContain("requested url");
       expect(styled.message).toContain("response buffer");
-      expect(styled.message).toContain("sandbox ls");
+      expect(styled.message).toContain("sandbox ls --all");
     } finally {
       createDebugger.enable(previous);
     }

--- a/packages/sandbox/src/util/format-error.test.ts
+++ b/packages/sandbox/src/util/format-error.test.ts
@@ -76,6 +76,24 @@ describe("formatApiError", () => {
     expect(styled.message).toContain("the request was invalid (400)");
     expect(styled.cause).toBe(apiError);
   });
+
+  it("suggests `sandbox ls` when a sandbox lookup 404s", async () => {
+    const apiError = makeApiError(404);
+    Object.defineProperty(apiError.response, "url", {
+      value: "https://vercel.com/api/v2/sandboxes/doesnotexist?teamId=t",
+    });
+    const styled = await formatApiError(apiError);
+    expect(styled.message).toContain("sandbox ls");
+  });
+
+  it("does not suggest `sandbox ls` for non-sandbox 404s", async () => {
+    const apiError = makeApiError(404);
+    Object.defineProperty(apiError.response, "url", {
+      value: "https://vercel.com/api/v2/snapshots/nope",
+    });
+    const styled = await formatApiError(apiError);
+    expect(styled.message).not.toContain("sandbox ls");
+  });
 });
 
 describe("formatApiTimeoutError / formatStreamError", () => {

--- a/packages/sandbox/src/util/format-error.test.ts
+++ b/packages/sandbox/src/util/format-error.test.ts
@@ -86,6 +86,39 @@ describe("formatApiError", () => {
     expect(styled.message).toContain("sandbox ls");
   });
 
+  it("keeps lookup 404s quiet: no request url or buffer path by default", async () => {
+    const apiError = makeApiError(404);
+    Object.defineProperty(apiError.response, "url", {
+      value: "https://vercel.com/api/v2/sandboxes/doesnotexist?teamId=t",
+    });
+    const styled = await formatApiError(apiError);
+    expect(styled.message).not.toContain("requested url");
+    expect(styled.message).not.toContain("response buffer");
+    expect(styled.message).toContain("status code: 404");
+    // The hint is the closing line of the quiet form.
+    expect(styled.message.trimEnd().split("\n").at(-1)).toContain(
+      "sandbox ls",
+    );
+  });
+
+  it("restores request detail on lookup 404s when DEBUG=sandbox:errors", async () => {
+    const createDebugger = (await import("debug")).default;
+    const previous = createDebugger.disable();
+    createDebugger.enable("sandbox:errors");
+    try {
+      const apiError = makeApiError(404);
+      Object.defineProperty(apiError.response, "url", {
+        value: "https://vercel.com/api/v2/sandboxes/doesnotexist?teamId=t",
+      });
+      const styled = await formatApiError(apiError);
+      expect(styled.message).toContain("requested url");
+      expect(styled.message).toContain("response buffer");
+      expect(styled.message).toContain("sandbox ls");
+    } finally {
+      createDebugger.enable(previous);
+    }
+  });
+
   it("does not suggest `sandbox ls` for non-sandbox 404s", async () => {
     const apiError = makeApiError(404);
     Object.defineProperty(apiError.response, "url", {

--- a/packages/sandbox/src/util/format-error.ts
+++ b/packages/sandbox/src/util/format-error.ts
@@ -38,7 +38,7 @@ export async function formatApiError(
       [
         message,
         `├▶ status code: ${status} ${error.response.statusText}`,
-        `╰▶ ${chalk.bold("hint:")} run ${chalk.cyan("sandbox ls")} to see the sandboxes in this project.`,
+        `╰▶ ${chalk.bold("hint:")} run ${chalk.cyan("sandbox ls --all")} to see the sandboxes in this project.`,
       ].join("\n"),
       error,
     );
@@ -52,7 +52,7 @@ export async function formatApiError(
   ];
   if (isLookupMiss) {
     lines.push(
-      `├▶ ${chalk.bold("hint:")} run ${chalk.cyan("sandbox ls")} to see the sandboxes in this project.`,
+      `├▶ ${chalk.bold("hint:")} run ${chalk.cyan("sandbox ls --all")} to see the sandboxes in this project.`,
     );
   }
   lines.push(

--- a/packages/sandbox/src/util/format-error.ts
+++ b/packages/sandbox/src/util/format-error.ts
@@ -30,8 +30,15 @@ export async function formatApiError(
     message,
     `├▶ requested url: ${error.response.url}`,
     `├▶ status code: ${status} ${error.response.statusText}`,
-    `╰▶ ${chalk.bold("hint:")} the full response buffer is stored in ${chalk.italic(tmpPath)}`,
   ];
+  if (status === 404 && /\/sandboxes\//.test(error.response.url)) {
+    lines.push(
+      `├▶ ${chalk.bold("hint:")} run ${chalk.cyan("sandbox ls")} to see the sandboxes in this project.`,
+    );
+  }
+  lines.push(
+    `╰▶ ${chalk.bold("hint:")} the full response buffer is stored in ${chalk.italic(tmpPath)}`,
+  );
   return new StyledError(lines.join("\n"), error);
 }
 

--- a/packages/sandbox/src/util/format-error.ts
+++ b/packages/sandbox/src/util/format-error.ts
@@ -22,16 +22,35 @@ const ApiErrorResponse = z.object({
 export async function formatApiError(
   error: APIError<unknown>,
 ): Promise<StyledError> {
-  const tmpPath = await writeResponseToTemp(error);
   const status = error.response.status;
   const parsedError = ApiErrorResponse.safeParse(error.json);
   const message = parsedError.data?.error.message ?? getErrorMessage(status);
+
+  // A 404 on a sandbox lookup is almost always a mistyped or removed name: a
+  // user mistake with a clear next step, not a system failure. Keep that
+  // output quiet and actionable; DEBUG=sandbox:errors restores the request
+  // detail and the response buffer.
+  const isLookupMiss =
+    status === 404 && /\/sandboxes\//.test(error.response.url);
+  if (isLookupMiss && !debug.enabled) {
+    debug(`requested url: ${error.response.url}`);
+    return new StyledError(
+      [
+        message,
+        `├▶ status code: ${status} ${error.response.statusText}`,
+        `╰▶ ${chalk.bold("hint:")} run ${chalk.cyan("sandbox ls")} to see the sandboxes in this project.`,
+      ].join("\n"),
+      error,
+    );
+  }
+
+  const tmpPath = await writeResponseToTemp(error);
   const lines = [
     message,
     `├▶ requested url: ${error.response.url}`,
     `├▶ status code: ${status} ${error.response.statusText}`,
   ];
-  if (status === 404 && /\/sandboxes\//.test(error.response.url)) {
+  if (isLookupMiss) {
     lines.push(
       `├▶ ${chalk.bold("hint:")} run ${chalk.cyan("sandbox ls")} to see the sandboxes in this project.`,
     );


### PR DESCRIPTION
Third of four PRs splitting #295 per change (independent, no stack).

## What

A 404 on a `/sandboxes/` route becomes a quiet, actionable error: the not-found message, the status code, and a closing `run sandbox ls` hint. The requested-url and response-buffer lines move behind `DEBUG=sandbox:errors` (the buffer file is only written in debug mode).

Default:

```
Named sandbox 'my-sandbox' not found for this project.
├▶ status code: 404 Not Found
╰▶ hint: run sandbox ls to see the sandboxes in this project.
```

With `DEBUG=sandbox:errors`, the full form (url + buffer path) is restored, with the hint included.

## Why

New-user friction audit: `sandbox connect <unknown-name>` dumps the raw API URL (teamId, internal query params, a .http buffer path) with no next step. Debugging gold, onboarding poison — the hint gives the user their way forward.

## Changelog entry (changeset included)

> Sandbox-lookup 404 errors now suggest running `sandbox ls` to see your sandboxes instead of ending at a raw API error.

## Verification

- format-error unit tests: 17/17 pass (quiet default + DEBUG restore covered)
- `pnpm typecheck` clean
