### PR TITLE
[sandbox-sdk] adopt the new snapshot defaults

### DIFF
--- a/.changeset/snapshot-defaults.md
+++ b/.changeset/snapshot-defaults.md
@@ -1,0 +1,7 @@
+---
+"@vercel/sandbox": major
+"@vercel/sandbox-mock": major
+"sandbox": major
+---
+
+**Breaking:** adopt the new snapshot defaults. Snapshots now expire after 7 days by default instead of 30, and persistent sandboxes get a `{ count: 1, deleteEvicted: true }` retention policy unless one is given: only the most recent snapshot is kept, and taking a new one deletes the previous snapshot immediately instead of leaving it around until it expires. Pass `keepLastSnapshots: null` (CLI: `--keep-last-snapshots 0`) to keep every snapshot until it expires.

--- a/.changeset/snapshot-defaults.md
+++ b/.changeset/snapshot-defaults.md
@@ -4,4 +4,7 @@
 "sandbox": major
 ---
 
-**Breaking:** adopt the new snapshot defaults. Snapshots now expire after 7 days by default instead of 30, and persistent sandboxes get a `{ count: 1, deleteEvicted: true }` retention policy unless one is given: only the most recent snapshot is kept, and taking a new one deletes the previous snapshot immediately instead of leaving it around until it expires. Pass `keepLastSnapshots: null` (CLI: `--keep-last-snapshots 0`) to keep every snapshot until it expires.
+**\[Breaking\]** Reduced default snapshots retention:
+
+- Snapshots now expire after 7 days by default instead of 30 days previously. You can keep using expiration to set a custom snapshot expiration window in milliseconds, or set it to 0 to disable expiration.
+- Persistent sandboxes now preserve only the last session's snapshot by default, instead of the snapshot of each session. You can still set a custom retention policy via keepLastSnapshots.

--- a/packages/sandbox/src/args/snapshot-retention.ts
+++ b/packages/sandbox/src/args/snapshot-retention.ts
@@ -5,7 +5,7 @@ export const snapshotExpiration = cmd.option({
   long: "snapshot-expiration",
   type: cmd.optional(SnapshotExpiration),
   description:
-    'Default snapshot expiration. Use "none" or 0 for no expiration. Example: 7d, 30d',
+    'Default snapshot expiration (7d when omitted). Use "none" or 0 for no expiration. Example: 7d, 30d',
 });
 
 export const keepLastSnapshots = cmd.option({
@@ -14,23 +14,24 @@ export const keepLastSnapshots = cmd.option({
     cmd.extendType(cmd.number, {
       displayName: "COUNT",
       async from(n) {
-        if (!Number.isInteger(n) || n < 1 || n > 10) {
+        if (!Number.isInteger(n) || n < 0 || n > 10) {
           throw new Error(
-            `Invalid --keep-last-snapshots value: ${n}. Must be an integer between 1 and 10.`,
+            `Invalid --keep-last-snapshots value: ${n}. Must be an integer between 0 and 10.`,
           );
         }
         return n;
       },
     }),
   ),
-  description: "Keep only the N most recent snapshots of this sandbox (1-10).",
+  description:
+    "Keep only the N most recent snapshots of this sandbox (1-10). Persistent sandboxes keep 1 by default; pass 0 to keep every snapshot until it expires.",
 });
 
 export const keepLastSnapshotsFor = cmd.option({
   long: "keep-last-snapshots-for",
   type: cmd.optional(SnapshotExpiration),
   description:
-    'Expiration applied to kept snapshots. Use "none" or 0 for no expiration. Example: 7d, 30d',
+    'Expiration applied to kept snapshots (7d when omitted). Use "none" or 0 for no expiration. Example: 7d, 30d',
 });
 
 export const deleteEvictedSnapshots = cmd.option({

--- a/packages/sandbox/src/commands/snapshot.ts
+++ b/packages/sandbox/src/commands/snapshot.ts
@@ -20,7 +20,8 @@ export const args = {
   expiration: cmd.option({
     long: "expiration",
     type: cmd.optional(Duration),
-    description: "The expiration time of the snapshot. Use 0 for no expiration.",
+    description:
+      "The expiration time of the snapshot. Defaults to the sandbox's snapshot expiration, or 7d. Use 0 for no expiration.",
   }),
   sandbox: cmd.positional({
     type: sandboxName as cmd.Type<string, string | Sandbox>,

--- a/packages/sandbox/src/util/keep-last-snapshots.test.ts
+++ b/packages/sandbox/src/util/keep-last-snapshots.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { buildKeepLastSnapshotsPayload } from "./keep-last-snapshots";
+
+describe("buildKeepLastSnapshotsPayload", () => {
+  it("returns undefined when no retention flag is passed", () => {
+    expect(
+      buildKeepLastSnapshotsPayload({
+        keepLastSnapshots: undefined,
+        keepLastSnapshotsFor: undefined,
+        deleteEvictedSnapshots: undefined,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("builds the payload from a count", () => {
+    expect(
+      buildKeepLastSnapshotsPayload({
+        keepLastSnapshots: 3,
+        keepLastSnapshotsFor: undefined,
+        deleteEvictedSnapshots: undefined,
+      }),
+    ).toEqual({ count: 3, expiration: undefined, deleteEvicted: undefined });
+  });
+
+  it("builds the payload from all the flags", () => {
+    expect(
+      buildKeepLastSnapshotsPayload({
+        keepLastSnapshots: 2,
+        keepLastSnapshotsFor: "7d",
+        deleteEvictedSnapshots: "true",
+      }),
+    ).toEqual({
+      count: 2,
+      expiration: 7 * 24 * 60 * 60 * 1000,
+      deleteEvicted: true,
+    });
+  });
+
+  it("returns null for a count of 0 to disable the default policy", () => {
+    expect(
+      buildKeepLastSnapshotsPayload({
+        keepLastSnapshots: 0,
+        keepLastSnapshotsFor: undefined,
+        deleteEvictedSnapshots: undefined,
+      }),
+    ).toBeNull();
+  });
+
+  it("throws when a count of 0 is combined with an expiration", () => {
+    expect(() =>
+      buildKeepLastSnapshotsPayload({
+        keepLastSnapshots: 0,
+        keepLastSnapshotsFor: "7d",
+        deleteEvictedSnapshots: undefined,
+      }),
+    ).toThrow(/cannot be combined with --keep-last-snapshots 0/);
+  });
+
+  it("throws when a count of 0 is combined with --delete-evicted-snapshots", () => {
+    expect(() =>
+      buildKeepLastSnapshotsPayload({
+        keepLastSnapshots: 0,
+        keepLastSnapshotsFor: undefined,
+        deleteEvictedSnapshots: "false",
+      }),
+    ).toThrow(/cannot be combined with --keep-last-snapshots 0/);
+  });
+
+  it("throws when the companion flags are passed without a count", () => {
+    expect(() =>
+      buildKeepLastSnapshotsPayload({
+        keepLastSnapshots: undefined,
+        keepLastSnapshotsFor: "7d",
+        deleteEvictedSnapshots: undefined,
+      }),
+    ).toThrow(/require --keep-last-snapshots/);
+  });
+});

--- a/packages/sandbox/src/util/keep-last-snapshots.ts
+++ b/packages/sandbox/src/util/keep-last-snapshots.ts
@@ -17,15 +17,16 @@ export interface KeepLastSnapshotsPayload {
 
 /**
  * Validates the `--keep-last-snapshots*` flag combination and builds the
- * payload object that the SDK expects, or returns `undefined` when no
- * retention policy was configured.
+ * payload object that the SDK expects. Returns `undefined` when no retention
+ * policy was configured, and `null` when `--keep-last-snapshots 0` opts out of
+ * the default policy.
  *
  * Throws when `--keep-last-snapshots-for` or `--delete-evicted-snapshots` are
- * passed without `--keep-last-snapshots`.
+ * passed without `--keep-last-snapshots`, or combined with a count of `0`.
  */
 export function buildKeepLastSnapshotsPayload(
   input: KeepLastSnapshotsInput,
-): KeepLastSnapshotsPayload | undefined {
+): KeepLastSnapshotsPayload | null | undefined {
   const { keepLastSnapshots, keepLastSnapshotsFor, deleteEvictedSnapshots } =
     input;
 
@@ -44,6 +45,21 @@ export function buildKeepLastSnapshotsPayload(
 
   if (keepLastSnapshots === undefined) {
     return undefined;
+  }
+
+  if (keepLastSnapshots === 0) {
+    if (
+      keepLastSnapshotsFor !== undefined ||
+      deleteEvictedSnapshots !== undefined
+    ) {
+      throw new Error(
+        [
+          "--keep-last-snapshots-for and --delete-evicted-snapshots cannot be combined with --keep-last-snapshots 0.",
+          `${chalk.bold("hint:")} A count of 0 disables the retention policy, so there is nothing to configure.`,
+        ].join("\n"),
+      );
+    }
+    return null;
   }
 
   return {

--- a/packages/vercel-sandbox-mock/src/fork.test.ts
+++ b/packages/vercel-sandbox-mock/src/fork.test.ts
@@ -95,6 +95,20 @@ describe("Sandbox.fork", () => {
     }
   });
 
+  test("falls back to the 7 day snapshot expiration when neither side sets one", async () => {
+    const name = uniq();
+    const source = await Sandbox.create({ name, persistent: true });
+
+    let fork: Sandbox | undefined;
+    try {
+      fork = await Sandbox.fork({ sourceSandbox: name });
+      expect(fork.snapshotExpiration).toBe(7 * DAY);
+      expect(fork.keepLastSnapshots).toEqual({ count: 1, deleteEvicted: true });
+    } finally {
+      await Promise.allSettled([fork?.delete(), source.delete()]);
+    }
+  });
+
   test("rejects when the source sandbox does not exist", async () => {
     await expect(
       Sandbox.fork({ sourceSandbox: `missing-${randomUUID().slice(0, 8)}` }),

--- a/packages/vercel-sandbox-mock/src/sandbox.test.ts
+++ b/packages/vercel-sandbox-mock/src/sandbox.test.ts
@@ -2,6 +2,8 @@ import { randomUUID } from "node:crypto";
 import { describe, expect, test } from "vitest";
 import { Sandbox } from "./sandbox";
 
+const DAY = 24 * 60 * 60 * 1000;
+
 const uniq = () => `sb-${randomUUID().slice(0, 8)}`;
 
 describe("Sandbox (real SDK over mock fetch)", () => {
@@ -10,6 +12,24 @@ describe("Sandbox (real SDK over mock fetch)", () => {
     const result = await sandbox.runCommand("echo", ["hi"]);
     expect(await result.stdout()).toBe("hi\n");
     await sandbox.stop();
+  });
+
+  test("persistent sandboxes get the default snapshot defaults", async () => {
+    const sandbox = await Sandbox.create({ name: uniq(), persistent: true });
+    expect(sandbox.snapshotExpiration).toBe(7 * DAY);
+    expect(sandbox.keepLastSnapshots).toEqual({ count: 1, deleteEvicted: true });
+    await sandbox.delete();
+  });
+
+  test("keepLastSnapshots: null opts out of the default retention policy", async () => {
+    const sandbox = await Sandbox.create({
+      name: uniq(),
+      persistent: true,
+      keepLastSnapshots: null,
+    });
+    expect(sandbox.keepLastSnapshots).toBeUndefined();
+    expect(sandbox.snapshotExpiration).toBe(7 * DAY);
+    await sandbox.delete();
   });
 
   test("get on an unknown name throws a 404 APIError", async () => {

--- a/packages/vercel-sandbox-mock/src/server/mock-server.ts
+++ b/packages/vercel-sandbox-mock/src/server/mock-server.ts
@@ -24,6 +24,24 @@ import {
 
 const DEFAULT_CWD = "/vercel/sandbox";
 const REGION = "iad1";
+const DEFAULT_SNAPSHOT_EXPIRATION_MS = 7 * 24 * 60 * 60 * 1000;
+const DEFAULT_SNAPSHOT_KEEP_LAST = { count: 1, deleteEvicted: true } as const;
+
+/**
+ * Mirrors the server default: persistent sandboxes keep only their latest
+ * snapshot unless the caller opts out with `null`.
+ */
+function resolveKeepLastSnapshots(
+  body: CreateBody,
+  fallback?: SandboxRecord["keepLastSnapshots"],
+): SandboxRecord["keepLastSnapshots"] {
+  if (body.keepLastSnapshots === null) return undefined;
+  if (body.keepLastSnapshots !== undefined) return body.keepLastSnapshots;
+  if (fallback !== undefined) return fallback;
+  return body.persistent !== false
+    ? { ...DEFAULT_SNAPSHOT_KEEP_LAST }
+    : undefined;
+}
 
 function newId(prefix: string): string {
   return `${prefix}_${randomUUID().replace(/-/g, "")}`;
@@ -45,7 +63,7 @@ interface CreateBody {
     count: number;
     expiration?: number;
     deleteEvicted?: boolean;
-  };
+  } | null;
   source?: { type: "git" | "tarball" | "snapshot"; snapshotId?: string };
 }
 
@@ -151,8 +169,9 @@ export class MockServer {
       ports,
       createdAt: Date.now(),
       updatedAt: Date.now(),
-      snapshotExpiration: body.snapshotExpiration,
-      keepLastSnapshots: body.keepLastSnapshots,
+      snapshotExpiration:
+        body.snapshotExpiration ?? DEFAULT_SNAPSHOT_EXPIRATION_MS,
+      keepLastSnapshots: resolveKeepLastSnapshots(body),
       sessionId: "",
       users: createUserState(),
     };
@@ -213,8 +232,14 @@ export class MockServer {
       ports: body.ports ?? source.ports,
       createdAt: Date.now(),
       updatedAt: Date.now(),
-      snapshotExpiration: body.snapshotExpiration ?? source.snapshotExpiration,
-      keepLastSnapshots: body.keepLastSnapshots ?? source.keepLastSnapshots,
+      snapshotExpiration:
+        body.snapshotExpiration ??
+        source.snapshotExpiration ??
+        DEFAULT_SNAPSHOT_EXPIRATION_MS,
+      keepLastSnapshots: resolveKeepLastSnapshots(
+        body,
+        source.keepLastSnapshots,
+      ),
       sessionId: "",
       users: createUserState(),
     };
@@ -458,6 +483,10 @@ export class MockServer {
     const body = readJson<{ expiration?: number }>(init);
     const files = await captureFileSystem(session.executor.fs);
     const record = this.#sandboxes.get(session.sandboxName)!;
+    const expiration =
+      body.expiration ??
+      record.snapshotExpiration ??
+      DEFAULT_SNAPSHOT_EXPIRATION_MS;
     const snapshot: SnapshotRecord = {
       id: newId("snap"),
       sandboxName: session.sandboxName,
@@ -471,7 +500,7 @@ export class MockServer {
       ),
       createdAt: Date.now(),
       updatedAt: Date.now(),
-      expiresAt: body.expiration ? Date.now() + body.expiration : undefined,
+      expiresAt: expiration ? Date.now() + expiration : undefined,
       parentId: record.currentSnapshotId,
       files,
     };

--- a/packages/vercel-sandbox/src/api-client/api-client.test.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.test.ts
@@ -1228,6 +1228,9 @@ describe("APIClient", () => {
       expect(mockFetch.mock.calls[0]?.[1]?.body).toBe(
         JSON.stringify({ expiration: 0 }),
       );
+      expect(mockFetch.mock.calls[0]?.[0]).toContain(
+        "/v3/sandboxes/sessions/sbx_123/snapshot",
+      );
     });
   });
 
@@ -1312,6 +1315,20 @@ describe("APIClient", () => {
       expect(body).not.toHaveProperty("keepLastSnapshots");
     });
 
+    it("sends null keepLastSnapshots to opt out of the default policy", async () => {
+      mockFetch.mockResolvedValue(sandboxResponse());
+
+      await client.createSandbox({
+        projectId: "proj_123",
+        keepLastSnapshots: null,
+      });
+
+      const [, opts] = mockFetch.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body).toHaveProperty("keepLastSnapshots");
+      expect(body.keepLastSnapshots).toBeNull();
+    });
+
     it("uses v2 when runtime is provided", async () => {
       mockFetch.mockResolvedValue(sandboxResponse());
 
@@ -1325,13 +1342,86 @@ describe("APIClient", () => {
       expect(JSON.parse(opts.body).runtime).toBe("node24");
     });
 
-    it("uses v3 when runtime is omitted", async () => {
+    it("uses v4 when runtime is omitted", async () => {
       mockFetch.mockResolvedValue(sandboxResponse());
 
       await client.createSandbox({ projectId: "proj_123" });
 
       const [url] = mockFetch.mock.calls[0];
-      expect(url).toContain("/v3/sandboxes");
+      expect(url).toContain("/v4/sandboxes");
+    });
+  });
+
+  describe("forkSandbox", () => {
+    let client: APIClient;
+    let mockFetch: ReturnType<typeof vi.fn>;
+
+    const sandboxResponse = () =>
+      new Response(
+        JSON.stringify({
+          sandbox: {
+            name: "my-fork",
+            persistent: true,
+            region: "iad1",
+            vcpus: 1,
+            memory: 2048,
+            timeout: 300000,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+            status: "running",
+            currentSessionId: "sbx_123",
+          },
+          session: {
+            id: "sbx_123",
+            memory: 2048,
+            vcpus: 1,
+            region: "iad1",
+            timeout: 300000,
+            status: "running",
+            requestedAt: Date.now(),
+            createdAt: Date.now(),
+            cwd: "/",
+            updatedAt: Date.now(),
+          },
+          routes: [],
+        }),
+        { headers: { "content-type": "application/json" } },
+      );
+
+    beforeEach(() => {
+      mockFetch = vi.fn();
+      client = new APIClient({
+        teamId: "team_123",
+        token: "1234",
+        fetch: mockFetch,
+      });
+    });
+
+    it("uses the v3 fork endpoint", async () => {
+      mockFetch.mockResolvedValue(sandboxResponse());
+
+      await client.forkSandbox({
+        projectId: "proj_123",
+        sourceSandbox: "my-sandbox",
+      });
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain("/v3/sandboxes/my-sandbox/fork");
+    });
+
+    it("sends null keepLastSnapshots to opt out of the default policy", async () => {
+      mockFetch.mockResolvedValue(sandboxResponse());
+
+      await client.forkSandbox({
+        projectId: "proj_123",
+        sourceSandbox: "my-sandbox",
+        keepLastSnapshots: null,
+      });
+
+      const [, opts] = mockFetch.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body).toHaveProperty("keepLastSnapshots");
+      expect(body.keepLastSnapshots).toBeNull();
     });
   });
 

--- a/packages/vercel-sandbox/src/api-client/api-client.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.ts
@@ -182,13 +182,13 @@ export class APIClient extends BaseClient {
         count: number;
         expiration?: number;
         deleteEvicted?: boolean;
-      };
+      } | null;
       signal?: AbortSignal;
     }>,
   ) {
     const privateParams = getPrivateParams(params);
     const endpoint =
-      params.runtime === undefined ? "/v3/sandboxes" : "/v2/sandboxes";
+      params.runtime === undefined ? "/v4/sandboxes" : "/v2/sandboxes";
     return parseOrThrow(
       SandboxAndSessionResponse,
       await this.request(endpoint, {
@@ -235,7 +235,7 @@ export class APIClient extends BaseClient {
         count: number;
         expiration?: number;
         deleteEvicted?: boolean;
-      };
+      } | null;
       signal?: AbortSignal;
     }>,
   ) {
@@ -243,7 +243,7 @@ export class APIClient extends BaseClient {
     return parseOrThrow(
       SandboxAndSessionResponse,
       await this.request(
-        `/v2/sandboxes/${encodeURIComponent(params.sourceSandbox)}/fork`,
+        `/v3/sandboxes/${encodeURIComponent(params.sourceSandbox)}/fork`,
         {
           method: "POST",
           query: { projectId: params.projectId },
@@ -838,7 +838,7 @@ export class APIClient extends BaseClient {
     expiration?: number;
     signal?: AbortSignal;
   }): Promise<Parsed<z.infer<typeof CreateSnapshotResponse>>> {
-    const url = `/v2/sandboxes/sessions/${params.sessionId}/snapshot`;
+    const url = `/v3/sandboxes/sessions/${params.sessionId}/snapshot`;
     const body =
       params.expiration === undefined
         ? undefined

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -704,7 +704,7 @@ describe("Sandbox.create environment selection", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url, init] = mockFetch.mock.calls[0];
-    expect(String(url)).toContain("/v3/sandboxes");
+    expect(String(url)).toContain("/v4/sandboxes");
     expect(init?.method).toBe("POST");
     const body = JSON.parse(String(init?.body));
     expect(body.image).toBe("my-repo:latest");

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -117,13 +117,16 @@ export interface BaseCreateSandboxParams {
   persistent?: boolean;
   /**
    * Default snapshot expiration in milliseconds.
-   * When set, snapshots created for this sandbox will expire after this duration.
-   * Use `0` for no expiration.
+   * Snapshots created for this sandbox expire after this duration.
+   * Defaults to 7 days. Use `0` for no expiration.
    */
   snapshotExpiration?: number;
   /**
    * Retention policy that keeps only the N most recent snapshots of this
    * sandbox. Older snapshots are evicted when a new one is created.
+   *
+   * Persistent sandboxes default to `{ count: 1, deleteEvicted: true }`.
+   * Pass `null` to disable the limit and keep every snapshot until it expires.
    */
   keepLastSnapshots?: {
     /**
@@ -140,7 +143,7 @@ export interface BaseCreateSandboxParams {
      * when `false`, they keep the default expiration.
      */
     deleteEvicted?: boolean;
-  };
+  } | null;
   /**
    * Called when the sandbox session is resumed (e.g., after a snapshot restore).
    * Use this to re-warm caches, restore transient state, or run other setup logic.
@@ -743,7 +746,8 @@ export class Sandbox implements ExecutionContext {
    * base environment when it has none) and copies its config — resources,
    * timeout, ports, tags, network policy, image, persistence, snapshot
    * settings, and environment variables. Any field passed in `params` overrides
-   * the copied value.
+   * the copied value. When neither the fork nor the source sets
+   * `snapshotExpiration`, the fork falls back to the 7 day default.
    *
    * @param params - Fork parameters and optional credentials.
    *   `sourceSandbox` is the name of the source sandbox; everything else
@@ -1660,7 +1664,8 @@ export class Sandbox implements ExecutionContext {
    * Note: this sandbox will be stopped as part of the snapshot creation process.
    *
    * @param opts - Optional parameters.
-   * @param opts.expiration - Optional expiration time in milliseconds. Use 0 for no expiration at all.
+   * @param opts.expiration - Optional expiration time in milliseconds. Defaults to
+   *   the sandbox's `snapshotExpiration`, or 7 days. Use 0 for no expiration at all.
    * @param opts.signal - An AbortSignal to cancel the operation.
    * @returns A promise that resolves to the Snapshot instance
    */

--- a/packages/vercel-sandbox/src/session.ts
+++ b/packages/vercel-sandbox/src/session.ts
@@ -797,7 +797,8 @@ export class Session implements ExecutionContext {
    * Note: this session will be stopped as part of the snapshot creation process.
    *
    * @param opts - Optional parameters.
-   * @param opts.expiration - Optional expiration time in milliseconds. Use 0 for no expiration at all.
+   * @param opts.expiration - Optional expiration time in milliseconds. Defaults to
+   *   the sandbox's `snapshotExpiration`, or 7 days. Use 0 for no expiration at all.
    * @param opts.signal - An AbortSignal to cancel the operation.
    * @returns A promise that resolves to the Snapshot instance
    */

--- a/skills/sandbox/SKILL.md
+++ b/skills/sandbox/SKILL.md
@@ -965,8 +965,8 @@ sandbox create --connect
 sandbox create --name my-app
 sandbox create --image my-repo:v1            # Boot from a VCR image
 sandbox create --non-persistent              # Disable filesystem persistence
-sandbox create --snapshot-expiration 7d      # Default snapshot TTL (7d when omitted)
-sandbox create --keep-last-snapshots 1       # Retention policy (persistent default: 1)
+sandbox create --snapshot-expiration 30d      # Default snapshot TTL (7d when omitted)
+sandbox create --keep-last-snapshots 3       # Retention policy (persistent default: 1)
 sandbox create --keep-last-snapshots 0       # Keep every snapshot until it expires
 sandbox create --tag env=staging             # Repeatable
 

--- a/skills/sandbox/SKILL.md
+++ b/skills/sandbox/SKILL.md
@@ -87,7 +87,7 @@ const sandbox = await Sandbox.create({
   env: { NODE_ENV: "production" }, // Env vars inherited by all commands
   tags: { env: "staging", team: "infra" }, // Up to 5 key:value tags
   persistent: true, // Default: true. Auto-snapshots on stop, restores on resume.
-  snapshotExpiration: ms("7d"), // Default TTL for snapshots. Use 0 for no expiration.
+  snapshotExpiration: ms("7d"), // Default TTL for snapshots (7 days). Use 0 for no expiration.
 });
 
 console.log(sandbox.name);
@@ -752,7 +752,7 @@ await sandbox.runCommand("npm", ["install"]);
 
 // Create snapshot (stops the sandbox)
 const snapshot = await sandbox.snapshot({
-  expiration: ms("14d"), // Default: 30 days, use 0 for no expiration
+  expiration: ms("14d"), // Defaults to the sandbox's snapshotExpiration, or 7 days. Use 0 for no expiration.
 });
 console.log("Snapshot ID:", snapshot.snapshotId);
 ```
@@ -764,7 +764,7 @@ Configure default expiration and retention policy per sandbox:
 ```typescript
 await Sandbox.create({
   name: "my-app",
-  snapshotExpiration: ms("7d"), // Default TTL for any snapshot of this sandbox
+  snapshotExpiration: ms("7d"), // Default TTL for any snapshot of this sandbox (7 days)
   keepLastSnapshots: {
     count: 1, // Keep only the most recent snapshot (1-10)
     expiration: ms("30d"), // Override expiration for kept snapshots
@@ -773,8 +773,10 @@ await Sandbox.create({
 });
 ```
 
-`keepLastSnapshots: { count: 1 }` is the recommended setting when you only
-care about the latest snapshot — it lets the SDK keep snapshot storage costs flat.
+Persistent sandboxes already default to `{ count: 1, deleteEvicted: true }`, so
+snapshot storage stays flat without configuring anything. Raise `count` to keep
+more history, or pass `keepLastSnapshots: null` (CLI: `--keep-last-snapshots 0`)
+to disable the limit and keep every snapshot until it expires.
 
 ### List, Get, and Delete
 
@@ -963,8 +965,9 @@ sandbox create --connect
 sandbox create --name my-app
 sandbox create --image my-repo:v1            # Boot from a VCR image
 sandbox create --non-persistent              # Disable filesystem persistence
-sandbox create --snapshot-expiration 7d      # Default snapshot TTL
-sandbox create --keep-last-snapshots 1       # Retention policy
+sandbox create --snapshot-expiration 7d      # Default snapshot TTL (7d when omitted)
+sandbox create --keep-last-snapshots 1       # Retention policy (persistent default: 1)
+sandbox create --keep-last-snapshots 0       # Keep every snapshot until it expires
 sandbox create --tag env=staging             # Repeatable
 
 # Fork an existing sandbox (inherits config, incl. env; --env replaces it)


### PR DESCRIPTION
The API changed its snapshot defaults (endpoints with major versions), but the SDK, CLI and Skill still targeted the previous versions.

These are the new defaults:

- Snapshots expire after **7 days** instead of 30.
- Persistent sandboxes get a `{ count: 1, deleteEvicted: true }` retention policy by default.
- `keepLastSnapshots: null` (CLI: `--keep-last-snapshots 0`) disables the limit and keeps every snapshot until it expires.