### PR TITLE
[images] add the fx coding agent to the universal image

### DIFF
--- a/.changeset/universal-fx-agent.md
+++ b/.changeset/universal-fx-agent.md
@@ -1,0 +1,5 @@
+---
+"sandbox-image-universal": patch
+---
+
+Add the `fx` coding agent (https://fx.sh) to the universal image.

--- a/images/universal/Dockerfile
+++ b/images/universal/Dockerfile
@@ -88,6 +88,9 @@ RUN npm install -g \
     npm install -g --ignore-scripts @earendil-works/pi-coding-agent && \
     npm cache clean --force
 
+RUN curl -fsSL https://fx.sh/setup.sh | FX_INSTALL_DIR=/usr/local/bin bash && \
+    chown root:root /usr/local/bin/fx
+
 RUN chown -R ubuntu:ubuntu /vercel
 
 ENV HOME=/vercel
@@ -112,4 +115,5 @@ RUN node --version && \
     opencode --version && \
     claude --version && \
     codex --version && \
-    pi --version
+    pi --version && \
+    fx --version

--- a/images/universal/README.md
+++ b/images/universal/README.md
@@ -23,6 +23,7 @@ Runs as the default `ubuntu` user (uid 1000) with passwordless sudo.
 - Claude Code (`claude`)
 - Codex (`codex`)
 - pi (`pi`)
+- fx (`fx`)
 
 ### Utilities
 


### PR DESCRIPTION
Adds [fx](https://fx.sh) to the `universal` image alongside opencode, Claude Code, Codex and pi.