### PR TITLE
fix(sdk): limit JWKS cache size on `defineSandboxProxy`

### DIFF
--- a/.changeset/tidy-cats-cache.md
+++ b/.changeset/tidy-cats-cache.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Update `defineSandboxProxy` to limit the JWKS issuer cache size to prevent unbounded memory usage.

--- a/packages/vercel-sandbox/package.json
+++ b/packages/vercel-sandbox/package.json
@@ -58,6 +58,7 @@
     "async-retry": "1.3.3",
     "jose": "6.2.3",
     "jsonlines": "0.1.1",
+    "lru-cache": "^11.5.2",
     "ms": "2.1.3",
     "picocolors": "^1.1.1",
     "tar-stream": "3.1.7",

--- a/packages/vercel-sandbox/package.json
+++ b/packages/vercel-sandbox/package.json
@@ -58,7 +58,7 @@
     "async-retry": "1.3.3",
     "jose": "6.2.3",
     "jsonlines": "0.1.1",
-    "lru-cache": "^11.5.2",
+    "lru-cache": "^10.4.3",
     "ms": "2.1.3",
     "picocolors": "^1.1.1",
     "tar-stream": "3.1.7",

--- a/packages/vercel-sandbox/src/proxy.test.ts
+++ b/packages/vercel-sandbox/src/proxy.test.ts
@@ -284,6 +284,31 @@ describe("defineSandboxProxy", () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  it("limits the number of cached JWKS issuers", async () => {
+    jwtVerifyMock.mockRejectedValue(new Error("bad token"));
+    const proxy = defineSandboxProxy(() => new Response("ok"));
+    const sendRequestWithIssuer = async (issuerIndex: number) => {
+      decodeJwtMock.mockReturnValue({
+        iss: `https://oidc.vercel.com/cache-test-${issuerIndex}`,
+      });
+      await proxy(makeProxyRequest());
+    };
+
+    for (let issuerIndex = 0; issuerIndex < 100; issuerIndex++) {
+      await sendRequestWithIssuer(issuerIndex);
+    }
+
+    await sendRequestWithIssuer(0);
+    await sendRequestWithIssuer(100);
+    await sendRequestWithIssuer(0);
+
+    expect(createRemoteJWKSetMock).toHaveBeenCalledTimes(101);
+
+    await sendRequestWithIssuer(1);
+
+    expect(createRemoteJWKSetMock).toHaveBeenCalledTimes(102);
+  });
+
   it("rejects tokens without a Vercel OIDC issuer before verifying the signature", async () => {
     decodeJwtMock.mockReturnValue({ iss: "https://example.com/team_123" });
     const handler = vi.fn(() => new Response("ok"));

--- a/packages/vercel-sandbox/src/proxy.ts
+++ b/packages/vercel-sandbox/src/proxy.ts
@@ -1,4 +1,5 @@
 import { createRemoteJWKSet, decodeJwt, jwtVerify } from "jose";
+import { LRUCache } from "lru-cache";
 
 const FORWARDED_HOST_HEADER = "vercel-forwarded-host";
 const FORWARDED_SCHEME_HEADER = "vercel-forwarded-scheme";
@@ -8,8 +9,11 @@ const SANDBOX_OIDC_TOKEN_HEADER = "vercel-sandbox-oidc-token";
 
 const VERCEL_OIDC_HOSTNAME = "oidc.vercel.com";
 const CLOCK_TOLERANCE_SECONDS = 60;
+const MAX_JWKS_CACHE_SIZE = 100;
 
-const jwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
+const jwksCache = new LRUCache<string, ReturnType<typeof createRemoteJWKSet>>({
+  max: MAX_JWKS_CACHE_SIZE,
+});
 
 export interface ProxyMeta {
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,8 +377,8 @@ importers:
         specifier: 0.1.1
         version: 0.1.1
       lru-cache:
-        specifier: ^11.5.2
-        version: 11.5.2
+        specifier: ^10.4.3
+        version: 10.4.3
       ms:
         specifier: 2.1.3
         version: 2.1.3
@@ -4441,9 +4441,8 @@ packages:
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
 
-  lru-cache@11.5.2:
-    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
-    engines: {node: 20 || >=22}
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lucide-react@0.511.0:
     resolution: {integrity: sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==}
@@ -10504,7 +10503,7 @@ snapshots:
       fault: 1.0.4
       highlight.js: 10.7.3
 
-  lru-cache@11.5.2: {}
+  lru-cache@10.4.3: {}
 
   lucide-react@0.511.0(react@19.1.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,6 +376,9 @@ importers:
       jsonlines:
         specifier: 0.1.1
         version: 0.1.1
+      lru-cache:
+        specifier: ^11.5.2
+        version: 11.5.2
       ms:
         specifier: 2.1.3
         version: 2.1.3
@@ -4437,6 +4440,10 @@ packages:
 
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
 
   lucide-react@0.511.0:
     resolution: {integrity: sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==}
@@ -10496,6 +10503,8 @@ snapshots:
     dependencies:
       fault: 1.0.4
       highlight.js: 10.7.3
+
+  lru-cache@11.5.2: {}
 
   lucide-react@0.511.0(react@19.1.1):
     dependencies:


### PR DESCRIPTION
This PR adds an LRU cache instead of a simple `Map` for the JWKS cache of `defineSandboxProxy` to prevent unbounded memory growth. The max size of 100 issuers is arbitrary but a good balance to prevent high memory usage/high number of open sockets while still avoiding to create new issuers all the time