### PR TITLE
fix(tags): allow only 1 tag on `Sandbox.list`

### DIFF
--- a/.changeset/spotty-poets-shake.md
+++ b/.changeset/spotty-poets-shake.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": patch
+---
+
+Reject multiple `tags` filters on `Sandbox.list()` at the type level. The API supports filtering by a single tag, so passing more than one key in `tags` is now a compile-time error instead of a 400 from the API.

--- a/packages/vercel-sandbox/src/api-client/api-client.test.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.test.ts
@@ -768,6 +768,36 @@ describe("APIClient", () => {
       expect(url).toContain("cursor=abc");
     });
 
+    it("passes a single tag filter as a query param", async () => {
+      const body = {
+        sandboxes: [],
+        pagination: { count: 0, next: null },
+      };
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(body), {
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await client.listSandboxes({
+        projectId: "proj_123",
+        tags: { env: "staging" },
+      });
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain(`tags=${encodeURIComponent("env:staging")}`);
+    });
+
+    it("rejects multiple tag filters at the type level", () => {
+      const check = () =>
+        client.listSandboxes({
+          projectId: "proj_123",
+          // @ts-expect-error — only a single tag filter is supported
+          tags: { env: "staging", team: "infra" },
+        });
+      expect(check).toBeInstanceOf(Function);
+    });
+
     it("passes sortOrder and sortBy statusUpdatedAt", async () => {
       const body = {
         sandboxes: [makeSandboxMetadata("sb-1")],

--- a/packages/vercel-sandbox/src/api-client/api-client.test.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.test.ts
@@ -798,6 +798,16 @@ describe("APIClient", () => {
       expect(check).toBeInstanceOf(Function);
     });
 
+    it("rejects multiple tag filters at runtime", async () => {
+      await expect(
+        client.listSandboxes({
+          projectId: "proj_123",
+          // @ts-expect-error — only a single tag filter is supported
+          tags: { env: "staging", team: "infra" },
+        }),
+      ).rejects.toThrow("Filtering by multiple tags is not supported");
+    });
+
     it("passes sortOrder and sortBy statusUpdatedAt", async () => {
       const body = {
         sandboxes: [makeSandboxMetadata("sb-1")],

--- a/packages/vercel-sandbox/src/api-client/api-client.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.ts
@@ -1087,6 +1087,11 @@ function toTagsFilter(
   if (tags === undefined) return undefined;
   const entries = Object.entries(tags);
   if (entries.length === 0) return undefined;
+  if (entries.length > 1) {
+    throw new Error(
+      "Filtering by multiple tags is not supported. Pass a single `{ key: value }` tag.",
+    );
+  }
   return entries.map(([key, value]) => `${key}:${value}`);
 }
 

--- a/packages/vercel-sandbox/src/api-client/api-client.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.ts
@@ -1100,4 +1100,4 @@ export type SingleTagFilter<Tags> = [keyof Tags] extends [
   UnionToIntersection<keyof Tags>,
 ]
   ? Tags
-  : "Error: filtering by multiple tags is not supported yet. Pass a single `{ key: value }` tag.";
+  : "Error: filtering by multiple tags is not supported. Pass a single `{ key: value }` tag.";

--- a/packages/vercel-sandbox/src/api-client/api-client.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.ts
@@ -908,14 +908,19 @@ export class APIClient extends BaseClient {
     );
   }
 
-  async listSandboxes(params: {
+  async listSandboxes<Tags extends Record<string, string>>(params: {
     projectId: string;
     limit?: number;
     sortBy?: "createdAt" | "name" | "statusUpdatedAt";
     sortOrder?: "asc" | "desc";
     namePrefix?: string;
     cursor?: string;
-    tags?: Record<string, string>;
+    /**
+     * Filter sandboxes by tag. Only a single `{ key: value }` tag filter is
+     * currently supported.
+     * @example { env: "staging" }
+     */
+    tags?: Tags & SingleTagFilter<Tags>;
     signal?: AbortSignal;
   }) {
     return parseOrThrow(
@@ -1084,3 +1089,15 @@ function toTagsFilter(
   if (entries.length === 0) return undefined;
   return entries.map(([key, value]) => `${key}:${value}`);
 }
+
+type UnionToIntersection<Union> = (
+  Union extends unknown ? (arg: Union) => void : never
+) extends (arg: infer Intersection) => void
+  ? Intersection
+  : never;
+
+export type SingleTagFilter<Tags> = [keyof Tags] extends [
+  UnionToIntersection<keyof Tags>,
+]
+  ? Tags
+  : "Error: filtering by multiple tags is not supported yet. Pass a single `{ key: value }` tag.";

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -1205,6 +1205,15 @@ for (const port of ports) {
     }
   });
 
+  it("rejects Sandbox.list with multiple tag filters at the type level", () => {
+    const check = () =>
+      Sandbox.list({
+        // @ts-expect-error — only a single tag filter is supported
+        tags: { purpose: "benchmark", execution: "execution-123" },
+      });
+    expect(check).toBeInstanceOf(Function);
+  });
+
   it("paginates listSessions across multiple pages", async () => {
     const sbx = await Sandbox.create({
       persistent: true,

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -9,7 +9,10 @@ import { APIClient } from "./api-client/index.js";
 import { APIError } from "./api-client/api-error.js";
 import { type Credentials, getCredentials } from "./utils/get-credentials.js";
 import { getPrivateParams, type WithPrivate } from "./utils/types.js";
-import type { WithFetchOptions } from "./api-client/api-client.js";
+import type {
+  SingleTagFilter,
+  WithFetchOptions,
+} from "./api-client/api-client.js";
 import { DEFAULT_SANDBOX_REGION } from "./constants.js";
 import type { ManagedImage, RUNTIMES, SandboxRegion } from "./constants.js";
 import { Session, type RunCommandParams } from "./session.js";
@@ -621,9 +624,17 @@ export class Sandbox implements ExecutionContext {
    * // or: for await (const page of result.pages()) { ... }
    * ```
    */
-  static async list(
-    params?: Partial<Parameters<APIClient["listSandboxes"]>[0]> &
-      Partial<Credentials> &
+  static async list<Tags extends Record<string, string>>(
+    params?: Partial<
+      Omit<Parameters<APIClient["listSandboxes"]>[0], "tags">
+    > & {
+      /**
+       * Filter sandboxes by tag. Only a single `{ key: value }` tag filter
+       * is currently supported.
+       * @example { env: "staging" }
+       */
+      tags?: Tags & SingleTagFilter<Tags>;
+    } & Partial<Credentials> &
       WithFetchOptions,
   ) {
     "use step";
@@ -634,7 +645,7 @@ export class Sandbox implements ExecutionContext {
       fetch: params?.fetch,
     });
     const fetchPage = async (cursor?: string) => {
-      const response = await client.listSandboxes({
+      const response = await client.listSandboxes<Tags>({
         ...credentials,
         ...params,
         ...(cursor !== undefined && { cursor }),


### PR DESCRIPTION
We support listing with 1 tag via the API. This PR adds type safety so that only 1 tag can be used in the `tags` object when listing sandboxes. We can use a union to show a type error if more than 1 is passed.


Example:

<img width="1775" height="336" alt="image" src="https://github.com/user-attachments/assets/17bbfabc-c64d-46d7-ad3a-0ff549b35570" />
