### PR TITLE
fix(cli): reject multiple list tag filters

### DIFF
--- a/.changeset/bright-tags-list.md
+++ b/.changeset/bright-tags-list.md
@@ -1,0 +1,5 @@
+---
+"sandbox": patch
+---
+
+Reject multiple `--tag` filters in `sandbox list` before sending the request to the API.

--- a/packages/sandbox/src/commands/list.ts
+++ b/packages/sandbox/src/commands/list.ts
@@ -77,6 +77,16 @@ export const list = cmd.command({
     limit,
     cursor,
   }) {
+    const tagKeys = Object.keys(tags);
+    if (tagKeys.length > 1) {
+      console.error(
+        chalk.red(
+          "Error: only one --tag filter is supported. Pass a single --tag key=value.",
+        ),
+      );
+      return;
+    }
+
     if (namePrefix) {
       if (sortBy && sortBy !== "name") {
         console.error(
@@ -103,7 +113,7 @@ export const list = cmd.command({
         ...(namePrefix && { namePrefix }),
         ...(sortBy && { sortBy }),
         ...(sortOrder && { sortOrder }),
-        ...(Object.keys(tags).length > 0 && { tags }),
+        ...(tagKeys.length > 0 && { tags }),
       });
     })();
 

--- a/packages/sandbox/src/commands/list.ts
+++ b/packages/sandbox/src/commands/list.ts
@@ -77,16 +77,6 @@ export const list = cmd.command({
     limit,
     cursor,
   }) {
-    const tagKeys = Object.keys(tags);
-    if (tagKeys.length > 1) {
-      console.error(
-        chalk.red(
-          "Error: only one --tag filter is supported. Pass a single --tag key=value.",
-        ),
-      );
-      return;
-    }
-
     if (namePrefix) {
       if (sortBy && sortBy !== "name") {
         console.error(
@@ -96,6 +86,17 @@ export const list = cmd.command({
       }
 
       sortBy = "name";
+    }
+
+    const tagKeys = Object.keys(tags);
+    if (tagKeys.length > 1) {
+      console.error(
+        chalk.red(
+          "Error: only one --tag filter is supported. Pass a single --tag key=value.",
+        ),
+      );
+      process.exitCode = 1;
+      return;
     }
 
     const { sandboxes, pagination } = await (async () => {

--- a/packages/sandbox/test/commands/list.test.ts
+++ b/packages/sandbox/test/commands/list.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import * as cmd from "cmd-ts";
+
+const { mockList } = vi.hoisted(() => ({
+  mockList: vi.fn(),
+}));
+
+vi.mock("../../src/client", () => ({
+  sandboxClient: {
+    get: vi.fn(),
+    create: vi.fn(),
+    fork: vi.fn(),
+    list: mockList,
+  },
+  snapshotClient: { get: vi.fn(), list: vi.fn(), tree: vi.fn() },
+}));
+
+vi.mock("@vercel/oidc", () => ({
+  getVercelOidcToken: vi.fn(),
+  getVercelToken: vi.fn(),
+}));
+
+vi.mock("../../src/commands/login", () => ({
+  login: { handler: vi.fn() },
+}));
+
+describe("list command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.VERCEL_AUTH_TOKEN = "tok";
+    mockList.mockResolvedValue({
+      sandboxes: [],
+      pagination: { count: 0, next: null },
+    });
+  });
+
+  test("passes a single tag filter to the client", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { list } = await import("../../src/commands/list.ts");
+
+    await cmd.run(list, [
+      "--tag=env=staging",
+      "--scope=team",
+      "--project=proj",
+    ]);
+
+    expect(mockList).toHaveBeenCalledOnce();
+    expect(mockList).toHaveBeenCalledWith(
+      expect.objectContaining({ tags: { env: "staging" } }),
+    );
+    log.mockRestore();
+  });
+
+  test("rejects multiple tag filters before calling the API", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { list } = await import("../../src/commands/list.ts");
+
+    await cmd.run(list, [
+      "--tag=env=staging",
+      "--tag=team=infra",
+      "--scope=team",
+      "--project=proj",
+    ]);
+
+    expect(mockList).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining("only one --tag filter is supported"),
+    );
+    error.mockRestore();
+  });
+});

--- a/packages/sandbox/test/commands/list.test.ts
+++ b/packages/sandbox/test/commands/list.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import * as cmd from "cmd-ts";
 
 const { mockList } = vi.hoisted(() => ({
@@ -33,6 +33,10 @@ describe("list command", () => {
       sandboxes: [],
       pagination: { count: 0, next: null },
     });
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
   });
 
   test("passes a single tag filter to the client", async () => {

--- a/packages/sandbox/test/commands/list.test.ts
+++ b/packages/sandbox/test/commands/list.test.ts
@@ -27,6 +27,7 @@ vi.mock("../../src/commands/login", () => ({
 describe("list command", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    process.exitCode = undefined;
     process.env.VERCEL_AUTH_TOKEN = "tok";
     mockList.mockResolvedValue({
       sandboxes: [],
@@ -66,6 +67,7 @@ describe("list command", () => {
     expect(error).toHaveBeenCalledWith(
       expect.stringContaining("only one --tag filter is supported"),
     );
+    expect(process.exitCode).toBe(1);
     error.mockRestore();
   });
 });


### PR DESCRIPTION
Summary

Reject multiple distinct --tag filters in the Sandbox CLI before making the API request.

The Sandbox API currently supports filtering by a single tag. While #312 adds type-level protection for SDK consumers, CLI input is runtime data and can still contain multiple tags.

This adds CLI-side validation so users receive an immediate, actionable error instead of an API error.

Changes

* Reject more than one distinct --tag filter in sandbox list
* Preserve the existing single-tag behaviour
* Avoid making an API request when the input is invalid
* Add regression coverage for valid and invalid tag filtering
* Add a patch changeset for the CLI package

Testing

Added command-level tests verifying:

* a single --tag is forwarded to sandboxClient.list()
* multiple distinct --tag values produce an error
* sandboxClient.list() is not called when multiple tags are supplied

Follow-up to the runtime validation concern raised in #312.