### PR TITLE
feat(sandbox,vercel-sandbox): support orhpan snapshot deletion

### DIFF
--- a/.changeset/delete-orphan-snapshots.md
+++ b/.changeset/delete-orphan-snapshots.md
@@ -1,0 +1,9 @@
+---
+"@vercel/sandbox": minor
+"@vercel/sandbox-mock": patch
+"sandbox": minor
+---
+
+Add a `deleteOrphanSnapshots` option when deleting a sandbox.
+
+Deleting a persistent sandbox left all of its snapshots alive until they expired. `sandbox.delete({ deleteOrphanSnapshots: true })` in the SDK and `sandbox remove <name> --delete-orphan-snapshots` in the CLI now also delete the snapshots of that sandbox that no other sandbox uses. It defaults to `false`, so the existing behaviour is unchanged.

--- a/packages/sandbox/src/commands/remove.ts
+++ b/packages/sandbox/src/commands/remove.ts
@@ -17,12 +17,18 @@ export const remove = cmd.command({
       type: sandboxName,
       description: "more sandboxes to remove",
     }),
+    deleteOrphanSnapshots: cmd.flag({
+      long: "delete-orphan-snapshots",
+      description:
+        "Also delete the snapshots of the sandbox that are not used by any other sandbox",
+    }),
     scope,
   },
   async handler({
     scope: { token, team, project },
     sandboxName,
     sandboxNames,
+    deleteOrphanSnapshots,
   }) {
     const tasks = Array.from(
       new Set([sandboxName, ...sandboxNames]),
@@ -35,7 +41,7 @@ export const remove = cmd.command({
             projectId: project,
             name,
           });
-          await sandbox.delete();
+          await sandbox.delete({ deleteOrphanSnapshots });
         },
       }),
     );

--- a/packages/vercel-sandbox-mock/src/server/mock-server.test.ts
+++ b/packages/vercel-sandbox-mock/src/server/mock-server.test.ts
@@ -290,5 +290,59 @@ describe("MockServer routing", () => {
       expect(recreate.status).toBe(410);
       expect((await j(recreate)).error.code).toBe("snapshot_not_found");
     });
+
+    test("deleting a sandbox keeps its snapshots unless asked to delete them", async () => {
+      const { call } = makeServer();
+      const { session } = await createSandbox(call, { name: "keep-sb" });
+      const created = await j(
+        await call("POST", `/v2/sandboxes/sessions/${session.id}/snapshot`, {
+          body: {},
+        }),
+      );
+
+      await call("DELETE", "/v2/sandboxes/keep-sb");
+
+      const got = await j(
+        await call("GET", `/v2/sandboxes/snapshots/${created.snapshot.id}`),
+      );
+      expect(got.snapshot.status).toBe("created");
+    });
+
+    test("deleting a sandbox with deleteOrphanSnapshots keeps the snapshots a fork still uses", async () => {
+      const { call } = makeServer();
+      const { session } = await createSandbox(call, { name: "orphan-sb" });
+      const orphan = await j(
+        await call("POST", `/v2/sandboxes/sessions/${session.id}/snapshot`, {
+          body: {},
+        }),
+      );
+
+      // A second snapshot becomes the sandbox's current one, and the fork
+      // restores from it, so only the first snapshot is an orphan.
+      const forked = await j(
+        await call("POST", `/v2/sandboxes/sessions/${session.id}/snapshot`, {
+          body: {},
+        }),
+      );
+      await call("POST", "/v2/sandboxes/orphan-sb/fork", {
+        body: { name: "orphan-sb-fork" },
+      });
+
+      const res = await call(
+        "DELETE",
+        "/v2/sandboxes/orphan-sb?deleteOrphanSnapshots=true",
+      );
+      expect(res.status).toBe(200);
+
+      const deleted = await j(
+        await call("GET", `/v2/sandboxes/snapshots/${orphan.snapshot.id}`),
+      );
+      expect(deleted.snapshot.status).toBe("deleted");
+
+      const kept = await j(
+        await call("GET", `/v2/sandboxes/snapshots/${forked.snapshot.id}`),
+      );
+      expect(kept.snapshot.status).toBe("created");
+    });
   });
 });

--- a/packages/vercel-sandbox-mock/src/server/mock-server.ts
+++ b/packages/vercel-sandbox-mock/src/server/mock-server.ts
@@ -149,7 +149,7 @@ export class MockServer {
       return this.#forkSandbox(name, init);
     if (method === "GET") return this.#getSandbox(name, url);
     if (method === "PATCH") return this.#updateSandbox(name, init);
-    if (method === "DELETE") return this.#deleteSandbox(name);
+    if (method === "DELETE") return this.#deleteSandbox(name, url);
 
     return apiError(404, "not_found", `No route for ${method} ${url.pathname}`);
   }
@@ -396,7 +396,7 @@ export class MockServer {
     return json({ sandbox: sandboxPayload(record, session), routes });
   }
 
-  async #deleteSandbox(name: string): Promise<Response> {
+  async #deleteSandbox(name: string, url: URL): Promise<Response> {
     const record = this.#sandboxes.get(name);
     if (!record)
       return apiError(404, "not_found", `Sandbox not found: ${name}`);
@@ -408,7 +408,33 @@ export class MockServer {
     }
     this.#sandboxes.delete(name);
     this.#disks.delete(name);
+    if (url.searchParams.get("deleteOrphanSnapshots") === "true") {
+      this.#deleteOrphanSnapshots(name);
+    }
     return json({ sandbox: sandboxPayload(record, session) });
+  }
+
+  /**
+   * Deletes the snapshots of a removed sandbox that no other sandbox still
+   * references, either as its current snapshot or as the snapshot it was
+   * created from — a fork keeps the snapshot it restored.
+   */
+  #deleteOrphanSnapshots(name: string): void {
+    const referenced = new Set(
+      [...this.#sandboxes.values()]
+        .flatMap((sandbox) => [
+          sandbox.currentSnapshotId,
+          sandbox.sourceSnapshotId,
+        ])
+        .filter((id): id is string => id !== undefined),
+    );
+    for (const snapshot of this.#snapshots.values()) {
+      if (snapshot.sandboxName !== name) continue;
+      if (snapshot.status === "deleted") continue;
+      if (referenced.has(snapshot.id)) continue;
+      snapshot.status = "deleted";
+      snapshot.updatedAt = Date.now();
+    }
   }
 
   // ---- sessions ------------------------------------------------------------

--- a/packages/vercel-sandbox/src/api-client/api-client.test.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.test.ts
@@ -1212,7 +1212,44 @@ describe("APIClient", () => {
       const [url, opts] = mockFetch.mock.calls[0];
       expect(url).toContain("/v2/sandboxes/my-sandbox");
       expect(url).toContain("projectId=proj_123");
+      expect(url).not.toContain("deleteOrphanSnapshots");
       expect(opts.method).toBe("DELETE");
+    });
+
+    it("sends deleteOrphanSnapshots when requested", async () => {
+      const body = { sandbox: makeSandboxMetadata() };
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(body), {
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await client.deleteSandbox({
+        name: "my-sandbox",
+        projectId: "proj_123",
+        deleteOrphanSnapshots: true,
+      });
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain("deleteOrphanSnapshots=true");
+    });
+
+    it("omits deleteOrphanSnapshots when false", async () => {
+      const body = { sandbox: makeSandboxMetadata() };
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(body), {
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await client.deleteSandbox({
+        name: "my-sandbox",
+        projectId: "proj_123",
+        deleteOrphanSnapshots: false,
+      });
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).not.toContain("deleteOrphanSnapshots");
     });
   });
 

--- a/packages/vercel-sandbox/src/api-client/api-client.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.ts
@@ -986,6 +986,7 @@ export class APIClient extends BaseClient {
   async deleteSandbox(params: {
     name: string;
     projectId: string;
+    deleteOrphanSnapshots?: boolean;
     signal?: AbortSignal;
   }) {
     return parseOrThrow(
@@ -994,6 +995,9 @@ export class APIClient extends BaseClient {
         method: "DELETE",
         query: {
           projectId: params.projectId,
+          deleteOrphanSnapshots: params.deleteOrphanSnapshots
+            ? "true"
+            : undefined,
         },
         signal: params.signal,
       }),

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -1800,13 +1800,21 @@ export class Sandbox implements ExecutionContext {
    *
    * After deletion the instance becomes inert — all further API calls will
    * throw immediately.
+   *
+   * @param opts.deleteOrphanSnapshots - When true, the snapshots of this
+   * sandbox that are not used by any other sandbox are deleted asynchronously
+   * too. Defaults to false, which keeps them until they expire.
    */
-  async delete(opts?: { signal?: AbortSignal }): Promise<void> {
+  async delete(opts?: {
+    deleteOrphanSnapshots?: boolean;
+    signal?: AbortSignal;
+  }): Promise<void> {
     "use step";
     const client = await this.ensureClient();
     await client.deleteSandbox({
       name: this.sandbox.name,
       projectId: this.projectId,
+      deleteOrphanSnapshots: opts?.deleteOrphanSnapshots,
       signal: opts?.signal,
     });
   }

--- a/skills/sandbox/SKILL.md
+++ b/skills/sandbox/SKILL.md
@@ -644,8 +644,11 @@ await sandbox.update({
 ## Deleting a Sandbox
 
 ```typescript
-// Permanently remove a sandbox and all its snapshots.
+// Permanently remove a sandbox. Its snapshots are kept until they expire.
 await sandbox.delete();
+
+// Also delete the snapshots that no other sandbox uses.
+await sandbox.delete({ deleteOrphanSnapshots: true });
 ```
 
 ## Stopping a Sandbox
@@ -1013,8 +1016,9 @@ sandbox cp local-file.txt <name>:/vercel/sandbox/
 # Stop sandbox (synchronous; reports snapshot + usage)
 sandbox stop <name>
 
-# Permanently delete sandbox and all its snapshots
+# Permanently delete sandbox; its snapshots are kept until they expire
 sandbox remove <name>
+sandbox remove <name> --delete-orphan-snapshots  # Also delete snapshots no other sandbox uses
 
 # Sessions
 sandbox sessions list <name>


### PR DESCRIPTION
Support `deleteOrphanSnapshots` parameter.

SDK:

```
await sandbox.delete({ deleteOrphanSnapshots: true });
```

CLI:

```
sandbox remove <name> --delete-orphan-snapshots
```