### PR TITLE
feat(sdk): add `driveId` getter on `Drive` class

### DIFF
--- a/.changeset/bright-drives-wave.md
+++ b/.changeset/bright-drives-wave.md
@@ -1,0 +1,6 @@
+---
+"@vercel/sandbox": minor
+"@vercel/sandbox-mock": minor
+---
+
+Add a `driveId` field on the `Drive` entity to retrieve the unique ID of a drive.

--- a/packages/vercel-sandbox-mock/src/drive.test.ts
+++ b/packages/vercel-sandbox-mock/src/drive.test.ts
@@ -14,12 +14,14 @@ describe("Drive", () => {
       maxSize: 1024,
     });
 
+    expect(drive.driveId).toMatch(/^drive_/);
     expect(drive.name).toBe("cache");
     expect(drive.region).toBe("sfo1");
     expect(drive.maxSize).toBe(1024);
 
     const result = await Drive.list();
     expect(result.drives).toHaveLength(1);
+    expect(result.drives[0].driveId).toBe(drive.driveId);
     expect(result.drives[0].name).toBe("cache");
     expect(result.drives[0].region).toBe("sfo1");
 

--- a/packages/vercel-sandbox-mock/src/server/mock-server.ts
+++ b/packages/vercel-sandbox-mock/src/server/mock-server.ts
@@ -201,6 +201,7 @@ export class MockServer {
       const body = readJson<CreateDriveBody>(init);
       const now = Date.now();
       const drive: DriveRecord = {
+        id: newId("drive"),
         name,
         projectId: body.projectId,
         region: body.region ?? REGION,

--- a/packages/vercel-sandbox-mock/src/server/registry.ts
+++ b/packages/vercel-sandbox-mock/src/server/registry.ts
@@ -108,6 +108,7 @@ export interface SnapshotRecord {
 }
 
 export interface DriveRecord {
+  id: string;
   name: string;
   projectId: string;
   region: string;

--- a/packages/vercel-sandbox/src/api-client/validators.ts
+++ b/packages/vercel-sandbox/src/api-client/validators.ts
@@ -270,6 +270,7 @@ export const SnapshotResponse = z.object({
 });
 
 export const Drive = z.object({
+  id: z.string(),
   name: z.string(),
   projectId: z.string(),
   region: z.string(),

--- a/packages/vercel-sandbox/src/drive.serialize.test.ts
+++ b/packages/vercel-sandbox/src/drive.serialize.test.ts
@@ -11,6 +11,7 @@ import { Drive, type SerializedDrive } from "./drive";
 
 describe("Drive serialization", () => {
   const mockDriveMetadata: DriveMetadata = {
+    id: "drive_test123",
     name: "workspace",
     projectId: "proj_test",
     region: "sfo1",
@@ -53,6 +54,7 @@ describe("Drive serialization", () => {
       const drive = createMockDrive();
       const serialized = serializeDrive(drive);
 
+      expect(serialized.drive.id).toBe("drive_test123");
       expect(serialized.drive.name).toBe("workspace");
       expect(serialized.drive.projectId).toBe("proj_test");
       expect(serialized.drive.region).toBe("sfo1");
@@ -87,6 +89,7 @@ describe("Drive serialization", () => {
 
       const result = deserializeDrive(serialized);
 
+      expect(result.driveId).toBe("drive_test123");
       expect(result.name).toBe("workspace");
       expect(result.projectId).toBe("proj_test");
       expect(result.region).toBe("sfo1");
@@ -153,6 +156,7 @@ describe("Drive serialization", () => {
       );
 
       expect(rehydrated).toBeInstanceOf(Drive);
+      expect(rehydrated.driveId).toBe("drive_test123");
       expect(rehydrated.name).toBe("workspace");
       expect(rehydrated.maxSize).toBe(1073741824);
     });

--- a/packages/vercel-sandbox/src/drive.test.ts
+++ b/packages/vercel-sandbox/src/drive.test.ts
@@ -8,6 +8,7 @@ const CREDENTIALS = {
 };
 
 const drivePayload = {
+  id: "drive_123",
   name: "workspace",
   projectId: "proj_123",
   region: "sfo1",
@@ -38,6 +39,7 @@ describe("Drive", () => {
       fetch: mockFetch,
     });
 
+    expect(drive.driveId).toBe("drive_123");
     expect(drive.name).toBe("workspace");
     expect(drive.projectId).toBe("proj_123");
     expect(drive.region).toBe("sfo1");
@@ -79,6 +81,7 @@ describe("Drive", () => {
     });
 
     expect(result.drives[0]).toBeInstanceOf(Drive);
+    expect(result.drives[0].driveId).toBe("drive_123");
     expect(result.drives[0].name).toBe("workspace");
     expect(result.drives[0].region).toBe("sfo1");
     await expect(result.toArray()).resolves.toEqual([

--- a/packages/vercel-sandbox/src/drive.ts
+++ b/packages/vercel-sandbox/src/drive.ts
@@ -60,6 +60,13 @@ export class Drive {
   }
 
   /**
+   * Unique ID of this drive.
+   */
+  public get driveId(): string {
+    return this.drive.id;
+  }
+
+  /**
    * The name of the drive.
    */
   public get name(): string {


### PR DESCRIPTION
The API is now returning a unique `id` field when creating or retrieving a drive, so this PR exposes it in the SDK via a new `driveId` getter