### PR TITLE
[sandbox-cli] remove ephemeral shells on exit

### DIFF
--- a/.changeset/quiet-pandas-clean.md
+++ b/.changeset/quiet-pandas-clean.md
@@ -1,0 +1,5 @@
+---
+"sandbox": minor
+---
+
+Add `sandbox sh --rm` to create a non-persistent sandbox and remove it when the shell exits.

--- a/packages/sandbox/docs/index.md
+++ b/packages/sandbox/docs/index.md
@@ -223,6 +223,7 @@ Flags:
 
     --non-persistent  Disable automatic restore of the filesystem between sessions. [optional]
     --silent          Don't write sandbox name to stdout [optional]
+    --rm              Automatically remove the sandbox when the shell exits. [optional]
     --help, -h        show help [optional]
 
 Auth & Scope:

--- a/packages/sandbox/src/commands/sh.ts
+++ b/packages/sandbox/src/commands/sh.ts
@@ -1,15 +1,53 @@
 import * as cmd from "cmd-ts";
 import * as Create from "./create";
+import * as Exec from "./exec";
 import { omit } from "../util/omit";
+
+const args = {
+  ...omit(Create.args, "connect"),
+  removeAfterUse: cmd.flag({
+    long: "rm",
+    description: "Automatically remove the sandbox when the shell exits.",
+  }),
+} as const;
 
 export const sh = cmd.command({
   name: "sh",
   description: "Create a sandbox and start an interactive shell",
-  args: omit(Create.args, "connect"),
-  async handler(args) {
-    return Create.create.handler({
-      ...args,
-      connect: true,
-    });
+  args,
+  async handler({ removeAfterUse, ...rest }) {
+    if (!removeAfterUse) {
+      return Create.create.handler({
+        ...rest,
+        connect: true,
+      });
+    }
+
+    const sandbox = await Create.create.handler({
+      ...rest,
+      connect: false,
+      nonPersistent: true,
+      __printConnectHint: false,
+    } as Parameters<typeof Create.create.handler>[0]);
+
+    try {
+      await Exec.exec.handler({
+        scope: rest.scope,
+        asSudo: false,
+        args: [],
+        cwd: undefined,
+        skipExtendingTimeout: false,
+        envVars: {},
+        command: "sh",
+        interactive: true,
+        tty: true,
+        sandbox,
+        timeout: undefined,
+      });
+    } finally {
+      await sandbox.delete();
+    }
+
+    return sandbox;
   },
 });

--- a/packages/sandbox/test/commands/sh.test.ts
+++ b/packages/sandbox/test/commands/sh.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const { mockCreate, mockExec } = vi.hoisted(() => ({
+  mockCreate: vi.fn(),
+  mockExec: vi.fn(),
+}));
+
+vi.mock("../../src/commands/create", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("../../src/commands/create")>();
+  return {
+    ...original,
+    create: { ...original.create, handler: mockCreate },
+  };
+});
+
+vi.mock("../../src/commands/exec", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("../../src/commands/exec")>();
+  return {
+    ...original,
+    exec: { ...original.exec, handler: mockExec },
+  };
+});
+
+const args = {
+  removeAfterUse: false,
+  nonPersistent: false,
+  scope: { token: "token", team: "team", project: "project" },
+};
+
+describe("sh command", () => {
+  const remove = vi.fn();
+  const sandbox = { name: "new-sandbox", delete: remove };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreate.mockResolvedValue(sandbox);
+    mockExec.mockResolvedValue(undefined);
+    remove.mockResolvedValue(undefined);
+  });
+
+  test("keeps the existing create-and-connect flow without --rm", async () => {
+    const { sh } = await import("../../src/commands/sh");
+
+    await sh.handler(args as Parameters<typeof sh.handler>[0]);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      nonPersistent: false,
+      scope: args.scope,
+      connect: true,
+    });
+    expect(mockExec).not.toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
+  });
+
+  test("creates a non-persistent sandbox and removes it after the shell exits", async () => {
+    const { sh } = await import("../../src/commands/sh");
+
+    await sh.handler({
+      ...args,
+      removeAfterUse: true,
+    } as Parameters<typeof sh.handler>[0]);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      nonPersistent: true,
+      scope: args.scope,
+      connect: false,
+      __printConnectHint: false,
+    });
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sandbox,
+        command: "sh",
+        interactive: true,
+      }),
+    );
+    expect(remove).toHaveBeenCalledOnce();
+    expect(mockExec.mock.invocationCallOrder[0]).toBeLessThan(
+      remove.mock.invocationCallOrder[0],
+    );
+  });
+
+  test("removes the sandbox when the shell disconnects with an error", async () => {
+    const shellError = new Error("shell disconnected");
+    mockExec.mockRejectedValue(shellError);
+    const { sh } = await import("../../src/commands/sh");
+
+    await expect(
+      sh.handler({
+        ...args,
+        removeAfterUse: true,
+      } as Parameters<typeof sh.handler>[0]),
+    ).rejects.toBe(shellError);
+
+    expect(remove).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Context: https://vercel.slack.com/archives/C0BPXESP5S7/p1788435760647519?thread_ts=1788390829.498199&cid=C0BPXESP5S7

`sandbox sh --rm` now creates a non-persistent sandbox, connects to its shell, and deletes that sandbox when the shell disconnects. Cleanup also runs when the interactive shell errors. This is limited to `sh`; `connect` and SSH-style access to existing sandboxes are unchanged.

Observed from the branch build:

```text
✅ Sandbox jade-armed-salamander-eFE3Kq created.
╰▶ connection to ▲ jade-armed-salamander-eFE3Kq closed.

Named sandbox 'jade-armed-salamander-eFE3Kq' not found for this project.
├▶ status code: 404 Not Found
```

Verified with 96/96 CLI tests, package typecheck, build, generated CLI docs, and the live create → exit → 404 flow above. Client-side cleanup cannot run after an uncatchable process termination such as `SIGKILL` or a machine crash.
