### PR TITLE
feat(sdk,cli): allow updating mounts on a sandbox

### DIFF
--- a/.changeset/update-sandbox-mounts.md
+++ b/.changeset/update-sandbox-mounts.md
@@ -1,0 +1,11 @@
+---
+"@vercel/sandbox": patch
+"@vercel/sandbox-mock": patch
+"sandbox": patch
+---
+
+Allow updating the drives mounted on a sandbox:
+
+- New `mounts` option on `Sandbox.update()`. It replaces all existing mounts and applies to the next session. Pass an empty object to remove all mounts.
+- New `sandbox config mounts <name> --mount drive:/path[:mode]` CLI command. Omit `--mount` to remove all mounts.
+- `sandbox config list` now shows the mounts.

--- a/packages/sandbox/docs/index.md
+++ b/packages/sandbox/docs/index.md
@@ -493,6 +493,7 @@ Commands:
     persistent                <name> <true|false>       Enable or disable automatic restore of the filesystem between sessions
     region                    <name> <REGION>           Update the region of a sandbox (will be applied to all new sessions)
     failover-regions          <name> <REGION,...|none>  Update the failover regions of a sandbox (replaces the existing list)
+    mounts                    <name>                    Update the drives mounted on a sandbox (replaces all existing mounts, applied to all new sessions). Pass no --mount flag to remove them.
     network-policy            <name>                    Update the network policy of a sandbox
     snapshot-expiration       <name> <DURATION|none>    Update the default snapshot expiration of a sandbox
     keep-last-snapshots       <name> <COUNT>            Update the snapshot retention policy (keep only the N most recent snapshots) of a sandbox

--- a/packages/sandbox/src/commands/config.ts
+++ b/packages/sandbox/src/commands/config.ts
@@ -11,6 +11,7 @@ import {
 import { buildNetworkPolicy, resolveMode } from "../util/network-policy";
 import { vcpusType } from "../args/vcpus";
 import { regionListType, regionType } from "../args/region";
+import { mounts as mountsOption } from "../args/drive";
 import { Duration } from "../types/duration";
 import { SnapshotExpiration } from "../types/snapshot-expiration";
 import { ObjectFromKeyValue } from "../args/key-value-pair";
@@ -599,6 +600,43 @@ const failoverRegionsCommand = cmd.command({
   },
 });
 
+const mountsCommand = cmd.command({
+  name: "mounts",
+  description: "Update the drives mounted on a sandbox (replaces all existing mounts, applied to all new sessions). Pass no --mount flag to remove them.",
+  args: {
+    sandbox: cmd.positional({
+      type: sandboxName,
+      description: "Sandbox name to update",
+    }),
+    mounts: mountsOption,
+    scope,
+  },
+  async handler({ scope: { token, team, project }, sandbox: name, mounts }) {
+    const sandbox = await sandboxClient.get({
+      name,
+      projectId: project,
+      teamId: team,
+      token,
+    });
+
+    const spinner = ora("Updating sandbox configuration...").start();
+    try {
+      await sandbox.update({ mounts });
+      spinner.stop();
+
+      process.stderr.write(
+        "✅ Configuration updated for sandbox " + chalk.cyan(name) + "\n",
+      );
+      process.stderr.write(
+        chalk.dim("   ╰ ") + "mounts: " + chalk.cyan(formatMounts(mounts)) + "\n",
+      );
+    } catch (error) {
+      spinner.stop();
+      throw error;
+    }
+  },
+});
+
 const listCommand = cmd.command({
   name: "list",
   description: "Display the current configuration of a sandbox",
@@ -642,6 +680,7 @@ const listCommand = cmd.command({
       { field: "Keep last snapshots", value: formatKeepLastSnapshots(sandbox.keepLastSnapshots) },
       { field: "Current snapshot", value: sandbox.currentSnapshotId ?? "-" },
       { field: "Tags", value: tagsDisplay },
+      { field: "Mounts", value: formatMounts(sandbox.mounts) },
     ];
 
     console.log(
@@ -803,6 +842,16 @@ function formatKeepLastSnapshots(
   return parts.join(", ");
 }
 
+function formatMounts(mounts: Sandbox["mounts"]): string {
+  const entries = Object.entries(mounts ?? {});
+  if (entries.length === 0) {
+    return "-";
+  }
+  return entries
+    .map(([path, { drive, mode }]) => `${drive}:${path}:${mode ?? "read-write"}`)
+    .join(", ");
+}
+
 function formatPorts(sandbox: Sandbox): string {
   const ports = getPublishedRoutes(sandbox)?.map((route) => route.port) ?? [];
 
@@ -829,6 +878,7 @@ export const config = cmd.subcommands({
     persistent: persistentCommand,
     region: regionCommand,
     "failover-regions": failoverRegionsCommand,
+    mounts: mountsCommand,
     "network-policy": networkPolicyCommand,
     "snapshot-expiration": snapshotExpirationCommand,
     "keep-last-snapshots": keepLastSnapshotsCommand,

--- a/packages/sandbox/test/commands/config.test.ts
+++ b/packages/sandbox/test/commands/config.test.ts
@@ -75,6 +75,37 @@ describe("config command", () => {
     });
   });
 
+  test("mounts sends the parsed mounts to the SDK", async () => {
+    const { config } = await import("../../src/commands/config.ts");
+    await cmd.run(config, [
+      "mounts",
+      "my-sandbox",
+      "--mount=data:/mnt/data:read-only",
+      "--mount=cache:/mnt/cache",
+      "--scope=team",
+      "--project=proj",
+    ]);
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      mounts: {
+        "/mnt/data": { drive: "data", mode: "read-only" },
+        "/mnt/cache": { drive: "cache", mode: undefined },
+      },
+    });
+  });
+
+  test("mounts without --mount clears the mounts", async () => {
+    const { config } = await import("../../src/commands/config.ts");
+    await cmd.run(config, [
+      "mounts",
+      "my-sandbox",
+      "--scope=team",
+      "--project=proj",
+    ]);
+
+    expect(mockUpdate).toHaveBeenCalledWith({ mounts: {} });
+  });
+
   test('failover-regions "none" clears the failover regions', async () => {
     const { config } = await import("../../src/commands/config.ts");
     await cmd.run(config, [

--- a/packages/vercel-sandbox-mock/src/sandbox.test.ts
+++ b/packages/vercel-sandbox-mock/src/sandbox.test.ts
@@ -27,6 +27,30 @@ describe("Sandbox (real SDK over mock fetch)", () => {
     await withRegion.delete();
   });
 
+  test("update replaces and clears mounts", async () => {
+    const sandbox = await Sandbox.create({
+      name: uniq(),
+      mounts: { "/mnt/data": { drive: "data" } },
+    });
+    expect(sandbox.mounts).toEqual({ "/mnt/data": { drive: "data" } });
+
+    await sandbox.update({
+      mounts: { "/mnt/cache": { drive: "cache", mode: "read-only" } },
+    });
+    expect(sandbox.mounts).toEqual({
+      "/mnt/cache": { drive: "cache", mode: "read-only" },
+    });
+
+    const reread = await Sandbox.get({ name: sandbox.name, resume: false });
+    expect(reread.mounts).toEqual({
+      "/mnt/cache": { drive: "cache", mode: "read-only" },
+    });
+
+    await sandbox.update({ mounts: {} });
+    expect(sandbox.mounts).toBeUndefined();
+    await sandbox.delete();
+  });
+
   test("create rejects failover regions that include the requested region", async () => {
     await expect(
       Sandbox.create({

--- a/packages/vercel-sandbox-mock/src/server/mock-server.ts
+++ b/packages/vercel-sandbox-mock/src/server/mock-server.ts
@@ -54,6 +54,13 @@ function validateFailoverRegions(
   return undefined;
 }
 
+/** An empty mounts object clears the mounts, matching the API. */
+function normalizeMounts(
+  mounts: SandboxRecord["mounts"],
+): SandboxRecord["mounts"] {
+  return mounts && Object.keys(mounts).length > 0 ? mounts : undefined;
+}
+
 interface CreateBody {
   name?: string;
   ports?: number[];
@@ -65,6 +72,7 @@ interface CreateBody {
   networkPolicy?: unknown;
   env?: Record<string, string>;
   tags?: Record<string, string>;
+  mounts?: SandboxRecord["mounts"];
   snapshotExpiration?: number;
   keepLastSnapshots?: {
     count: number;
@@ -250,6 +258,7 @@ export class MockServer {
       runtime: body.runtime,
       timeout: body.timeout ?? 300_000,
       tags: body.tags,
+      mounts: normalizeMounts(body.mounts),
       networkPolicy: body.networkPolicy,
       cwd: DEFAULT_CWD,
       env: body.env,
@@ -447,6 +456,7 @@ export class MockServer {
       session.networkPolicy = body.networkPolicy;
     }
     if (body.tags !== undefined) record.tags = body.tags;
+    if (body.mounts !== undefined) record.mounts = normalizeMounts(body.mounts);
     if (body.snapshotExpiration !== undefined)
       record.snapshotExpiration = body.snapshotExpiration;
     if (body.keepLastSnapshots !== undefined) {

--- a/packages/vercel-sandbox-mock/src/server/payloads.ts
+++ b/packages/vercel-sandbox-mock/src/server/payloads.ts
@@ -98,6 +98,7 @@ export function sandboxPayload(sandbox: SandboxRecord, session: SessionRecord) {
     statusUpdatedAt: sandbox.statusUpdatedAt,
     cwd: sandbox.cwd,
     tags: sandbox.tags,
+    mounts: sandbox.mounts,
     snapshotExpiration: sandbox.snapshotExpiration,
     keepLastSnapshots: sandbox.keepLastSnapshots,
   };

--- a/packages/vercel-sandbox-mock/src/server/registry.ts
+++ b/packages/vercel-sandbox-mock/src/server/registry.ts
@@ -71,6 +71,7 @@ export interface SandboxRecord {
   runtime?: string;
   timeout: number;
   tags?: Record<string, string>;
+  mounts?: Record<string, { drive: string; mode?: "read-only" | "read-write" }>;
   networkPolicy?: unknown;
   cwd: string;
   env?: Record<string, string>;

--- a/packages/vercel-sandbox/src/api-client/api-client.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.ts
@@ -1030,6 +1030,7 @@ export class APIClient extends BaseClient {
     currentSnapshotId?: string;
     region?: SandboxRegion;
     failoverRegions?: SandboxRegion[];
+    mounts?: BaseCreateSandboxParams["mounts"];
     signal?: AbortSignal;
   }) {
     return parseOrThrow(
@@ -1053,6 +1054,7 @@ export class APIClient extends BaseClient {
           currentSnapshotId: params.currentSnapshotId,
           region: params.region,
           failoverRegions: params.failoverRegions,
+          mounts: params.mounts,
         }),
         signal: params.signal,
       }),

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -747,6 +747,33 @@ describe("Sandbox.create mounts", () => {
   });
 });
 
+describe("Sandbox.update mounts", () => {
+  it("forwards mounts to updateSandbox and reflects the response", async () => {
+    const mounts = { "/mnt/storage": { drive: "my-drive" } };
+    const updateSandboxMock = vi.fn(async () => ({
+      json: { sandbox: { ...makeSandboxMetadata(), mounts } },
+    }));
+    const sandbox = new Sandbox({
+      client: { updateSandbox: updateSandboxMock } as unknown as APIClient,
+      routes: [],
+      sandbox: makeSandboxMetadata(),
+      session: {} as any,
+      projectId: "test-project",
+    });
+
+    await sandbox.update({ mounts });
+
+    expect(updateSandboxMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "test-name",
+        projectId: "test-project",
+        mounts,
+      }),
+    );
+    expect(sandbox.mounts).toEqual(mounts);
+  });
+});
+
 describe("Sandbox.create environment selection", () => {
   const CREDENTIALS = {
     token: "test-token",

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -1748,6 +1748,9 @@ export class Sandbox implements ExecutionContext {
    * running session keeps the region it started in. Pass an empty
    * `failoverRegions` array to remove all failover regions.
    *
+   * When `mounts` is provided, it replaces all current mounts and applies to
+   * the next session. Pass an empty object to remove all mounts.
+   *
    * @param params - Fields to update.
    * @param opts - Optional abort signal.
    */
@@ -1768,6 +1771,7 @@ export class Sandbox implements ExecutionContext {
       currentSnapshotId?: string;
       region?: SandboxRegion;
       failoverRegions?: SandboxRegion[];
+      mounts?: SandboxMounts;
     },
     opts?: { signal?: AbortSignal },
   ): Promise<void> {
@@ -1796,6 +1800,7 @@ export class Sandbox implements ExecutionContext {
       currentSnapshotId: params.currentSnapshotId,
       region: params.region,
       failoverRegions: params.failoverRegions,
+      mounts: params.mounts,
       signal: opts?.signal,
     });
     this.sandbox = response.json.sandbox;


### PR DESCRIPTION
Support updating mounts.

List config from my sandbox:
```
❯ sandbox config list my-sandbox
FIELD                 VALUE                        
Region                iad1                         
Failover regions      -                            
vCPUs                 2                            
Timeout               5 minutes                    
Persistent            true                         
Network policy        allow-all                    
Ports                 -                            
Snapshot expiration   -                            
Keep last snapshots   -                            
Current snapshot      -                            
Tags                  -                            
Mounts                my-drive:/mnt/data:read-write
```

Update the mount and list my sandbox:
```
❯ sandbox config mounts my-sandbox --mount my-drive:/mnt/data:read-only
✅ Configuration updated for sandbox my-sandbox
   ╰ mounts: my-drive:/mnt/data:read-only

❯ sandbox config list my-sandbox
FIELD                 VALUE                       
Region                iad1                        
Failover regions      -                           
vCPUs                 2                           
Timeout               5 minutes                   
Persistent            true                        
Network policy        allow-all                   
Ports                 -                           
Snapshot expiration   -                           
Keep last snapshots   -                           
Current snapshot      -                           
Tags                  -                           
Mounts                my-drive:/mnt/data:read-only
```

Clear the mount and list my sandbox:
```
❯ sandbox config mounts my-sandbox
✅ Configuration updated for sandbox my-sandbox
   ╰ mounts: -

❯ /Users/marc/Documents/Repositories/my-sandbox-app/node_modules/.bin/sandbox config list my-sandbox
FIELD                 VALUE    
Region                iad1     
Failover regions      -        
vCPUs                 2        
Timeout               5 minutes
Persistent            true     
Network policy        allow-all
Ports                 -        
Snapshot expiration   -        
Keep last snapshots   -        
Current snapshot      -        
Tags                  -        
Mounts                - 
```