### PR TITLE
[sandbox-sdk] add response rules to network policy

### DIFF
--- a/.changeset/lucky-pianos-wander.md
+++ b/.changeset/lucky-pianos-wander.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sandbox": minor
+---
+
+Add `response` to network policy rules, so a rule can be answered by the sandbox proxy instead of being sent to the destination. A trailing `response` rule with no `match` answers whatever the earlier rules did not claim, which restricts an allowed domain to specific paths without running your own proxy.

--- a/packages/vercel-sandbox/src/api-client/validators.ts
+++ b/packages/vercel-sandbox/src/api-client/validators.ts
@@ -39,21 +39,58 @@ export const NetworkPolicyTransformValidator = z.object({
   headers: z.record(z.string(), z.string()).optional(),
 });
 
+// Headers the proxy sets itself on a direct response. Mirrors hive's
+// ValidateDirectResponse so a bad rule fails here instead of at cell start.
+const PROXY_MANAGED_RESPONSE_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "transfer-encoding",
+]);
+
+// Status codes that cannot carry a body.
+const BODYLESS_STATUS_CODES = new Set([204, 205, 304]);
+
+export const NetworkPolicyDirectResponseValidator = z
+  .object({
+    statusCode: z.number().int().min(200).max(599),
+    headers: z.record(z.string(), z.string()).optional(),
+    body: z.string().optional(),
+    contentType: z.string().optional(),
+  })
+  .refine(({ body, contentType }) => body === undefined || contentType !== undefined, {
+    message: "contentType must be provided when body is set",
+  })
+  .refine(({ statusCode, body }) => body === undefined || !BODYLESS_STATUS_CODES.has(statusCode), {
+    message: "body is not allowed on status codes 204, 205, and 304",
+  })
+  .refine(
+    ({ headers }) =>
+      Object.keys(headers ?? {}).every(
+        (name) => !PROXY_MANAGED_RESPONSE_HEADERS.has(name.toLowerCase()),
+      ),
+    { message: "headers cannot set proxy-managed headers" },
+  )
+  .refine(({ headers }) => {
+    const names = Object.keys(headers ?? {}).map((name) => name.toLowerCase());
+    return new Set(names).size === names.length;
+  }, { message: "headers cannot contain duplicate names" });
+
 export const NetworkPolicyRuleValidator = z
   .object({
     match: RuleMatchValidator.optional(),
     transform: z.array(NetworkPolicyTransformValidator).optional(),
     forwardURL: z.string().optional(),
+    response: NetworkPolicyDirectResponseValidator.optional(),
   })
   .refine(
-    ({ transform, forwardURL }) =>
-      transform === undefined || forwardURL === undefined,
-    { message: "transform and forwardURL cannot be used together" },
+    ({ transform, forwardURL, response }) =>
+      [transform, forwardURL, response].filter((v) => v !== undefined).length <= 1,
+    { message: "only one of transform, forwardURL, or response can be used per rule" },
   )
   .refine(
-    ({ transform, forwardURL }) =>
-      transform !== undefined || forwardURL !== undefined,
-    { message: "transform or forwardURL must be provided" },
+    ({ transform, forwardURL, response }) =>
+      transform !== undefined || forwardURL !== undefined || response !== undefined,
+    { message: "transform, forwardURL, or response must be provided" },
   );
 
 export const V2NetworkPolicyObjectValidator = z.object({

--- a/packages/vercel-sandbox/src/network-policy.ts
+++ b/packages/vercel-sandbox/src/network-policy.ts
@@ -53,12 +53,29 @@ export type NetworkPolicyMatch = {
 };
 
 /**
+ * A response the sandbox network proxy returns itself, without contacting the
+ * destination. Use it to deny the requests an allowed domain's earlier rules
+ * did not claim, since allowing a domain otherwise allows every request to it.
+ */
+export type NetworkPolicyResponse = {
+  /** Status code to answer with, between 200 and 599. */
+  statusCode: number;
+  /** Response headers. Proxy-managed headers are rejected. */
+  headers?: Record<string, string>;
+  /** Response body. Requires `contentType`, and is not allowed on 204, 205, or 304. */
+  body?: string;
+  /** Content type for `body`. Required whenever `body` is set. */
+  contentType?: string;
+};
+
+/**
  * A rule applied to requests matching a domain in the network policy.
  */
 export type NetworkPolicyRule = {
   /**
-   * Optional request matcher. When provided, transforms and forwarding rules
-   * only apply to requests that match every specified dimension.
+   * Optional request matcher. When provided, the rule only applies to requests
+   * that match every specified dimension. A rule without `match` applies to
+   * every request to the domain.
    */
   match?: NetworkPolicyMatch;
 } & (
@@ -66,24 +83,40 @@ export type NetworkPolicyRule = {
       /**
        * Transforms to apply to matching requests.
        *
-       * `transform` cannot be used together with `forwardURL`.
+       * `transform` cannot be used together with `forwardURL` or `response`.
        */
       transform: NetworkTransformer[];
       forwardURL?: never;
+      response?: never;
     }
   | {
       transform?: never;
+      response?: never;
       /**
        * HTTPS proxy URL to forward matching requests to. Must not include query string or fragment.
        *
        * You can use the `defineSandboxProxy` helper from `@vercel/sandbox/proxy` to implement the proxy handler
        * automatically, which handles authorization and extracts metadata about the request and sandbox.
        *
-       * `forwardURL` cannot be used together with `transform`.
+       * `forwardURL` cannot be used together with `transform` or `response`.
        *
        * @see https://vercel.com/docs/vercel-sandbox/concepts/firewall#requests-proxying
        */
       forwardURL: string;
+    }
+  | {
+      transform?: never;
+      forwardURL?: never;
+      /**
+       * Answer matching requests from the proxy instead of contacting the destination.
+       *
+       * Rules run in declaration order, so a trailing `response` rule with no `match`
+       * answers whatever the earlier rules did not claim. This is how you restrict an
+       * allowed domain to specific paths without running a proxy of your own.
+       *
+       * `response` cannot be used together with `transform` or `forwardURL`.
+       */
+      response: NetworkPolicyResponse;
     }
 );
 

--- a/packages/vercel-sandbox/src/utils/network-policy.test.ts
+++ b/packages/vercel-sandbox/src/utils/network-policy.test.ts
@@ -217,11 +217,11 @@ describe("toAPINetworkPolicy", () => {
     } as unknown as NetworkPolicy;
 
     expect(() => toAPINetworkPolicy(networkPolicy)).toThrow(
-      "transform and forwardURL cannot be used together",
+      "only one of transform, forwardURL, or response can be used per rule",
     );
   });
 
-  it("rejects rules without transform or forwardURL", () => {
+  it("rejects rules without transform, forwardURL, or response", () => {
     const networkPolicy = {
       allow: {
         "api.example.com": [{ match: { method: ["GET"] } }],
@@ -229,7 +229,105 @@ describe("toAPINetworkPolicy", () => {
     } as unknown as NetworkPolicy;
 
     expect(() => toAPINetworkPolicy(networkPolicy)).toThrow(
-      "transform or forwardURL must be provided",
+      "transform, forwardURL, or response must be provided",
+    );
+  });
+
+  it("converts a path allowlist built from a trailing response rule", () => {
+    const networkPolicy: NetworkPolicy = {
+      allow: {
+        "api.github.com": [
+          {
+            match: { path: { startsWith: "/repos/my-org/" } },
+            transform: [{ headers: { authorization: "Bearer secret" } }],
+          },
+          { response: { statusCode: 403 } },
+        ],
+      },
+    };
+
+    expect(toAPINetworkPolicy(networkPolicy)).toEqual(networkPolicy);
+  });
+
+  it("converts a response rule with a body", () => {
+    const networkPolicy: NetworkPolicy = {
+      allow: {
+        "api.example.com": [
+          {
+            response: {
+              statusCode: 451,
+              headers: { "x-denied-by": "policy" },
+              body: '{"error":"blocked"}',
+              contentType: "application/json",
+            },
+          },
+        ],
+      },
+    };
+
+    expect(toAPINetworkPolicy(networkPolicy)).toEqual(networkPolicy);
+  });
+
+  it("rejects rules with response and transform", () => {
+    const networkPolicy = {
+      allow: {
+        "api.example.com": [
+          {
+            transform: [{ headers: { authorization: "Bearer secret" } }],
+            response: { statusCode: 403 },
+          },
+        ],
+      },
+    } as unknown as NetworkPolicy;
+
+    expect(() => toAPINetworkPolicy(networkPolicy)).toThrow(
+      "only one of transform, forwardURL, or response can be used per rule",
+    );
+  });
+
+  it("rejects a response status code outside 200 to 599", () => {
+    const networkPolicy = {
+      allow: { "api.example.com": [{ response: { statusCode: 100 } }] },
+    } as unknown as NetworkPolicy;
+
+    expect(() => toAPINetworkPolicy(networkPolicy)).toThrow();
+  });
+
+  it("rejects a response body without a contentType", () => {
+    const networkPolicy = {
+      allow: { "api.example.com": [{ response: { statusCode: 403, body: "nope" } }] },
+    } as unknown as NetworkPolicy;
+
+    expect(() => toAPINetworkPolicy(networkPolicy)).toThrow(
+      "contentType must be provided when body is set",
+    );
+  });
+
+  it("rejects a response body on a bodyless status code", () => {
+    const networkPolicy = {
+      allow: {
+        "api.example.com": [
+          { response: { statusCode: 204, body: "nope", contentType: "text/plain" } },
+        ],
+      },
+    } as unknown as NetworkPolicy;
+
+    expect(() => toAPINetworkPolicy(networkPolicy)).toThrow(
+      "body is not allowed on status codes 204, 205, and 304",
+    );
+  });
+
+  it("rejects a response that sets a proxy-managed header", () => {
+    const networkPolicy = {
+      allow: {
+        "api.example.com": [
+          { response: { statusCode: 403, headers: { "Content-Length": "0" } } },
+        ],
+      },
+    } as unknown as NetworkPolicy;
+
+    expect(() => toAPINetworkPolicy(networkPolicy)).toThrow(
+      "headers cannot set proxy-managed headers",
     );
   });
 


### PR DESCRIPTION
Follows:
- https://github.com/vercel/hive/pull/3160 (`direct_response` proxy handler)
- https://github.com/vercel/api/pull/89825 (per-rule `response` on the network policy API)

Both of those are live in production, but the SDK rejects a `response` rule in its own validation before anything is sent:

```
[{ "code": "custom", "path": ["allow","httpbin.org",1],
   "message": "transform or forwardURL must be provided" }]
```

`NetworkPolicyRule` is a two-arm union (`transform` xor `forwardURL`), so there is no slot for `response` and the only way to reach the feature today is calling `POST /v2/sandboxes/sessions/{id}/network-policy` by hand. This adds the third arm:

```ts
await Sandbox.create({
  networkPolicy: {
    allow: {
      'api.github.com': [
        { match: { path: { startsWith: '/repos/my-org/' } },
          transform: [{ headers: { authorization: `Bearer ${token}` } }] },
        { response: { statusCode: 403 } },
      ],
    },
  },
});
```

This:
- adds the `NetworkPolicyResponse` type and a `response` arm to `NetworkPolicyRule`, with `never` guards so the three handlers stay mutually exclusive
- validates in `NetworkPolicyDirectResponseValidator` the same way api#89825 does, so a bad rule fails locally rather than at the API: `statusCode` 200 to 599, `contentType` required with `body`, no `body` on 204/205/304, proxy-managed headers (`connection`, `content-length`, `transfer-encoding`) rejected, case-insensitive duplicate header names rejected
- rewords the two exclusivity errors to name all three handlers

Deliberately not included: reconstructing `response` rules in `fromAPINetworkPolicy`. `get-sandbox` returns them as `responseRules`, but the sanitized row keeps `{ domain, statusCode, matchDimensions }` and I did not want to guess how `matchDimensions` maps back onto `match`. Reading a policy back therefore still omits response rules, the same way it omitted forward rules before they were added. Worth a follow-up.

Verification

- `pnpm -F @vercel/sandbox test`: 298 passed, 81 skipped, and the same 3 pre-existing `package-exports` failures the clean tree produces (291 passed there, so +7 and no regressions).
- `tsc --noEmit`: clean.
- Live end-to-end against production with this branch built and linked into a scratch project, using the snippet above against `httpbin.org` with `statusCode: 418`: the allowed path returned `200` with real origin JSON, the non-matching path returned `418` with a `0`-byte body. 418 is a code no origin returns and an empty body is a locally generated answer, so the proxy answered it rather than the destination.
- Enforcement confirmed in `iad1`, `sfo1`, `cle1`, and `cdg1`.
