### PR TITLE
feat(sdk,cli): add support for secure compute

### DIFF
--- a/.changeset/witty-ways-hunt.md
+++ b/.changeset/witty-ways-hunt.md
@@ -1,0 +1,9 @@
+---
+"@vercel/sandbox-mock": minor
+"@vercel/sandbox": minor
+"sandbox": minor
+---
+
+Add support for attaching sandboxes to Secure Compute networks:
+- In the CLI, use `sandbox create --network-id ID` with your Secure Compute network id 
+- In the SDK, use `Sandbox.create({ networkId: 'ID' })` with your Secure Compute network id 

--- a/packages/sandbox/docs/index.md
+++ b/packages/sandbox/docs/index.md
@@ -93,6 +93,7 @@ Options:
     --tag <key=value>, -t=<key=value>          Key-value tags to associate with the sandbox (e.g. --tag env=staging)
     --region <REGION>                          Region to create the sandbox in (defaults to iad1; see the Vercel docs for available regions) [optional]
     --failover-regions <REGION,...|none>       Comma-separated regions the sandbox can fail over to (e.g. --failover-regions sfo1,cle1). Must not include the sandbox region. Pass "none" for no failover regions, overriding the project default. [optional]
+    --network-id <NETWORK_ID>                  Connect network ID for the target Secure Compute private network [optional]
     --snapshot-expiration <DURATION|none>      Default snapshot expiration. Use "none" or 0 for no expiration. Example: 7d, 30d [optional]
     --keep-last-snapshots <COUNT>              Keep only the N most recent snapshots of this sandbox (1-10). [optional]
     --keep-last-snapshots-for <DURATION|none>  Expiration applied to kept snapshots. Use "none" or 0 for no expiration. Example: 7d, 30d [optional]
@@ -153,6 +154,7 @@ Options:
     --tag <key=value>, -t=<key=value>          Key-value tags to associate with the sandbox (e.g. --tag env=staging)
     --region <REGION>                          Region to create the sandbox in (defaults to iad1; see the Vercel docs for available regions) [optional]
     --failover-regions <REGION,...|none>       Comma-separated regions the sandbox can fail over to (e.g. --failover-regions sfo1,cle1). Must not include the sandbox region. Pass "none" for no failover regions, overriding the project default. [optional]
+    --network-id <NETWORK_ID>                  Connect network ID for the target Secure Compute private network [optional]
     --snapshot-expiration <DURATION|none>      Default snapshot expiration. Use "none" or 0 for no expiration. Example: 7d, 30d [optional]
     --keep-last-snapshots <COUNT>              Keep only the N most recent snapshots of this sandbox (1-10). [optional]
     --keep-last-snapshots-for <DURATION|none>  Expiration applied to kept snapshots. Use "none" or 0 for no expiration. Example: 7d, 30d [optional]
@@ -207,6 +209,7 @@ Options:
     --tag <key=value>, -t=<key=value>          Key-value tags to associate with the sandbox (e.g. --tag env=staging)
     --region <REGION>                          Region to create the sandbox in (defaults to iad1; see the Vercel docs for available regions) [optional]
     --failover-regions <REGION,...|none>       Comma-separated regions the sandbox can fail over to (e.g. --failover-regions sfo1,cle1). Must not include the sandbox region. Pass "none" for no failover regions, overriding the project default. [optional]
+    --network-id <NETWORK_ID>                  Connect network ID for the target Secure Compute private network [optional]
     --snapshot-expiration <DURATION|none>      Default snapshot expiration. Use "none" or 0 for no expiration. Example: 7d, 30d [optional]
     --keep-last-snapshots <COUNT>              Keep only the N most recent snapshots of this sandbox (1-10). [optional]
     --keep-last-snapshots-for <DURATION|none>  Expiration applied to kept snapshots. Use "none" or 0 for no expiration. Example: 7d, 30d [optional]
@@ -256,6 +259,7 @@ Options:
     --tag <key=value>, -t=<key=value>          Key-value tags to associate with the fork. When provided, fully replaces the tags copied from the source (no per-key merge).
     --region <REGION>                          Region to create the sandbox in (defaults to iad1; see the Vercel docs for available regions) [optional]
     --failover-regions <REGION,...|none>       Comma-separated regions the sandbox can fail over to (e.g. --failover-regions sfo1,cle1). Must not include the sandbox region. Pass "none" for no failover regions, overriding the project default. [optional]
+    --network-id <NETWORK_ID>                  Connect network ID for the target Secure Compute private network [optional]
     --snapshot-expiration <DURATION|none>      Default snapshot expiration. Use "none" or 0 for no expiration. Example: 7d, 30d [optional]
     --keep-last-snapshots <COUNT>              Keep only the N most recent snapshots of this sandbox (1-10). [optional]
     --keep-last-snapshots-for <DURATION|none>  Expiration applied to kept snapshots. Use "none" or 0 for no expiration. Example: 7d, 30d [optional]
@@ -474,6 +478,7 @@ Commands:
     persistent                <name> <true|false>       Enable or disable automatic restore of the filesystem between sessions
     region                    <name> <REGION>           Update the region of a sandbox (will be applied to all new sessions)
     failover-regions          <name> <REGION,...|none>  Update the failover regions of a sandbox (replaces the existing list)
+    network-id                <name> <NETWORK_ID|none>  Update the Secure Compute network of a sandbox
     network-policy            <name>                    Update the network policy of a sandbox
     snapshot-expiration       <name> <DURATION|none>    Update the default snapshot expiration of a sandbox
     keep-last-snapshots       <name> <COUNT>            Update the snapshot retention policy (keep only the N most recent snapshots) of a sandbox

--- a/packages/sandbox/src/args/network-id.ts
+++ b/packages/sandbox/src/args/network-id.ts
@@ -1,0 +1,29 @@
+import * as cmd from "cmd-ts";
+
+export const networkIdType = cmd.extendType(cmd.string, {
+  displayName: "NETWORK_ID",
+  async from(value) {
+    const networkId = value.trim();
+    if (networkId === "") {
+      throw new Error("Network ID cannot be empty.");
+    }
+    if (networkId.length > 255) {
+      throw new Error("Network ID cannot exceed 255 characters.");
+    }
+    return networkId;
+  },
+});
+
+export const networkIdOrNoneType = cmd.extendType(cmd.string, {
+  displayName: "NETWORK_ID|none",
+  async from(value) {
+    return value.trim() === "none" ? null : networkIdType.from(value);
+  },
+});
+
+export const networkId = cmd.option({
+  long: "network-id",
+  type: cmd.optional(networkIdType),
+  description:
+    "Connect network ID for the target Secure Compute private network",
+});

--- a/packages/sandbox/src/commands/config.ts
+++ b/packages/sandbox/src/commands/config.ts
@@ -11,6 +11,7 @@ import {
 import { buildNetworkPolicy, resolveMode } from "../util/network-policy";
 import { vcpusType } from "../args/vcpus";
 import { failoverRegionListType, regionType } from "../args/region";
+import { networkIdOrNoneType } from "../args/network-id";
 import { Duration } from "../types/duration";
 import { SnapshotExpiration } from "../types/snapshot-expiration";
 import { ObjectFromKeyValue } from "../args/key-value-pair";
@@ -51,9 +52,7 @@ const vcpusCommand = cmd.command({
       spinner.stop();
 
       process.stderr.write(
-        "✅ Configuration updated for sandbox " +
-          chalk.cyan(name) +
-          "\n",
+        "✅ Configuration updated for sandbox " + chalk.cyan(name) + "\n",
       );
       process.stderr.write(
         chalk.dim("   ╰ ") + "vcpus: " + chalk.cyan(count) + "\n",
@@ -67,7 +66,8 @@ const vcpusCommand = cmd.command({
 
 const timeoutCommand = cmd.command({
   name: "timeout",
-  description: "Update the timeout of a sandbox (will be applied to all new sessions)",
+  description:
+    "Update the timeout of a sandbox (will be applied to all new sessions)",
   args: {
     sandbox: cmd.positional({
       type: sandboxName,
@@ -75,15 +75,12 @@ const timeoutCommand = cmd.command({
     }),
     duration: cmd.positional({
       type: Duration,
-      description: "The maximum duration a sandbox can run for. Example: 5m, 1h",
+      description:
+        "The maximum duration a sandbox can run for. Example: 5m, 1h",
     }),
     scope,
   },
-  async handler({
-    scope: { token, team, project },
-    sandbox: name,
-    duration,
-  }) {
+  async handler({ scope: { token, team, project }, sandbox: name, duration }) {
     const sandbox = await sandboxClient.get({
       name,
       projectId: project,
@@ -97,9 +94,7 @@ const timeoutCommand = cmd.command({
       spinner.stop();
 
       process.stderr.write(
-        "✅ Configuration updated for sandbox " +
-          chalk.cyan(name) +
-          "\n",
+        "✅ Configuration updated for sandbox " + chalk.cyan(name) + "\n",
       );
       process.stderr.write(
         chalk.dim("   ╰ ") + "timeout: " + chalk.cyan(duration) + "\n",
@@ -113,7 +108,8 @@ const timeoutCommand = cmd.command({
 
 const persistentCommand = cmd.command({
   name: "persistent",
-  description: "Enable or disable automatic restore of the filesystem between sessions",
+  description:
+    "Enable or disable automatic restore of the filesystem between sessions",
   args: {
     sandbox: cmd.positional({
       type: sandboxName,
@@ -121,15 +117,12 @@ const persistentCommand = cmd.command({
     }),
     value: cmd.positional({
       type: { ...cmd.oneOf(["true", "false"]), displayName: "true|false" },
-      description: "Enable or disable automatic restore of the filesystem between sessions",
+      description:
+        "Enable or disable automatic restore of the filesystem between sessions",
     }),
     scope,
   },
-  async handler({
-    scope: { token, team, project },
-    sandbox: name,
-    value,
-  }) {
+  async handler({ scope: { token, team, project }, sandbox: name, value }) {
     const sandbox = await sandboxClient.get({
       name,
       projectId: project,
@@ -143,9 +136,7 @@ const persistentCommand = cmd.command({
       spinner.stop();
 
       process.stderr.write(
-        "✅ Configuration updated for sandbox " +
-          chalk.cyan(name) +
-          "\n",
+        "✅ Configuration updated for sandbox " + chalk.cyan(name) + "\n",
       );
       process.stderr.write(
         chalk.dim("   ╰ ") + "persistent: " + chalk.cyan(value) + "\n",
@@ -167,15 +158,12 @@ const snapshotExpirationCommand = cmd.command({
     }),
     duration: cmd.positional({
       type: SnapshotExpiration,
-      description: 'Snapshot expiration duration (e.g. 7d, 30d) or "none" for no expiration',
+      description:
+        'Snapshot expiration duration (e.g. 7d, 30d) or "none" for no expiration',
     }),
     scope,
   },
-  async handler({
-    scope: { token, team, project },
-    sandbox: name,
-    duration,
-  }) {
+  async handler({ scope: { token, team, project }, sandbox: name, duration }) {
     const sandbox = await sandboxClient.get({
       name,
       projectId: project,
@@ -190,12 +178,13 @@ const snapshotExpirationCommand = cmd.command({
 
       const display = ms(duration) === 0 ? "none" : duration;
       process.stderr.write(
-        "✅ Configuration updated for sandbox " +
-          chalk.cyan(name) +
-          "\n",
+        "✅ Configuration updated for sandbox " + chalk.cyan(name) + "\n",
       );
       process.stderr.write(
-        chalk.dim("   ╰ ") + "snapshot-expiration: " + chalk.cyan(display) + "\n",
+        chalk.dim("   ╰ ") +
+          "snapshot-expiration: " +
+          chalk.cyan(display) +
+          "\n",
       );
     } catch (error) {
       spinner.stop();
@@ -232,11 +221,7 @@ const keepLastSnapshotsCommand = cmd.command({
     }),
     scope,
   },
-  async handler({
-    scope: { token, team, project },
-    sandbox: name,
-    count,
-  }) {
+  async handler({ scope: { token, team, project }, sandbox: name, count }) {
     const sandbox = await sandboxClient.get({
       name,
       projectId: project,
@@ -292,11 +277,7 @@ const keepLastSnapshotsForCommand = cmd.command({
     }),
     scope,
   },
-  async handler({
-    scope: { token, team, project },
-    sandbox: name,
-    duration,
-  }) {
+  async handler({ scope: { token, team, project }, sandbox: name, duration }) {
     const sandbox = await sandboxClient.get({
       name,
       projectId: project,
@@ -358,11 +339,7 @@ const deleteEvictedSnapshotsCommand = cmd.command({
     }),
     scope,
   },
-  async handler({
-    scope: { token, team, project },
-    sandbox: name,
-    value,
-  }) {
+  async handler({ scope: { token, team, project }, sandbox: name, value }) {
     const sandbox = await sandboxClient.get({
       name,
       projectId: project,
@@ -439,19 +416,17 @@ const currentSnapshotCommand = cmd.command({
       spinner.stop();
 
       process.stderr.write(
-        "✅ Configuration updated for sandbox " +
-          chalk.cyan(name) +
-          "\n",
+        "✅ Configuration updated for sandbox " + chalk.cyan(name) + "\n",
       );
       process.stderr.write(
-        chalk.dim("   ╰ ") + "current-snapshot: " + chalk.cyan(snapshotId) + "\n",
+        chalk.dim("   ╰ ") +
+          "current-snapshot: " +
+          chalk.cyan(snapshotId) +
+          "\n",
       );
     } catch (error) {
       spinner.stop();
-      if (
-        error instanceof APIError &&
-        error.response.status === 404
-      ) {
+      if (error instanceof APIError && error.response.status === 404) {
         throw new StyledError(
           `Snapshot '${snapshotId}' was not found or does not belong to this project.`,
           error,
@@ -513,7 +488,8 @@ const portsCommand = cmd.command({
 
 const regionCommand = cmd.command({
   name: "region",
-  description: "Update the region of a sandbox (will be applied to all new sessions)",
+  description:
+    "Update the region of a sandbox (will be applied to all new sessions)",
   args: {
     sandbox: cmd.positional({
       type: sandboxName,
@@ -553,7 +529,8 @@ const regionCommand = cmd.command({
 
 const failoverRegionsCommand = cmd.command({
   name: "failover-regions",
-  description: "Update the failover regions of a sandbox (replaces the existing list)",
+  description:
+    "Update the failover regions of a sandbox (replaces the existing list)",
   args: {
     sandbox: cmd.positional({
       type: sandboxName,
@@ -561,11 +538,16 @@ const failoverRegionsCommand = cmd.command({
     }),
     failoverRegions: cmd.positional({
       type: failoverRegionListType,
-      description: 'Comma-separated regions the sandbox can fail over to (e.g. sfo1,cle1). Must not include the sandbox region. Pass "none" to remove them.',
+      description:
+        'Comma-separated regions the sandbox can fail over to (e.g. sfo1,cle1). Must not include the sandbox region. Pass "none" to remove them.',
     }),
     scope,
   },
-  async handler({ scope: { token, team, project }, sandbox: name, failoverRegions }) {
+  async handler({
+    scope: { token, team, project },
+    sandbox: name,
+    failoverRegions,
+  }) {
     const sandbox = await sandboxClient.get({
       name,
       projectId: project,
@@ -578,12 +560,56 @@ const failoverRegionsCommand = cmd.command({
       await sandbox.update({ failoverRegions });
       spinner.stop();
 
-      const display = failoverRegions.length === 0 ? "cleared" : failoverRegions.join(", ");
+      const display =
+        failoverRegions.length === 0 ? "cleared" : failoverRegions.join(", ");
       process.stderr.write(
         "✅ Configuration updated for sandbox " + chalk.cyan(name) + "\n",
       );
       process.stderr.write(
         chalk.dim("   ╰ ") + "failover-regions: " + chalk.cyan(display) + "\n",
+      );
+    } catch (error) {
+      spinner.stop();
+      throw error;
+    }
+  },
+});
+
+const networkIdCommand = cmd.command({
+  name: "network-id",
+  description: "Update the Secure Compute network of a sandbox",
+  args: {
+    sandbox: cmd.positional({
+      type: sandboxName,
+      description: "Sandbox name to update",
+    }),
+    networkId: cmd.positional({
+      type: networkIdOrNoneType,
+      description: 'Connect network ID, or "none" to remove Secure Compute',
+    }),
+    scope,
+  },
+  async handler({ scope: { token, team, project }, sandbox: name, networkId }) {
+    const sandbox = await sandboxClient.get({
+      name,
+      projectId: project,
+      teamId: team,
+      token,
+    });
+
+    const spinner = ora("Updating sandbox configuration...").start();
+    try {
+      await sandbox.update({ networkId });
+      spinner.stop();
+
+      process.stderr.write(
+        "✅ Configuration updated for sandbox " + chalk.cyan(name) + "\n",
+      );
+      process.stderr.write(
+        chalk.dim("   ╰ ") +
+          "network-id: " +
+          chalk.cyan(networkId ?? "cleared") +
+          "\n",
       );
     } catch (error) {
       spinner.stop();
@@ -616,23 +642,47 @@ const listCommand = cmd.command({
       });
     })();
 
-    const networkPolicy = typeof sandbox.networkPolicy === "string" ? sandbox.networkPolicy : "restricted";
-    const tagsDisplay = sandbox.tags && Object.keys(sandbox.tags).length > 0
-      ? Object.entries(sandbox.tags).map(([k, v]) => `${k}=${v}`).join(", ")
-      : "-";
+    const networkPolicy =
+      typeof sandbox.networkPolicy === "string"
+        ? sandbox.networkPolicy
+        : "restricted";
+    const tagsDisplay =
+      sandbox.tags && Object.keys(sandbox.tags).length > 0
+        ? Object.entries(sandbox.tags)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(", ")
+        : "-";
     const rows = [
       { field: "Region", value: sandbox.region },
       {
         field: "Failover regions",
-        value: sandbox.failoverRegions.length ? sandbox.failoverRegions.join(", ") : "-",
+        value: sandbox.failoverRegions.length
+          ? sandbox.failoverRegions.join(", ")
+          : "-",
       },
+      { field: "Secure Compute network", value: sandbox.networkId ?? "-" },
       { field: "vCPUs", value: String(sandbox.vcpus ?? "-") },
-      { field: "Timeout", value: sandbox.timeout != null ? ms(sandbox.timeout, { long: true }) : "-" },
+      {
+        field: "Timeout",
+        value:
+          sandbox.timeout != null ? ms(sandbox.timeout, { long: true }) : "-",
+      },
       { field: "Persistent", value: String(sandbox.persistent) },
       { field: "Network policy", value: String(networkPolicy) },
       { field: "Ports", value: formatPorts(sandbox) },
-      { field: "Snapshot expiration", value: sandbox.snapshotExpiration != null && sandbox.snapshotExpiration > 0 ? ms(sandbox.snapshotExpiration, { long: true }) : sandbox.snapshotExpiration === 0 ? "none" : "-" },
-      { field: "Keep last snapshots", value: formatKeepLastSnapshots(sandbox.keepLastSnapshots) },
+      {
+        field: "Snapshot expiration",
+        value:
+          sandbox.snapshotExpiration != null && sandbox.snapshotExpiration > 0
+            ? ms(sandbox.snapshotExpiration, { long: true })
+            : sandbox.snapshotExpiration === 0
+              ? "none"
+              : "-",
+      },
+      {
+        field: "Keep last snapshots",
+        value: formatKeepLastSnapshots(sandbox.keepLastSnapshots),
+      },
       { field: "Current snapshot", value: sandbox.currentSnapshotId ?? "-" },
       { field: "Tags", value: tagsDisplay },
     ];
@@ -711,7 +761,8 @@ const networkPolicyCommand = cmd.command({
           chalk.cyan(sandbox.name) +
           "\n",
       );
-      const mode = typeof networkPolicy === "string" ? networkPolicy : "restricted";
+      const mode =
+        typeof networkPolicy === "string" ? networkPolicy : "restricted";
       process.stderr.write(
         chalk.dim("   ╰ ") + "mode: " + chalk.cyan(mode) + "\n",
       );
@@ -724,7 +775,8 @@ const networkPolicyCommand = cmd.command({
 
 const tagsCommand = cmd.command({
   name: "tags",
-  description: "Update the tags of a sandbox. Replaces all existing tags with the provided tags.",
+  description:
+    "Update the tags of a sandbox. Replaces all existing tags with the provided tags.",
   args: {
     sandbox: cmd.positional({
       type: sandboxName,
@@ -734,7 +786,8 @@ const tagsCommand = cmd.command({
       long: "tag",
       short: "t",
       type: ObjectFromKeyValue,
-      description: "Key-value tags to set (e.g. --tag env=staging). Omit to clear all tags.",
+      description:
+        "Key-value tags to set (e.g. --tag env=staging). Omit to clear all tags.",
     }),
     scope,
   },
@@ -764,7 +817,9 @@ const tagsCommand = cmd.command({
           const [k, v] = entries[i];
           const isLast = i === entries.length - 1;
           const prefix = isLast ? chalk.dim("   ╰ ") : chalk.dim("   │ ");
-          process.stderr.write(prefix + chalk.cyan(k) + "=" + chalk.cyan(v) + "\n");
+          process.stderr.write(
+            prefix + chalk.cyan(k) + "=" + chalk.cyan(v) + "\n",
+          );
         }
       }
     } catch (error) {
@@ -822,6 +877,7 @@ export const config = cmd.subcommands({
     persistent: persistentCommand,
     region: regionCommand,
     "failover-regions": failoverRegionsCommand,
+    "network-id": networkIdCommand,
     "network-policy": networkPolicyCommand,
     "snapshot-expiration": snapshotExpirationCommand,
     "keep-last-snapshots": keepLastSnapshotsCommand,

--- a/packages/sandbox/src/commands/create.ts
+++ b/packages/sandbox/src/commands/create.ts
@@ -18,6 +18,7 @@ import { buildKeepLastSnapshotsPayload } from "../util/keep-last-snapshots";
 import { printSandboxSummary } from "../util/print-sandbox-summary";
 import { startLatestVersionCheck } from "../util/check-latest-version";
 import { region, failoverRegions } from "../args/region";
+import { networkId } from "../args/network-id";
 
 export const args = {
   name: cmd.option({
@@ -71,6 +72,7 @@ export const args = {
   }),
   region,
   failoverRegions,
+  networkId,
   ...snapshotRetentionArgs,
   ...networkPolicyArgs,
   scope,
@@ -103,6 +105,7 @@ export const create = cmd.command({
       tags,
       region,
       failoverRegions,
+      networkId,
       snapshotExpiration,
       keepLastSnapshots,
       keepLastSnapshotsFor,
@@ -157,6 +160,7 @@ export const create = cmd.command({
           tags: tagsObj,
           region,
           failoverRegions,
+          networkId,
           persistent,
           snapshotExpiration: snapshotExpiration
             ? ms(snapshotExpiration)
@@ -182,6 +186,7 @@ export const create = cmd.command({
           tags: tagsObj,
           region,
           failoverRegions,
+          networkId,
           persistent,
           snapshotExpiration: snapshotExpiration
             ? ms(snapshotExpiration)

--- a/packages/sandbox/src/commands/fork.ts
+++ b/packages/sandbox/src/commands/fork.ts
@@ -16,6 +16,7 @@ import { ObjectFromKeyValue } from "../args/key-value-pair";
 import { buildKeepLastSnapshotsPayload } from "../util/keep-last-snapshots";
 import { printSandboxSummary } from "../util/print-sandbox-summary";
 import { region, failoverRegions } from "../args/region";
+import { networkId } from "../args/network-id";
 
 export const args = {
   source: cmd.positional({
@@ -67,6 +68,7 @@ export const args = {
   }),
   region,
   failoverRegions,
+  networkId,
   ...snapshotRetentionArgs,
   ...networkPolicyArgs,
   scope,
@@ -101,6 +103,7 @@ export const fork = cmd.command({
     tags,
     region,
     failoverRegions,
+    networkId,
     snapshotExpiration,
     keepLastSnapshots,
     keepLastSnapshotsFor,
@@ -150,6 +153,7 @@ export const fork = cmd.command({
       ...(tagsObj !== undefined && { tags: tagsObj }),
       ...(region !== undefined && { region }),
       ...(failoverRegions !== undefined && { failoverRegions }),
+      ...(networkId !== undefined && { networkId }),
       ...(nonPersistent && { persistent: false }),
       ...(snapshotExpiration !== undefined && {
         snapshotExpiration: ms(snapshotExpiration),

--- a/packages/sandbox/src/util/print-sandbox-summary.ts
+++ b/packages/sandbox/src/util/print-sandbox-summary.ts
@@ -42,9 +42,18 @@ export function printSandboxSummary(opts: {
   process.stderr.write(
     chalk.dim("   │ ") + "region: " + chalk.cyan(sandbox.region) + "\n",
   );
+  if (sandbox.networkId) {
+    process.stderr.write(
+      chalk.dim("   │ ") +
+        "secure compute network: " +
+        chalk.cyan(sandbox.networkId) +
+        "\n",
+    );
+  }
 
   // With a connect hint, the hint becomes the closing "╰" line.
-  const close = (last: boolean) => chalk.dim(last && !connectHint ? "   ╰ " : "   │ ");
+  const close = (last: boolean) =>
+    chalk.dim(last && !connectHint ? "   ╰ " : "   │ ");
 
   if (hasPorts) {
     process.stderr.write(
@@ -55,7 +64,12 @@ export function printSandboxSummary(opts: {
       const route = routes[i];
       const isLast = i === routes.length - 1;
       process.stderr.write(
-        close(isLast) + "• " + route.port + " -> " + chalk.cyan(route.url) + "\n",
+        close(isLast) +
+          "• " +
+          route.port +
+          " -> " +
+          chalk.cyan(route.url) +
+          "\n",
       );
     }
   } else {

--- a/packages/sandbox/test/args/network-id.test.ts
+++ b/packages/sandbox/test/args/network-id.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import * as cmd from "cmd-ts";
+import { networkId, networkIdOrNoneType } from "../../src/args/network-id.ts";
+
+describe("network ID args", () => {
+  const command = cmd.command({
+    name: "test",
+    args: { networkId },
+    handler(args) {
+      return args;
+    },
+  });
+
+  test("parses and trims a network ID", async () => {
+    const args = await cmd.run(command, ["--network-id", " network_123 "]);
+    expect(args.networkId).toBe("network_123");
+  });
+
+  test("defaults to undefined when omitted", async () => {
+    expect((await cmd.run(command, [])).networkId).toBeUndefined();
+  });
+
+  test("parses none as null for updates", async () => {
+    expect(await networkIdOrNoneType.from(" none ")).toBeNull();
+  });
+
+  test("rejects invalid values", async () => {
+    await expect(cmd.run(command, ["--network-id", " "])).rejects.toThrow();
+    await expect(
+      cmd.run(command, ["--network-id", "x".repeat(256)]),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/sandbox/test/commands/config.test.ts
+++ b/packages/sandbox/test/commands/config.test.ts
@@ -33,6 +33,7 @@ const fakeSandbox = (overrides: Record<string, unknown> = {}) => ({
   timeout: 300_000,
   persistent: true,
   networkPolicy: "restricted",
+  networkId: "network_123",
   interactivePort: 8443,
   routes: [],
   tags: undefined,
@@ -88,6 +89,22 @@ describe("config command", () => {
     expect(mockUpdate).toHaveBeenCalledWith({ failoverRegions: [] });
   });
 
+  test.each([
+    ["network_456", "network_456"],
+    ["none", null],
+  ])("network-id updates with %s", async (value, networkId) => {
+    const { config } = await import("../../src/commands/config.ts");
+    await cmd.run(config, [
+      "network-id",
+      "my-sandbox",
+      value,
+      "--scope=team",
+      "--project=proj",
+    ]);
+
+    expect(mockUpdate).toHaveBeenCalledWith({ networkId });
+  });
+
   test("list prints the region and the failover regions", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
     const { config } = await import("../../src/commands/config.ts");
@@ -101,6 +118,7 @@ describe("config command", () => {
     const output = log.mock.calls.map(([line]) => String(line)).join("\n");
     expect(output).toContain("sfo1");
     expect(output).toContain("iad1, cle1");
+    expect(output).toContain("network_123");
     log.mockRestore();
   });
 

--- a/packages/sandbox/test/commands/create.test.ts
+++ b/packages/sandbox/test/commands/create.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import * as cmd from "cmd-ts";
+
+const { mockCreate } = vi.hoisted(() => ({ mockCreate: vi.fn() }));
+
+vi.mock("../../src/client", () => ({
+  sandboxClient: {
+    create: mockCreate,
+    fork: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn(),
+  },
+  snapshotClient: { get: vi.fn(), list: vi.fn(), tree: vi.fn() },
+}));
+
+vi.mock("@vercel/oidc", () => ({
+  getVercelOidcToken: vi.fn(),
+  getVercelToken: vi.fn(),
+}));
+
+vi.mock("../../src/commands/login", () => ({
+  login: { handler: vi.fn() },
+}));
+
+describe("create command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreate.mockResolvedValue({
+      name: "my-sandbox",
+      interactivePort: 8443,
+      routes: [],
+    });
+    process.env.VERCEL_AUTH_TOKEN = "tok";
+  });
+
+  test("forwards --network-id to Sandbox.create", async () => {
+    const { create } = await import("../../src/commands/create.ts");
+    await cmd.run(create, [
+      "--network-id=network_123",
+      "--scope=team",
+      "--project=proj",
+      "--silent",
+    ]);
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ networkId: "network_123" }),
+    );
+  });
+});

--- a/packages/sandbox/test/commands/fork.test.ts
+++ b/packages/sandbox/test/commands/fork.test.ts
@@ -94,6 +94,19 @@ describe("fork command", () => {
     expect(call.failoverRegions).toEqual(["sfo1", "iad1"]);
   });
 
+  test("forwards --network-id to Sandbox.fork", async () => {
+    const { fork } = await import("../../src/commands/fork.ts");
+    await cmd.run(fork, [
+      "my-source",
+      "--network-id=network_123",
+      "--scope=team",
+      "--project=proj",
+      "--silent",
+    ]);
+
+    expect(mockFork.mock.calls[0][0].networkId).toBe("network_123");
+  });
+
   test("does not forward overrides for unspecified options (server uses copied source values)", async () => {
     const { fork } = await import("../../src/commands/fork.ts");
     await cmd.run(fork, [
@@ -113,6 +126,7 @@ describe("fork command", () => {
     expect(call.keepLastSnapshots).toBeUndefined();
     expect(call.region).toBeUndefined();
     expect(call.failoverRegions).toBeUndefined();
+    expect(call.networkId).toBeUndefined();
   });
 
   test("fails when the source positional is missing", async () => {

--- a/packages/vercel-sandbox-mock/src/fork.test.ts
+++ b/packages/vercel-sandbox-mock/src/fork.test.ts
@@ -41,7 +41,9 @@ describe("Sandbox.fork", () => {
       expect(fork.snapshotExpiration).toBe(7 * DAY);
       expect(fork.keepLastSnapshots?.count).toBe(3);
 
-      const forkPorts = fork.routes.map((route) => route.port).sort((a, b) => a - b);
+      const forkPorts = fork.routes
+        .map((route) => route.port)
+        .sort((a, b) => a - b);
       expect(forkPorts).toEqual([3000, 8080]);
 
       expect(await readEnv(fork, "FORKED")).toBe("yes");
@@ -70,6 +72,33 @@ describe("Sandbox.fork", () => {
       overridden = await Sandbox.fork({ sourceSandbox: name, region: "cle1" });
       expect(overridden.region).toBe("cle1");
       expect(overridden.failoverRegions).toEqual(["iad1"]);
+    } finally {
+      await Promise.allSettled([
+        inherited?.delete(),
+        overridden?.delete(),
+        source.delete(),
+      ]);
+    }
+  });
+
+  test("inherits the source network and honors an explicit override", async () => {
+    const name = uniq();
+    const source = await Sandbox.create({
+      name,
+      networkId: "network_123",
+    });
+
+    let inherited: Sandbox | undefined;
+    let overridden: Sandbox | undefined;
+    try {
+      inherited = await Sandbox.fork({ sourceSandbox: name });
+      expect(inherited.networkId).toBe("network_123");
+
+      overridden = await Sandbox.fork({
+        sourceSandbox: name,
+        networkId: "network_456",
+      });
+      expect(overridden.networkId).toBe("network_456");
     } finally {
       await Promise.allSettled([
         inherited?.delete(),

--- a/packages/vercel-sandbox-mock/src/sandbox.test.ts
+++ b/packages/vercel-sandbox-mock/src/sandbox.test.ts
@@ -27,6 +27,21 @@ describe("Sandbox (real SDK over mock fetch)", () => {
     await withRegion.delete();
   });
 
+  test("creates and updates a Secure Compute network", async () => {
+    const sandbox = await Sandbox.create({
+      name: uniq(),
+      networkId: "network_123",
+    });
+    expect(sandbox.networkId).toBe("network_123");
+
+    await sandbox.update({ networkId: "network_456" });
+    expect(sandbox.networkId).toBe("network_456");
+
+    await sandbox.update({ networkId: null });
+    expect(sandbox.networkId).toBeUndefined();
+    await sandbox.delete();
+  });
+
   test("create rejects failover regions that include the requested region", async () => {
     await expect(
       Sandbox.create({
@@ -93,16 +108,24 @@ describe("Sandbox (real SDK over mock fetch)", () => {
   });
 
   test("get on an unknown name throws a 404 APIError", async () => {
-    await expect(Sandbox.get({ name: "does-not-exist" })).rejects.toMatchObject({
-      response: { status: 404 },
-    });
+    await expect(Sandbox.get({ name: "does-not-exist" })).rejects.toMatchObject(
+      {
+        response: { status: 404 },
+      },
+    );
   });
 
   test("getOrCreate runs onCreate exactly once for a name", async () => {
     const name = uniq();
     let created = 0;
-    const first = await Sandbox.getOrCreate({ name, onCreate: async () => void created++ });
-    const second = await Sandbox.getOrCreate({ name, onCreate: async () => void created++ });
+    const first = await Sandbox.getOrCreate({
+      name,
+      onCreate: async () => void created++,
+    });
+    const second = await Sandbox.getOrCreate({
+      name,
+      onCreate: async () => void created++,
+    });
     expect(created).toBe(1);
     expect(second.name).toBe(name);
     await first.delete();
@@ -140,14 +163,20 @@ describe("Sandbox (real SDK over mock fetch)", () => {
   test("update({ ports }) refreshes routes so domain() resolves", async () => {
     const sandbox = await Sandbox.create({ name: uniq() });
     await sandbox.update({ ports: [8080] });
-    expect(sandbox.domain(8080)).toBe(sandbox.routes.find((r) => r.port === 8080)?.url);
+    expect(sandbox.domain(8080)).toBe(
+      sandbox.routes.find((r) => r.port === 8080)?.url,
+    );
     expect(() => sandbox.domain(9999)).toThrow(/No route/);
     await sandbox.stop();
   });
 
   test("detached commands expose wait/logs/kill", async () => {
     const sandbox = await Sandbox.create({ name: uniq() });
-    const command = await sandbox.runCommand({ cmd: "echo", args: ["detached"], detached: true });
+    const command = await sandbox.runCommand({
+      cmd: "echo",
+      args: ["detached"],
+      detached: true,
+    });
     expect(typeof command.cmdId).toBe("string");
 
     const finished = await command.wait();

--- a/packages/vercel-sandbox-mock/src/server/mock-server.ts
+++ b/packages/vercel-sandbox-mock/src/server/mock-server.ts
@@ -61,6 +61,7 @@ interface CreateBody {
   image?: string;
   persistent?: boolean;
   networkPolicy?: unknown;
+  networkId?: string;
   env?: Record<string, string>;
   tags?: Record<string, string>;
   snapshotExpiration?: number;
@@ -181,6 +182,7 @@ export class MockServer {
       timeout: body.timeout ?? 300_000,
       tags: body.tags,
       networkPolicy: body.networkPolicy,
+      networkId: body.networkId,
       cwd: DEFAULT_CWD,
       env: body.env,
       ports,
@@ -252,6 +254,7 @@ export class MockServer {
       timeout: body.timeout ?? source.timeout,
       tags: body.tags ?? source.tags,
       networkPolicy: body.networkPolicy ?? source.networkPolicy,
+      networkId: body.networkId ?? source.networkId,
       cwd: source.cwd,
       env: body.env ?? source.env,
       ports: body.ports ?? source.ports,
@@ -344,7 +347,12 @@ export class MockServer {
     const record = this.#sandboxes.get(name);
     if (!record)
       return apiError(404, "not_found", `Sandbox not found: ${name}`);
-    const body = readJson<CreateBody & { currentSnapshotId?: string }>(init);
+    const body = readJson<
+      Omit<CreateBody, "networkId"> & {
+        currentSnapshotId?: string;
+        networkId?: string | null;
+      }
+    >(init);
     const session = this.#sessions.get(record.sessionId)!;
 
     // Each side can be updated on its own, so the resulting combination is
@@ -375,6 +383,9 @@ export class MockServer {
     if (body.networkPolicy !== undefined) {
       record.networkPolicy = body.networkPolicy;
       session.networkPolicy = body.networkPolicy;
+    }
+    if (body.networkId !== undefined) {
+      record.networkId = body.networkId ?? undefined;
     }
     if (body.tags !== undefined) record.tags = body.tags;
     if (body.snapshotExpiration !== undefined)

--- a/packages/vercel-sandbox-mock/src/server/payloads.ts
+++ b/packages/vercel-sandbox-mock/src/server/payloads.ts
@@ -85,6 +85,7 @@ export function sandboxPayload(sandbox: SandboxRecord, session: SessionRecord) {
     runtime: sandbox.runtime,
     timeout: sandbox.timeout,
     networkPolicy: responseNetworkPolicy(sandbox.networkPolicy),
+    networkId: sandbox.networkId,
     createdAt: sandbox.createdAt,
     updatedAt: sandbox.updatedAt,
     currentSessionId: sandbox.sessionId,

--- a/packages/vercel-sandbox-mock/src/server/registry.ts
+++ b/packages/vercel-sandbox-mock/src/server/registry.ts
@@ -72,6 +72,7 @@ export interface SandboxRecord {
   timeout: number;
   tags?: Record<string, string>;
   networkPolicy?: unknown;
+  networkId?: string;
   cwd: string;
   env?: Record<string, string>;
   ports: number[];

--- a/packages/vercel-sandbox/src/api-client/api-client.test.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.test.ts
@@ -1188,6 +1188,26 @@ describe("APIClient", () => {
       expect(body.failoverRegions).toEqual(["iad1"]);
     });
 
+    it.each([
+      ["sets", "network_123"],
+      ["clears", null],
+    ])("%s the Secure Compute network", async (_action, networkId) => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ sandbox: makeSandboxMetadata() }), {
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await client.updateSandbox({
+        name: "my-sandbox",
+        projectId: "proj_123",
+        networkId,
+      });
+
+      const [, opts] = mockFetch.mock.calls[0];
+      expect(JSON.parse(opts.body)).toHaveProperty("networkId", networkId);
+    });
+
     it("sends an empty failoverRegions array to clear them", async () => {
       mockFetch.mockResolvedValue(
         new Response(JSON.stringify({ sandbox: makeSandboxMetadata() }), {
@@ -1428,6 +1448,27 @@ describe("APIClient", () => {
       expect(body).not.toHaveProperty("keepLastSnapshots");
     });
 
+    it("forwards networkId in the request body", async () => {
+      mockFetch.mockResolvedValue(sandboxResponse());
+
+      await client.createSandbox({
+        projectId: "proj_123",
+        networkId: "network_123",
+      });
+
+      const [, opts] = mockFetch.mock.calls[0];
+      expect(JSON.parse(opts.body).networkId).toBe("network_123");
+    });
+
+    it("omits networkId when not provided", async () => {
+      mockFetch.mockResolvedValue(sandboxResponse());
+
+      await client.createSandbox({ projectId: "proj_123" });
+
+      const [, opts] = mockFetch.mock.calls[0];
+      expect(JSON.parse(opts.body)).not.toHaveProperty("networkId");
+    });
+
     it("forwards region and failoverRegions in the request body", async () => {
       mockFetch.mockResolvedValue(sandboxResponse());
 
@@ -1536,6 +1577,19 @@ describe("APIClient", () => {
       const body = JSON.parse(opts.body);
       expect(body.region).toBe("sfo1");
       expect(body.failoverRegions).toEqual(["iad1"]);
+    });
+
+    it("forwards networkId in the request body", async () => {
+      mockFetch.mockResolvedValue(sandboxResponse());
+
+      await client.forkSandbox({
+        projectId: "proj_123",
+        sourceSandbox: "my-sandbox",
+        networkId: "network_123",
+      });
+
+      const [, opts] = mockFetch.mock.calls[0];
+      expect(JSON.parse(opts.body).networkId).toBe("network_123");
     });
   });
 

--- a/packages/vercel-sandbox/src/api-client/api-client.ts
+++ b/packages/vercel-sandbox/src/api-client/api-client.ts
@@ -175,6 +175,7 @@ export class APIClient extends BaseClient {
       runtime?: RUNTIMES | (string & {});
       image?: string;
       networkPolicy?: NetworkPolicy;
+      networkId?: string;
       env?: Record<string, string>;
       tags?: Record<string, string>;
       snapshotExpiration?: number;
@@ -208,6 +209,7 @@ export class APIClient extends BaseClient {
           networkPolicy: params.networkPolicy
             ? toAPINetworkPolicy(params.networkPolicy)
             : undefined,
+          networkId: params.networkId,
           env: params.env,
           tags: params.tags,
           snapshotExpiration: params.snapshotExpiration,
@@ -232,6 +234,7 @@ export class APIClient extends BaseClient {
       persistent?: boolean;
       image?: string;
       networkPolicy?: NetworkPolicy;
+      networkId?: string;
       env?: Record<string, string>;
       tags?: Record<string, string>;
       snapshotExpiration?: number;
@@ -263,6 +266,7 @@ export class APIClient extends BaseClient {
             networkPolicy: params.networkPolicy
               ? toAPINetworkPolicy(params.networkPolicy)
               : undefined,
+            networkId: params.networkId,
             env: params.env,
             tags: params.tags,
             snapshotExpiration: params.snapshotExpiration,
@@ -948,6 +952,7 @@ export class APIClient extends BaseClient {
     resources?: { vcpus?: number; memory?: number };
     timeout?: number;
     networkPolicy?: NetworkPolicy;
+    networkId?: string | null;
     tags?: Record<string, string>;
     ports?: number[];
     snapshotExpiration?: number;
@@ -975,6 +980,7 @@ export class APIClient extends BaseClient {
           networkPolicy: params.networkPolicy
             ? toAPINetworkPolicy(params.networkPolicy)
             : undefined,
+          networkId: params.networkId,
           tags: params.tags,
           ports: params.ports,
           snapshotExpiration: params.snapshotExpiration,

--- a/packages/vercel-sandbox/src/api-client/validators.ts
+++ b/packages/vercel-sandbox/src/api-client/validators.ts
@@ -274,6 +274,7 @@ export const Sandbox = z.object({
   persistent: z.boolean(),
   region: z.string().optional(),
   failoverRegions: z.array(z.string()).optional(),
+  networkId: z.string().optional(),
   vcpus: z.number().optional(),
   memory: z.number().optional(),
   runtime: z.string().optional(),

--- a/packages/vercel-sandbox/src/sandbox.test.ts
+++ b/packages/vercel-sandbox/src/sandbox.test.ts
@@ -133,6 +133,35 @@ describe("source getters", () => {
     expect(sandbox.region).toBe("sfo1");
     expect(sandbox.failoverRegions).toEqual(["iad1", "cle1"]);
   });
+
+  it("exposes the Secure Compute network ID", () => {
+    const sandbox = makeSandbox({ networkId: "network_123" });
+    expect(sandbox.networkId).toBe("network_123");
+  });
+});
+
+describe("update networkId", () => {
+  it.each([
+    ["sets", "network_123"],
+    ["clears", null],
+  ])("%s the Secure Compute network", async (_action, networkId) => {
+    const updateSandboxMock = vi.fn(async () => ({
+      json: { sandbox: makeSandboxMetadata() },
+    }));
+    const sandbox = new Sandbox({
+      client: { updateSandbox: updateSandboxMock } as unknown as APIClient,
+      routes: [],
+      sandbox: makeSandboxMetadata(),
+      session: {} as any,
+      projectId: "test-project",
+    });
+
+    await sandbox.update({ networkId });
+
+    expect(updateSandboxMock).toHaveBeenCalledWith(
+      expect.objectContaining({ networkId }),
+    );
+  });
 });
 
 describe("updatePorts", () => {

--- a/packages/vercel-sandbox/src/sandbox.ts
+++ b/packages/vercel-sandbox/src/sandbox.ts
@@ -93,6 +93,10 @@ export interface BaseCreateSandboxParams {
    */
   networkPolicy?: NetworkPolicy;
   /**
+   * Connect network ID for the target Secure Compute private network.
+   */
+  networkId?: string;
+  /**
    * Default environment variables for the sandbox.
    * These are inherited by all commands unless overridden with
    * the `env` option in `runCommand`.
@@ -423,6 +427,13 @@ export class Sandbox implements ExecutionContext {
   }
 
   /**
+   * Connect network ID for the target Secure Compute private network.
+   */
+  public get networkId(): string | undefined {
+    return this.sandbox.networkId;
+  }
+
+  /**
    * Number of virtual CPUs allocated.
    */
   public get vcpus(): number | undefined {
@@ -747,6 +758,7 @@ export class Sandbox implements ExecutionContext {
       runtime: params?.runtime,
       image: params?.image,
       networkPolicy: params?.networkPolicy,
+      networkId: params?.networkId,
       env: params?.env,
       tags: params?.tags,
       snapshotExpiration: params?.snapshotExpiration,
@@ -817,6 +829,7 @@ export class Sandbox implements ExecutionContext {
       resources: params.resources,
       image: params.image,
       networkPolicy: params.networkPolicy,
+      networkId: params.networkId,
       env: params.env,
       tags: params.tags,
       snapshotExpiration: params.snapshotExpiration,
@@ -1729,6 +1742,8 @@ export class Sandbox implements ExecutionContext {
       resources?: { vcpus?: number };
       timeout?: number;
       networkPolicy?: NetworkPolicy;
+      /** Set to `null` to remove the sandbox from Secure Compute. */
+      networkId?: string | null;
       tags?: Record<string, string>;
       ports?: number[];
       snapshotExpiration?: number;
@@ -1761,6 +1776,7 @@ export class Sandbox implements ExecutionContext {
       resources,
       timeout: params.timeout,
       networkPolicy: params.networkPolicy,
+      networkId: params.networkId,
       tags: params.tags,
       ports: params.ports,
       snapshotExpiration: params.snapshotExpiration,


### PR DESCRIPTION
Add support for attaching sandboxes to Secure Compute networks:
- In the CLI, use `sandbox create --network-id ID` with your Secure Compute network id 
- In the SDK, use `Sandbox.create({ networkId: 'ID' })` with your Secure Compute network id 